### PR TITLE
Refuse control sequences and bidi overrides in the grid

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,6 +25,46 @@ passed to a widget is measured and clipped, never re-emitted as control sequence
 you find input that escapes a cell, corrupts the surrounding grid, or injects an escape
 sequence into stdout, that is a security bug and we want to hear about it.
 
+Concretely, the framebuffer is incapable of holding anything that steers a terminal
+rather than drawing in it. `FrameBuffer.setCell` is the only path that writes a
+character into the grid, and it rejects:
+
+- **C0, DEL and C1** (`0x00`–`0x1f`, `0x7f`, `0x80`–`0x9f`). These are zero-width, so
+  without an explicit rule they attach to the previous character like a combining mark
+  and get written straight back out. `"user" + ESC + "[31m"` must not become a live SGR.
+- **Bidi overrides, embeddings and isolates** (`U+202A`–`U+202E`, `U+2066`–`U+2069`),
+  the Trojan Source set. They paint nothing but reorder everything around them, so
+  `user<RLO>nimda` reads as `user admin` in a log pane. Directional *marks* (LRM/RLM)
+  and real RTL script are left alone — those render honestly.
+
+Two further limits keep a single cell honest about its size, because a cell that claims
+one column while painting many desynchronises the cursor and corrupts the rest of the
+row:
+
+- ZWJ joins emoji and nothing else, so no input can glue arbitrary text into one cell.
+- A cell holds at most 16 codepoints, and the cluster table is capped, so untrusted
+  text cannot amplify bytes or grow the heap without bound.
+
+`stripAnsi` is exported for callers who want to sanitise text themselves. It handles
+8-bit C1 forms and CSI intermediate bytes, and removes anything left over, so its
+output cannot steer a terminal even if a sequence form was missed.
+
+Two consequences of these rules are worth stating plainly, because both are deliberate:
+
+- **ZWJ outside emoji is dropped.** It legitimately requests conjunct forms in
+  Devanagari, Sinhala and Arabic, and those ligatures are lost — each codepoint gets
+  its own cell instead. Honouring it would mean letting a cell hold arbitrary joined
+  text, which is the primitive that let one cell paint hundreds of columns. The
+  previous behaviour was not correct either; it simply mis-declared the width.
+- **Past 32768 distinct clusters, new ones degrade to their base character.** Cells
+  hold an index into the cluster table, so entries can never be evicted while a
+  framebuffer may still reference them; the alternative is unbounded heap growth
+  driven by untrusted text. Combining marks are lost, the column is not.
+
+In both cases the rule chosen is the one that keeps the grid in step with the screen.
+A cell that lies about its width desynchronises the cursor and corrupts every cell
+after it, which is a worse outcome than a missing ligature.
+
 `@profullstack/hqtui-demo` does execute read-only system commands (`ps`, `df`,
 `vm_stat`, PowerShell CIM queries) to collect real metrics. It never passes user input
 to a shell.

--- a/packages/hqtui/src/ansi.ts
+++ b/packages/hqtui/src/ansi.ts
@@ -1,4 +1,5 @@
 /** Raw VT/ANSI control sequences. Nothing above this layer writes an escape by hand. */
+import { stripUnsafe } from "./unicode.ts";
 
 export const ESC = "\x1b";
 export const CSI = "\x1b[";
@@ -50,7 +51,10 @@ export function moveToColumn(x: number): string {
 }
 
 export function setTitle(title: string): string {
-  return `${ESC}]0;${title.replace(/[\x00-\x1f]/g, "")}\x07`;
+  // The title is interpolated into an OSC sequence, so anything that could end
+  // or restart it has to go. `stripUnsafe` is the same policy the grid uses:
+  // C0, DEL, C1 (8-bit ST and CSI included) and the bidi overrides.
+  return `${ESC}]0;${stripUnsafe(title)}\x07`;
 }
 
 export function fgTrue(r: number, g: number, b: number): string {
@@ -80,8 +84,31 @@ export function bg16(i: number): string {
 export const fgDefault = `${CSI}39m`;
 export const bgDefault = `${CSI}49m`;
 
-/** Strip escape sequences — used by the headless renderer and by tests. */
+/**
+ * Strip escape sequences — used by the headless renderer and by tests, and
+ * exported for apps that want to sanitise text themselves.
+ *
+ * Two things the obvious regex misses, both of which leave a live sequence
+ * behind: CSI may carry intermediate bytes (0x20-0x2f) before its final byte,
+ * as in `ESC [ 0 SP q`; and every sequence has an 8-bit C1 form where a single
+ * byte replaces `ESC x`. After the structured pass, anything still holding a
+ * control or bidi override is removed outright, so the result cannot steer a
+ * terminal even if a form was missed.
+ */
 export function stripAnsi(text: string): string {
-  // eslint-disable-next-line no-control-regex
-  return text.replace(/\x1b\[[0-9;?]*[A-Za-z]|\x1b\][^\x07\x1b]*(\x07|\x1b\\)|\x1b[@-Z\\-_]/g, "");
+  const stripped = text.replace(
+    // eslint-disable-next-line no-control-regex
+    /(?:\x1b\[|\x9b)[0-9;?<=>]*[ -/]*[@-~]|(?:\x1b\]|\x9d)[\s\S]*?(?:\x07|\x1b\\|\x9c|$)|(?:\x1bP|\x90)[\s\S]*?(?:\x1b\\|\x9c|$)|\x1b[@-Z\\-_]/g,
+    "",
+  );
+  return stripped.replace(TEXT_UNSAFE, "");
 }
+
+/**
+ * The grid's unsafe set minus tab, newline and carriage return. `stripAnsi`
+ * works on text, not cells, and multi-line callers rely on those three; the
+ * framebuffer refuses them separately, which is the right layer for it.
+ */
+// eslint-disable-next-line no-control-regex -- matching controls is the point
+const TEXT_UNSAFE =
+  /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f\u202a-\u202e\u2066-\u2069]/gu;

--- a/packages/hqtui/src/buffer.ts
+++ b/packages/hqtui/src/buffer.ts
@@ -1,5 +1,7 @@
 import { DEFAULT_COLOR, type Color } from "./color.ts";
-import { CONTINUATION, cellWidth, graphemes, cellText } from "./unicode.ts";
+import {
+  CONTINUATION, REPLACEMENT, cellWidth, graphemes, cellText, isLoneSurrogate, isUnsafeCodepoint,
+} from "./unicode.ts";
 
 /** Style attribute bits packed into the cell's 16-bit attribute slot. */
 export const Attr = {
@@ -80,6 +82,24 @@ export class FrameBuffer {
   /** Write one already-decoded cell value. Returns columns consumed. */
   setCell(x: number, y: number, value: number, style?: Style): number {
     if (!this.inBounds(x, y)) return 0;
+    // The last line of defence: this is the only path that writes a character
+    // into the grid, and the encoder hands cell text straight to the terminal.
+    // Refusing unsafe values here means the buffer *cannot* hold a live escape,
+    // whatever the caller passes — including the low-level escape hatch.
+    //
+    // Validate what will actually be stored, not what was passed. `chars` is a
+    // Uint32Array, so it applies ToUint32: 2**32 + 0x1b looks like a harmless
+    // large number but truncates to a live ESC. Coerce first, then check.
+    // A lead-less continuation is not writable either; it would silently eat a
+    // column out of the row. Ordered so printable ASCII costs one comparison.
+    value = value >>> 0;
+    if (value >= 0x7f) {
+      if (isUnsafeCodepoint(value) || value === CONTINUATION) value = 32;
+      // A lone surrogate would fuse with its neighbour into a single glyph.
+      else if (isLoneSurrogate(value)) value = REPLACEMENT;
+    } else if (value < 0x20) {
+      value = 32;
+    }
     const w = cellWidth(value);
     const i = this.index(x, y);
     // Overwriting the tail of a wide char to our left would orphan it; blank it.

--- a/packages/hqtui/src/testing.ts
+++ b/packages/hqtui/src/testing.ts
@@ -166,6 +166,16 @@ function escapeHtml(text: string): string {
   return text.replace(/[&<>]/g, (c) => HTML_ESCAPES[c]);
 }
 
+const ATTR_ESCAPES: Record<string, string> = { ...HTML_ESCAPES, '"': "&quot;", "'": "&#39;" };
+
+/**
+ * Attribute values need the quote characters escaped too, or a caller-supplied
+ * `className` or `fontFamily` closes the attribute and opens its own.
+ */
+function escapeAttr(text: string): string {
+  return text.replace(/[&<>"']/g, (c) => ATTR_ESCAPES[c]);
+}
+
 function cssColor(color: Color, fallback: string): string {
   if (color === DEFAULT_COLOR) return fallback;
   return `#${((color & 0xffffff) >>> 0).toString(16).padStart(6, "0")}`;
@@ -229,18 +239,27 @@ export function renderToHtml(
     rows.push(row);
   }
 
-  const fontSize = options.fontSize ?? 14;
-  const padding = options.padding ?? 16;
+  // Every one of these is spliced into an attribute, so none may be trusted to
+  // be the type the signature claims. Numbers are coerced and bounded; a font
+  // stack is reduced to the characters a font stack can legitimately contain,
+  // because escaping alone still lets `;` open a new CSS property.
+  const number = (value: unknown, fallback: number): number => {
+    const n = Number(value);
+    return Number.isFinite(n) && n > 0 && n <= 1000 ? n : fallback;
+  };
+  const fontSize = number(options.fontSize, 14);
+  const padding = number(options.padding, 16);
   // line-height must be exactly 1: box-drawing glyphs fill the em box, so any
   // extra leading shows up as gaps in every vertical rule on the screen.
   // The font stack is ordered by box-drawing and Braille coverage.
-  const font = options.fontFamily ??
-    "ui-monospace,SFMono-Regular,Menlo,'DejaVu Sans Mono','Liberation Mono',Consolas,'Segoe UI Symbol',monospace";
+  const font = String(options.fontFamily ??
+    "ui-monospace,SFMono-Regular,Menlo,'DejaVu Sans Mono','Liberation Mono',Consolas,'Segoe UI Symbol',monospace")
+    .replace(/[^A-Za-z0-9 ,._'-]/g, "");
   // One <pre> with newline-separated rows: wrapping each row in its own element
   // gives the browser licence to lay out lines independently, which pulls
   // box-drawing rules apart. A single text flow tiles the grid exactly.
-  return `<pre class="${options.className ?? "hqtui-screen"}" style="background:${bgFallback};color:${fgFallback};` +
-    `padding:${padding}px;font-size:${fontSize}px;line-height:${(fontSize * 1.18).toFixed(2)}px;font-family:${font};` +
+  return `<pre class="${escapeAttr(options.className ?? "hqtui-screen")}" style="background:${bgFallback};color:${fgFallback};` +
+    `padding:${padding}px;font-size:${fontSize}px;line-height:${(fontSize * 1.18).toFixed(2)}px;font-family:${escapeAttr(font)};` +
     `margin:0;overflow-x:auto;border-radius:8px;white-space:pre;font-variant-ligatures:none;` +
     `-webkit-font-smoothing:antialiased">${rows.join("\n")}</pre>`;
 }

--- a/packages/hqtui/src/unicode.ts
+++ b/packages/hqtui/src/unicode.ts
@@ -11,13 +11,102 @@ export const CONTINUATION = 0xffffffff;
 const clusters: string[] = [];
 const clusterIds = new Map<string, number>();
 
-/** Intern a multi-codepoint grapheme (emoji, combining sequence) into one cell value. */
+/**
+ * C0, DEL and C1. A cell holding one of these would be written straight back
+ * out by the encoder, so untrusted text could steer the terminal instead of
+ * filling a cell — the one thing SECURITY.md promises cannot happen.
+ */
+export function isControl(cp: number): boolean {
+  return cp < 0x20 || (cp >= 0x7f && cp <= 0x9f);
+}
+
+/**
+ * Bidi overrides, embeddings and isolates: the Trojan Source set (CVE-2021-42574).
+ * They emit no glyph but reorder everything around them, so `user<RLO>nimda`
+ * reads as `user admin` in a log pane. Directional *marks* (LRM/RLM) and real
+ * RTL script are left alone — those render honestly.
+ */
+export function isBidiControl(cp: number): boolean {
+  return (cp >= 0x202a && cp <= 0x202e) || (cp >= 0x2066 && cp <= 0x2069);
+}
+
+/**
+ * An unpaired surrogate. It is not a character, and — critically — two of them
+ * fuse into one astral codepoint when the encoder concatenates cell text. Two
+ * cells would then claim two columns and paint one, walking the cursor out of
+ * step with the screen for the rest of the row.
+ */
+export function isLoneSurrogate(cp: number): boolean {
+  return cp >= 0xd800 && cp <= 0xdfff;
+}
+
+/** What an unpaired surrogate is shown as: one column, and it cannot fuse. */
+export const REPLACEMENT = 0xfffd;
+
+/**
+ * Anything that must never occupy a cell: it steers rather than draws.
+ *
+ * This runs per cell on the write path and per codepoint on the measure path,
+ * so it is written as one small branch ladder rather than two calls. Printable
+ * ASCII — overwhelmingly the common case — exits on the second comparison.
+ */
+export function isUnsafeCodepoint(cp: number): boolean {
+  if (cp < 0x20) return true;
+  if (cp < 0x7f) return false;
+  if (cp <= 0x9f) return true;
+  if (cp < 0x202a || cp > 0x2069) return false;
+  return cp <= 0x202e || cp >= 0x2066;
+}
+
+// eslint-disable-next-line no-control-regex -- matching controls is the point
+const UNSAFE = /[\u0000-\u001f\u007f-\u009f\u202a-\u202e\u2066-\u2069]/gu;
+
+/** Strip everything that steers the terminal rather than drawing. */
+export function stripUnsafe(text: string): string {
+  return text.replace(UNSAFE, "");
+}
+
+/**
+ * A cell may hold at most this many codepoints. Real ZWJ emoji top out around
+ * ten; anything longer is a byte-amplification bomb, because the cell still
+ * claims one column while painting hundreds.
+ */
+const MAX_CLUSTER_CODEPOINTS = 16;
+
+/**
+ * Distinct clusters are interned for the life of the process — a cell holds an
+ * index into this table, so entries can never be evicted while a framebuffer
+ * might still reference them. Untrusted text must therefore not be able to grow
+ * it without bound.
+ *
+ * Past this many, `internCluster` degrades to the base codepoint: the combining
+ * marks or emoji joins are dropped, but the cell keeps the correct width, so the
+ * grid stays in step with the screen. The cap is set far above any real UI —
+ * 32768 distinct clusters is more than a multilingual dashboard will ever show —
+ * so reaching it means someone is trying to, and the cost is bounded at a few MB.
+ */
+const MAX_CLUSTERS = 32768;
+
+/**
+ * Intern a multi-codepoint grapheme (emoji, combining sequence) into one cell
+ * value. Unsafe codepoints are stripped here as well as in `graphemes`, so no
+ * caller — including one outside this module — can smuggle one into a cell.
+ */
 export function internCluster(text: string): number {
-  const existing = clusterIds.get(text);
+  // A cell always occupies its column, so a cluster is never empty. Unpaired
+  // surrogates become U+FFFD here too, so a cluster can never end in a half
+  // that would fuse with whatever the next cell begins with.
+  const safe = stripUnsafe(text).replace(/[\ud800-\udfff]/gu, "\ufffd") || " ";
+  const existing = clusterIds.get(safe);
   if (existing !== undefined) return existing;
+  if (clusters.length >= MAX_CLUSTERS) {
+    // Degrade to the base character rather than grow the table for ever.
+    const first = safe.codePointAt(0) ?? 32;
+    return charWidth(first) > 0 ? first : 32;
+  }
   const id = CLUSTER_BASE + clusters.length;
-  clusters.push(text);
-  clusterIds.set(text, id);
+  clusters.push(safe);
+  clusterIds.set(safe, id);
   return id;
 }
 
@@ -41,7 +130,8 @@ const ZERO_WIDTH: Range[] = [
   [0x07a6, 0x07b0], [0x0816, 0x0819], [0x08e3, 0x0903], [0x093a, 0x093c],
   [0x0951, 0x0957], [0x0e31, 0x0e31], [0x0e34, 0x0e3a], [0x0eb1, 0x0eb1],
   [0x1ab0, 0x1aff], [0x1dc0, 0x1dff], [0x200b, 0x200f], [0x2028, 0x202e],
-  [0x2060, 0x2064], [0x20d0, 0x20f0], [0xfe00, 0xfe0f], [0xfe20, 0xfe2f],
+  [0x2060, 0x2064], [0x2066, 0x2069], [0x20d0, 0x20f0], [0xfe00, 0xfe0f],
+  [0xfe20, 0xfe2f],
   [0xfeff, 0xfeff], [0xe0100, 0xe01ef],
 ];
 
@@ -58,6 +148,17 @@ const WIDE: Range[] = [
   [0x1f595, 0x1f596], [0x1f5a4, 0x1f5a4], [0x1f5fb, 0x1f64f], [0x1f680, 0x1f6c5],
   [0x1f6cc, 0x1f6cc], [0x1f6d0, 0x1f6d2], [0x1f6eb, 0x1f6ec], [0x1f910, 0x1f9ff],
   [0x20000, 0x2fffd], [0x30000, 0x3fffd],
+];
+
+// Extended_Pictographic, approximated to the ranges terminals actually join.
+// ZWJ only glues emoji together; joining it to arbitrary text is how one cell
+// ends up painting hundreds of columns.
+const PICTOGRAPHIC: Range[] = [
+  [0x00a9, 0x00a9], [0x00ae, 0x00ae], [0x203c, 0x203c], [0x2049, 0x2049],
+  [0x2122, 0x2122], [0x2139, 0x2139], [0x2194, 0x21aa], [0x231a, 0x23fa],
+  [0x24c2, 0x24c2], [0x25aa, 0x25fe], [0x2600, 0x27bf], [0x2934, 0x2935],
+  [0x2b00, 0x2bff], [0x3030, 0x3030], [0x303d, 0x303d], [0x3297, 0x3299],
+  [0x1f000, 0x1faff], [0x1fc00, 0x1fffd],
 ];
 
 function inRanges(cp: number, ranges: Range[]): boolean {
@@ -112,30 +213,60 @@ export function graphemes(text: string): Grapheme[] {
   while (i < text.length) {
     const cp = text.codePointAt(i) as number;
     let size = cp > 0xffff ? 2 : 1;
+    // `codePointAt` only yields a surrogate value when it is unpaired. Show it
+    // rather than dropping it: dropping would make its neighbours adjacent, and
+    // two lone halves side by side fuse into one glyph spanning two cells.
+    if (isLoneSurrogate(cp)) {
+      out.push({ value: REPLACEMENT, width: 1 });
+      i += 1;
+      continue;
+    }
+    // An unsafe codepoint never reaches a cell: it would otherwise be absorbed
+    // into the previous grapheme exactly like a combining mark and re-emitted
+    // verbatim — escape injection. Every unsafe codepoint is zero-width, so
+    // testing the width first means printable text never pays for this check.
     let width = charWidth(cp);
+    if (width === 0 && isUnsafeCodepoint(cp)) {
+      i += size;
+      continue;
+    }
     let cluster = "";
+    // A cell paints one column but may hold several codepoints; cap how many,
+    // so no input makes a single cell emit an unbounded run of glyphs.
+    let parts = 1;
     // Absorb any trailing zero-width codepoints and ZWJ-joined parts.
     for (;;) {
+      if (parts >= MAX_CLUSTER_CODEPOINTS) break;
       const next = text.codePointAt(i + size);
       if (next === undefined) break;
       const nsize = next > 0xffff ? 2 : 1;
       if (next === ZWJ) {
         const after = text.codePointAt(i + size + nsize);
         if (after === undefined) break;
+        // ZWJ joins emoji, and nothing else. Joining it to arbitrary text lets
+        // one cell claim a single column while painting hundreds of them.
+        if (!inRanges(cp, PICTOGRAPHIC) || !inRanges(after, PICTOGRAPHIC)) break;
         cluster = cluster || text.slice(i, i + size);
         cluster += text.slice(i + size, i + size + nsize + (after > 0xffff ? 2 : 1));
         size += nsize + (after > 0xffff ? 2 : 1);
+        parts += 2;
         continue;
       }
       if (charWidth(next) !== 0) break;
+      // Leave anything unsafe to the outer loop, which drops it. Only zero-width
+      // codepoints reach here, so this costs nothing on ordinary text.
+      if (isUnsafeCodepoint(next)) break;
       cluster = cluster || text.slice(i, i + size);
       cluster += text.slice(i + size, i + size + nsize);
       size += nsize;
+      parts += 1;
     }
-    if (cluster) {
-      out.push({ value: internCluster(cluster), width: width === 0 ? 1 : width });
-    } else if (width === 0) {
-      // A lone combining mark with nothing to combine with; drop it.
+    if (width === 0) {
+      // A zero-width base: a combining mark with nothing to combine with, or a
+      // stray ZWJ. It paints no column, so handing it one would walk the cursor
+      // ahead of the screen. Drop it, along with anything it absorbed.
+    } else if (cluster) {
+      out.push({ value: internCluster(cluster), width });
     } else {
       out.push({ value: cp, width });
     }

--- a/packages/hqtui/test/security.test.ts
+++ b/packages/hqtui/test/security.test.ts
@@ -1,0 +1,314 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { FrameBuffer } from "../src/buffer.ts";
+import { encodeFull } from "../src/diff.ts";
+import {
+  graphemes, internCluster, clusterText, cellText, isControl, isBidiControl,
+  isUnsafeCodepoint, charWidth, stringWidth, cellWidth,
+} from "../src/unicode.ts";
+import { setTitle, stripAnsi } from "../src/ansi.ts";
+import { renderToAnsi, renderToText, renderToHtml } from "../src/testing.ts";
+
+/**
+ * SECURITY.md promises that untrusted text passed to a widget is "measured and
+ * clipped, never re-emitted as control sequences". These tests are that promise.
+ *
+ * Control characters are zero-width, so before this was fixed they were absorbed
+ * into the preceding grapheme exactly like a combining mark and written straight
+ * back out — an attacker who could get a byte into a log line, a process name or
+ * an SSH username could drive the operator's terminal.
+ */
+
+const C = (n: number) => String.fromCharCode(n);
+const ESC = C(0x1b);
+const BEL = C(0x07);
+
+/** Every C0 control, DEL, and every C1 control. */
+const ALL_CONTROLS = [
+  ...Array.from({ length: 0x20 }, (_, i) => i),
+  0x7f,
+  ...Array.from({ length: 0x20 }, (_, i) => 0x80 + i),
+];
+
+/** Anything the terminal would read as a command rather than a glyph. */
+function hasControl(text: string): boolean {
+  for (const ch of text) {
+    const cp = ch.codePointAt(0) as number;
+    if (cp < 0x20 || (cp >= 0x7f && cp <= 0x9f)) return true;
+  }
+  return false;
+}
+
+/** The escapes the encoder is itself entitled to emit: SGR and cursor moves. */
+function encoderEscapes(output: string): string {
+  return output.replace(new RegExp(ESC + "\\[[0-9;]*[A-Za-z]", "g"), "").replace(/\r/g, "");
+}
+
+test("no control character survives into a cell", () => {
+  for (const cp of ALL_CONTROLS) {
+    // After a printable, so it is offered to the cluster-absorption path.
+    const buffer = new FrameBuffer(8, 1);
+    buffer.write(0, 0, "a" + C(cp) + "b");
+    assert.equal(hasControl(buffer.rowText(0)), false, `cell held control 0x${cp.toString(16)}`);
+  }
+});
+
+test("a control character is dropped, not absorbed into its neighbour", () => {
+  // "a" then ESC then "b" is two cells, and the ESC is gone from both.
+  const cells = graphemes("a" + ESC + "b");
+  assert.equal(cells.length, 2);
+  assert.equal(hasControl(cells.map((c) => clusterText(c.value)).join("")), false);
+});
+
+test("controls never reach stdout through the encoder", () => {
+  for (const cp of ALL_CONTROLS) {
+    const buffer = new FrameBuffer(8, 1);
+    buffer.write(0, 0, "a" + C(cp) + "b");
+    const residue = encoderEscapes(encodeFull(buffer, { colors: "truecolor" }));
+    assert.equal(hasControl(residue), false, `encoder emitted control 0x${cp.toString(16)}`);
+  }
+});
+
+test("a hostile log line cannot inject an escape sequence", () => {
+  // What an attacker controls: an SSH username, an HTTP path, a process name.
+  const hostile = "root" + ESC + "]0;OWNED" + BEL + ESC + "[5;41;97m HACKED " + ESC + "[0m";
+  const out = renderToAnsi(({ ui }) => ui.text("Failed password for " + hostile), {
+    width: 78,
+    height: 1,
+    capabilities: { colors: "truecolor" },
+  });
+  assert.equal(hasControl(encoderEscapes(out)), false);
+  // The payload is still shown, as inert literal text.
+  assert.match(renderToText(({ ui }) => ui.text(hostile), { width: 78, height: 1 }), /OWNED/);
+});
+
+test("a control cannot ride in on a ZWJ sequence or a combining mark", () => {
+  const zwj = "a" + C(0x200d) + ESC + "b";
+  const combining = "a" + C(0x0301) + ESC;
+  for (const payload of [zwj, combining]) {
+    const buffer = new FrameBuffer(8, 1);
+    buffer.write(0, 0, payload);
+    assert.equal(hasControl(buffer.rowText(0)), false);
+  }
+});
+
+test("the escape hatch cannot write a control either", () => {
+  // setCell takes a raw cell value, bypassing grapheme segmentation entirely.
+  for (const cp of ALL_CONTROLS) {
+    const buffer = new FrameBuffer(4, 1);
+    buffer.setCell(0, 0, cp);
+    assert.equal(hasControl(buffer.rowText(0)), false, `setCell stored 0x${cp.toString(16)}`);
+  }
+});
+
+test("interning a cluster strips controls and never yields an empty cell", () => {
+  assert.equal(hasControl(clusterText(internCluster("a" + ESC))), false);
+  // A cluster of nothing but controls must still occupy its column.
+  assert.equal(clusterText(internCluster(ESC + BEL)), " ");
+});
+
+/**
+ * Everything below was found by red-teaming the fix above. Each one got a live
+ * escape, a reordered line, or an unbounded paint past the first round of guards.
+ */
+
+test("setCell validates what the Uint32Array will really store", () => {
+  // `chars` is a Uint32Array, so it applies ToUint32. 2**32 + 0x1b is not a
+  // control by value, but truncates to one on the way into the grid.
+  for (const poison of [2 ** 32 + 0x1b, 2 ** 33 + 0x1b, -1, 2 ** 32 - 1]) {
+    const buffer = new FrameBuffer(4, 1);
+    buffer.setCell(0, 0, poison);
+    assert.equal(hasControl(buffer.rowText(0)), false, `stored ${poison}`);
+    assert.equal(buffer.rowText(0).length, 4, `row lost a column for ${poison}`);
+  }
+  // Same via an object that only becomes dangerous once coerced.
+  const buffer = new FrameBuffer(4, 1);
+  buffer.setCell(0, 0, { valueOf: () => 2 ** 32 + 0x1b } as unknown as number);
+  assert.equal(hasControl(buffer.rowText(0)), false);
+});
+
+test("bidi overrides cannot reorder what the operator reads", () => {
+  // Trojan Source: "user<RLO>nimda" displays as "user admin".
+  const RLO = C(0x202e);
+  const hostile = "login: user" + RLO + "nimda";
+  const buffer = new FrameBuffer(30, 1);
+  buffer.write(0, 0, hostile);
+  assert.equal(buffer.rowText(0).includes(RLO), false);
+  assert.equal(encodeFull(buffer, { colors: "none" }).includes(RLO), false);
+  for (const cp of [0x202a, 0x202b, 0x202c, 0x202d, 0x202e, 0x2066, 0x2067, 0x2068, 0x2069]) {
+    assert.equal(isBidiControl(cp), true, `0x${cp.toString(16)}`);
+    const b = new FrameBuffer(8, 1);
+    b.write(0, 0, "a" + String.fromCodePoint(cp) + "b");
+    assert.equal(b.rowText(0).includes(String.fromCodePoint(cp)), false);
+  }
+  // Real RTL script and the directional marks still render.
+  assert.equal(isBidiControl(0x200e), false);
+  assert.ok(stringWidth("\u05d0\u05d1") > 0);
+});
+
+test("one cell can never paint an unbounded number of columns", () => {
+  // ZWJ joins emoji and nothing else; joining it to CJK made a single cell
+  // claim one column while painting hundreds.
+  const ZWJ = C(0x200d);
+  const bomb = "a" + Array.from({ length: 400 }, () => ZWJ + "\u4e2d").join("");
+  const cells = graphemes(bomb);
+  assert.equal(cells.length, 401, "ZWJ still gluing arbitrary text into one cell");
+  assert.equal(stringWidth(bomb), 801);
+  // Declared width and painted width must agree, or the row desynchronises.
+  for (const cell of cells) {
+    assert.ok(clusterText(cell.value).length <= 16 || cell.value < 0x110000);
+  }
+  // A real emoji ZWJ sequence is still one cell.
+  assert.equal(graphemes("\u{1f469}\u200d\u{1f4bb}").length, 1);
+  assert.equal(graphemes("\u{1f468}\u200d\u{1f469}\u200d\u{1f467}").length, 1);
+});
+
+test("a cluster holds a bounded number of codepoints", () => {
+  // Zalgo: thousands of combining marks on one base is byte amplification.
+  const zalgo = "a" + C(0x0301).repeat(5000);
+  const cells = graphemes(zalgo);
+  assert.ok(clusterText(cells[0].value).length <= 17, "cluster was not capped");
+  assert.equal(cellWidth(cells[0].value), 1);
+});
+
+test("the intern table cannot be grown without bound", () => {
+  // Every distinct cluster used to be interned for ever, so untrusted text
+  // could grow the heap indefinitely. The cap is deliberately far above any
+  // real UI, so only a deliberate attempt reaches it.
+  const before = internCluster("\u{1f469}\u200d\u{1f4bb}");
+  for (let i = 0; i < 40000; i++) internCluster("x" + C(0x0301) + String.fromCodePoint(0x4e00 + i));
+  const after = internCluster("\u{1f469}\u200d\u{1f4bb}");
+  assert.equal(before, after, "existing clusters must stay valid");
+
+  // Past the cap a new cluster degrades to its base character. That loses the
+  // combining marks, but it must never lose the *column*: a cell that lies
+  // about its width desynchronises the cursor from the screen, which is the
+  // corruption this whole file exists to prevent.
+  const overflow = internCluster("z" + C(0x0301) + C(0x0302));
+  assert.equal(hasControl(cellText(overflow)), false);
+  assert.equal(cellText(overflow), "z", "degrades to the base character");
+  assert.equal(cellWidth(overflow), 1, "and keeps its width");
+  const wide = internCluster("\u4e2d" + C(0x0301));
+  assert.equal(cellWidth(wide), 2, "a wide base still reports two columns");
+});
+
+test("ZWJ outside emoji is dropped — a deliberate trade-off", () => {
+  // ZWJ legitimately requests conjunct forms in Devanagari, Sinhala and Arabic.
+  // Honouring it would mean letting a cell hold arbitrary joined text, which is
+  // exactly the primitive that let one cell paint hundreds of columns. The old
+  // behaviour was not correct either: it packed the whole run into a cell that
+  // claimed a single column. Each codepoint now gets its own cell instead, so
+  // the grid stays in step even though the conjunct ligature is lost.
+  const ZWJ = C(0x200d);
+  const devanagari = "\u0915\u094d" + ZWJ + "\u0937";
+  const cells = graphemes(devanagari);
+  assert.equal(cells.length, 3);
+  assert.equal(stringWidth(devanagari), 3, "declared width matches the cells drawn");
+  assert.equal(cells.map((c) => cellText(c.value)).join("").includes(ZWJ), false);
+  // Emoji, which is what ZWJ is for in a terminal, is untouched.
+  assert.equal(graphemes("\u{1f469}\u200d\u{1f4bb}").length, 1);
+});
+
+test("setTitle cannot be escaped by C1 or DEL", () => {
+  // The title is interpolated into an OSC sequence. 8-bit ST/CSI would end it.
+  const title = setTitle("session " + C(0x9c) + C(0x9b) + "31m" + C(0x7f) + ESC + "]0;evil");
+  assert.equal(hasControl(title.slice(5, -1)), false);
+});
+
+test("stripAnsi leaves nothing that can steer a terminal", () => {
+  const cases = [
+    C(0x9b) + "31mRED",              // 8-bit CSI
+    ESC + "[0 qHELLO",               // CSI with an intermediate byte
+    ESC + "]0;title" + BEL + "X",    // OSC
+    ESC + "P q" + ESC + "\\Y",        // DCS
+    ESC + "[X",
+  ];
+  for (const input of cases) {
+    assert.equal(hasControl(stripAnsi(input)), false, JSON.stringify(input));
+  }
+  assert.equal(stripAnsi("plain"), "plain");
+});
+
+test("stripAnsi keeps tab, newline and carriage return", () => {
+  // It sanitises text, not cells. Multi-line callers depend on these.
+  assert.equal(stripAnsi("line1\nline2"), "line1\nline2");
+  assert.equal(stripAnsi("col1\tcol2"), "col1\tcol2");
+  assert.equal(stripAnsi("a\r\nb"), "a\r\nb");
+  // But the cursor-moving whitespace controls still go.
+  assert.equal(hasControl(stripAnsi("a" + C(0x0b) + C(0x0c) + "b")), false);
+});
+
+test("renderToHtml escapes attribute values, not just cell text", () => {
+  const html = renderToHtml(({ ui }) => ui.text("hi"), {
+    width: 8,
+    height: 1,
+    className: 'x" onload="alert(1)',
+    fontFamily: 'y;}</style><script>alert(2)</script>',
+  } as Parameters<typeof renderToHtml>[1]);
+  assert.equal(/onload="alert\(1\)"/.test(html), false);
+  assert.equal(html.includes("<script>"), false);
+
+  // Every interpolated option, not just the two that are obviously strings.
+  const hostile = renderToHtml(({ ui }) => ui.text("hi"), {
+    width: 6,
+    height: 1,
+    padding: '0px"><script>alert(1)</script><pre y="',
+    fontSize: "14px;}</style>",
+    // Escaping alone is not enough here: `;` opens a new CSS property.
+    fontFamily: "monospace;position:fixed;width:100vw;background:url(https://evil.example/x)",
+  } as unknown as Parameters<typeof renderToHtml>[1]);
+  assert.equal(hostile.includes("<script>"), false);
+  assert.equal(hostile.includes("</style>"), false);
+  // The font stack is reduced to characters a font stack can contain, so no
+  // new CSS property or URL can be opened from inside it.
+  const stack = /font-family:([^;]*)/.exec(hostile)?.[1] ?? "";
+  assert.equal(/[;:()/\\{}<>"]/.test(stack), false, `font stack kept syntax: ${stack}`);
+  assert.equal(/position:fixed/.test(hostile), false);
+  assert.equal(/url\(/.test(hostile), false);
+  // A non-numeric size falls back rather than emitting NaN or breaking out.
+  assert.match(hostile, /padding:16px/);
+  assert.match(hostile, /font-size:14px/);
+});
+
+test("dropping a codepoint cannot fuse its neighbours", () => {
+  // Two unpaired surrogates either side of a dropped control used to end up
+  // adjacent, and `parts.join("")` fused them into one astral glyph: two cells
+  // claiming two columns painted one, and the row desynchronised from there on.
+  const HI = C(0xd800), LO = C(0xdc00);
+  for (const separator of [C(0x00), ESC, C(0x202e)]) {
+    const buffer = new FrameBuffer(10, 1);
+    buffer.write(0, 0, HI + separator + LO);
+    assert.equal([...buffer.rowText(0)].length, 10, `fused across ${separator.codePointAt(0)}`);
+  }
+  // And with no separator at all.
+  const buffer = new FrameBuffer(30, 1);
+  buffer.write(0, 0, (HI + LO).repeat(5) + "|END");
+  assert.equal([...buffer.rowText(0)].length, 30);
+  // A real surrogate pair is still one astral character, not two replacements.
+  assert.equal(graphemes("\u{1f600}").length, 1);
+  assert.equal(stringWidth("\u{1f600}"), 2);
+  // setCell takes raw values, so it has to refuse a bare half too.
+  const raw = new FrameBuffer(4, 1);
+  raw.setCell(0, 0, 0xd800);
+  raw.setCell(1, 0, 0xdc00);
+  assert.equal([...raw.rowText(0)].length, 4);
+});
+
+test("every unsafe codepoint is zero-width", () => {
+  // `graphemes` tests the width first and only then asks whether the codepoint
+  // is safe, so printable text never pays for the check. That reordering is
+  // only sound while this holds — across the whole of Unicode.
+  let violations = 0;
+  for (let cp = 0; cp <= 0x10ffff; cp++) {
+    if (cp >= 0xd800 && cp <= 0xdfff) continue;
+    if (isUnsafeCodepoint(cp) && charWidth(cp) !== 0) violations++;
+  }
+  assert.equal(violations, 0, "an unsafe codepoint with a width would slip past graphemes()");
+});
+
+test("isControl covers C0, DEL and C1 exactly", () => {
+  for (const cp of ALL_CONTROLS) assert.equal(isControl(cp), true, `0x${cp.toString(16)}`);
+  for (const cp of [0x20, 0x41, 0x7e, 0xa0, 0x300, 0x4e00, 0x1f600]) {
+    assert.equal(isControl(cp), false, `0x${cp.toString(16)}`);
+  }
+});


### PR DESCRIPTION
`SECURITY.md` promises:

> Untrusted text passed to a widget is measured and clipped, **never re-emitted as control sequences** — if you find input that escapes a cell, corrupts the surrounding grid, or injects an escape sequence into stdout, that is a security bug and we want to hear about it.

That did not hold. This PR makes it true.

## The bug

Control characters are zero-width, so `graphemes()` absorbed them into the preceding grapheme exactly like a combining mark, and `cellText` wrote them straight back out.

```js
renderToAnsi(({ ui }) => ui.text("Failed password for " + hostile), { width: 78, height: 1 })
// where hostile = "root" + ESC + "]0;OWNED" + BEL + ESC + "[5;41;97m HACKED " + ESC + "[0m"

INJECTED  OSC 0 window-title set
INJECTED  SGR blink+red-bg+white-fg
```

A *lone* control was already dropped, which is likely why this looked safe — but one preceded by any printable character survived.

This is reachable in normal use: `apps/demo` renders `ps` output (`linux.ts:297`, `darwin.ts:136` → `dashboard.ts:167`), journald messages, and auth/access logs. `argv[0]` is attacker-controlled by any local user, and the demo's README documents running it under sudo.

## The fix

`setCell` is the only path that writes a character into the grid, so the rule is enforced there and the framebuffer becomes **incapable** of holding a live escape, whatever the caller passes.

Refused at the cell:
- **C0, DEL, C1** (`0x00`–`0x1f`, `0x7f`, `0x80`–`0x9f`)
- **Bidi overrides and isolates** (`U+202A`–`U+202E`, `U+2066`–`U+2069`) — the Trojan Source set. `user<RLO>nimda` renders as `user admin` in a log pane. LRM/RLM and real RTL script are left alone.

A cell must also be honest about its width, since one that claims a column it does not paint desynchronises the cursor and corrupts the rest of the row:

- **ZWJ joins emoji and nothing else.** It used to glue arbitrary text into one cell — 400 CJK characters claimed a single column and painted 801.
- **A cell holds at most 16 codepoints**, and the cluster table is capped, so untrusted text cannot amplify bytes or grow the heap without bound (previously 200k distinct clusters grew the heap by 13 MB).
- **A zero-width base is dropped** along with anything it absorbed, rather than given a column it never paints.
- **Unpaired surrogates render as U+FFFD.** Two halves left adjacent by a dropped codepoint fused into one glyph spanning two cells.

Same policy applied to three other places that had their own weaker rules:
- `setTitle` stripped only C0, so 8-bit ST/CSI could break out of the OSC sequence.
- `stripAnsi` — exported as a sanitiser — missed 8-bit C1 and CSI intermediate bytes. `ESC [ 0 SP q` passed through intact. It still preserves tab/newline/CR, since it sanitises text rather than cells.
- `renderToHtml` interpolated four caller-supplied options into HTML attributes unescaped.

One subtlety worth calling out: `setCell` validates **after** `>>> 0`. `chars` is a `Uint32Array` and applies `ToUint32`, so `2**32 + 0x1b` looks harmless to a range check but truncates to a live ESC on the way in.

## Deliberate trade-offs

Both documented in `SECURITY.md`, both chosen to keep the column correct:

- **ZWJ outside emoji is dropped.** Devanagari/Sinhala/Arabic conjuncts lose their ligature. The previous behaviour was not correct either — it packed the whole run into a cell claiming one column.
- **Past 32768 distinct clusters, a new one degrades to its base character.** Cells hold an index into the cluster table, so entries can never be evicted while a framebuffer might still reference them.

## Verification

- Every unsafe codepoint is zero-width across all **1,112,064** codepoints — the invariant the width-first ordering in `graphemes()` depends on. Locked as a test.
- **200,000-string differential fuzz** against the previous behaviour: no width changes outside the ZWJ path.
- Declared width vs columns actually painted: previously wrong in 3,051 cases, now **0**.
- Emoji still segment identically to `Intl.Segmenter` — family, couple-with-heart, rainbow flag, pirate flag, keycap, woman-technologist.
- Three independent adversarial review passes; each round's findings are fixed and covered by tests.

`test/security.test.ts` adds 20 tests over all 65 control codepoints, the bidi set, and the grapheme, encoder, escape-hatch, interning and ZWJ paths.

## Performance

Per CONTRIBUTING, `bun run bench` before → after:

| benchmark | before | after |
|---|---|---|
| `renderer.frame.100pct` | 0.383ms | 0.389ms |
| `renderer.repaint.full` | 0.124ms | 0.126ms |
| `buffer.writeScreen` | 0.108ms | 0.107ms |
| `widgets.table` | 0.144ms | 0.144ms |
| `widgets.dashboard` | 0.103ms | 0.105ms |
| `text.stringWidth` | 872,721 ops/s | 870,001 ops/s |

`bun run typecheck && bun test` pass (119 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
