### PR TITLE
Fix two hangs that leave the terminal unrecoverable

### DIFF
--- a/packages/hqtui/src/graphics/braille.ts
+++ b/packages/hqtui/src/graphics/braille.ts
@@ -32,11 +32,15 @@ export class BrailleCanvas {
     this.dots.fill(0);
   }
 
-  /** Set one pixel. Out-of-range coordinates are ignored, not clamped. */
+  /**
+   * Set one pixel. Out-of-range coordinates are ignored, not clamped — and the
+   * test is written positively so that NaN, which compares false against
+   * everything, is ignored too rather than landing in cell 0.
+   */
   pixel(x: number, y: number): void {
     const px = Math.round(x);
     const py = Math.round(y);
-    if (px < 0 || py < 0 || px >= this.width || py >= this.height) return;
+    if (!(px >= 0 && py >= 0 && px < this.width && py < this.height)) return;
     const cell = (py >> 2) * this.cols + (px >> 1);
     this.dots[cell] |= DOT_BITS[py & 3][px & 1];
   }
@@ -44,7 +48,7 @@ export class BrailleCanvas {
   unset(x: number, y: number): void {
     const px = Math.round(x);
     const py = Math.round(y);
-    if (px < 0 || py < 0 || px >= this.width || py >= this.height) return;
+    if (!(px >= 0 && py >= 0 && px < this.width && py < this.height)) return;
     const cell = (py >> 2) * this.cols + (px >> 1);
     this.dots[cell] &= ~DOT_BITS[py & 3][px & 1];
   }
@@ -52,7 +56,7 @@ export class BrailleCanvas {
   get(x: number, y: number): boolean {
     const px = Math.round(x);
     const py = Math.round(y);
-    if (px < 0 || py < 0 || px >= this.width || py >= this.height) return false;
+    if (!(px >= 0 && py >= 0 && px < this.width && py < this.height)) return false;
     const cell = (py >> 2) * this.cols + (px >> 1);
     return (this.dots[cell] & DOT_BITS[py & 3][px & 1]) !== 0;
   }
@@ -63,6 +67,10 @@ export class BrailleCanvas {
     let y = Math.round(y0);
     const ex = Math.round(x1);
     const ey = Math.round(y1);
+    // The loop below only ends at `x === ex && y === ey`. A non-finite endpoint
+    // makes every comparison false, so it would never end at all — the render
+    // loop would hang and the terminal would never be restored.
+    if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(ex) || !Number.isFinite(ey)) return;
     const dx = Math.abs(ex - x);
     const dy = -Math.abs(ey - y);
     const sx = x < ex ? 1 : -1;

--- a/packages/hqtui/src/graphics/plot.ts
+++ b/packages/hqtui/src/graphics/plot.ts
@@ -31,9 +31,16 @@ export interface PlotOptions {
   baseline?: number;
 }
 
+/** A finite number, or undefined — `sum / count` with no samples is NaN. */
+function bound(value: number | undefined): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
 function extent(seriesList: Series[], options: PlotOptions): [number, number] {
-  let min = options.min;
-  let max = options.max;
+  // A caller's axis bound is data, and data can be NaN. Falling back to the
+  // computed extent keeps every plotted coordinate finite.
+  let min = bound(options.min);
+  let max = bound(options.max);
   if (min === undefined || max === undefined) {
     let lo = Infinity;
     let hi = -Infinity;

--- a/packages/hqtui/src/input.ts
+++ b/packages/hqtui/src/input.ts
@@ -83,9 +83,25 @@ function keyEvent(
  * Feed it chunks, get events. Stateful so a sequence split across two reads
  * (common over SSH) still decodes correctly.
  */
+const PASTE_END = "\x1b[201~";
+
+/** Length of the longest suffix of `text` that is a proper prefix of `marker`. */
+function partialSuffix(text: string, marker: string): number {
+  for (let n = Math.min(text.length, marker.length - 1); n > 0; n--) {
+    if (text.endsWith(marker.slice(0, n))) return n;
+  }
+  return 0;
+}
+
 export class InputParser {
   private pending = "";
   private pasteBuffer: string | null = null;
+  /**
+   * Bytes held back mid-paste because they could be the start of the end
+   * marker. Kept separate from `pending` so they do not look like an
+   * unterminated escape and trip the Escape-key timeout.
+   */
+  private pasteTail = "";
 
   /** True when bytes are buffered awaiting the rest of a sequence. */
   get hasPending(): boolean {
@@ -98,6 +114,12 @@ export class InputParser {
    * so the terminal calls this on a short timeout.
    */
   flush(): InputEvent[] {
+    // Mid-paste, held-back bytes are a partial end marker that never completed,
+    // so they are paste content — not a lone Escape.
+    if (this.pasteBuffer !== null && this.pasteTail.length > 0) {
+      this.pasteBuffer += this.pasteTail;
+      this.pasteTail = "";
+    }
     if (this.pending.length === 0) return [];
     const data = this.pending;
     this.pending = "";
@@ -113,19 +135,29 @@ export class InputParser {
     const events: InputEvent[] = [];
     let data = this.pending + chunk;
     this.pending = "";
+    if (this.pasteTail.length > 0) {
+      data = this.pasteTail + data;
+      this.pasteTail = "";
+    }
 
     while (data.length > 0) {
       if (this.pasteBuffer !== null) {
-        const end = data.indexOf("\x1b[201~");
+        const end = data.indexOf(PASTE_END);
         if (end === -1) {
-          this.pasteBuffer += data;
+          // The end marker can straddle two reads, which is routine over SSH.
+          // Swallowing a partial one here used to lose it for good: the paste
+          // never ended, and every later keystroke — Ctrl+C included — went
+          // into the buffer instead of being dispatched.
+          const keep = partialSuffix(data, PASTE_END);
+          this.pasteBuffer += keep > 0 ? data.slice(0, data.length - keep) : data;
+          this.pasteTail = keep > 0 ? data.slice(data.length - keep) : "";
           data = "";
           break;
         }
         this.pasteBuffer += data.slice(0, end);
         events.push({ type: "paste", text: this.pasteBuffer });
         this.pasteBuffer = null;
-        data = data.slice(end + 6);
+        data = data.slice(end + PASTE_END.length);
         continue;
       }
 

--- a/packages/hqtui/test/braille.test.ts
+++ b/packages/hqtui/test/braille.test.ts
@@ -60,3 +60,14 @@ test("block glyph ramps are monotonic", () => {
   assert.equal(horizontalGlyph(1), "█");
   assert.notEqual(verticalGlyph(0.5), verticalGlyph(0.9));
 });
+
+test("braille ignores non-finite coordinates instead of looping forever", () => {
+  const canvas = new BrailleCanvas(20, 8);
+  canvas.line(0, 0, 5, Number.NaN);
+  canvas.line(Number.NaN, 0, 5, 5);
+  canvas.line(0, 0, Number.POSITIVE_INFINITY, 5);
+  canvas.pixel(Number.NaN, 0);
+  canvas.pixel(0, Number.NaN);
+  // Nothing was drawn at the origin by a NaN coordinate.
+  assert.equal(canvas.get(0, 0), false);
+});

--- a/packages/hqtui/test/input.test.ts
+++ b/packages/hqtui/test/input.test.ts
@@ -117,3 +117,43 @@ test("matchKey accepts both bare and modified forms", () => {
   assert.ok(matchKey(ctrlC, "ctrl+c"));
   assert.ok(!matchKey(ctrlC, "c"));
 });
+
+test("a paste terminator split across reads still ends the paste", () => {
+  // Routine over SSH. A partial end marker used to be swallowed into the paste
+  // buffer and lost, so the paste never ended and every later keystroke —
+  // Ctrl+C included — was buffered instead of dispatched.
+  const START = "\x1b[200~";
+  const END = "\x1b[201~";
+  for (let cut = 0; cut <= END.length; cut++) {
+    const parser = new InputParser();
+    const full = START + "hello" + END;
+    const at = START.length + "hello".length + cut;
+    const events = [...parser.parse(full.slice(0, at)), ...parser.parse(full.slice(at))];
+    const paste = events.find((e) => e.type === "paste");
+    assert.ok(paste, `split at ${cut} lost the paste`);
+    assert.equal(paste.type === "paste" && paste.text, "hello");
+    // And the parser is still usable afterwards.
+    assert.equal(parser.parse("q")[0]?.type, "key");
+  }
+});
+
+test("a paste delivered one byte at a time still decodes", () => {
+  const parser = new InputParser();
+  const events: ReturnType<InputParser["parse"]> = [];
+  for (const ch of "\x1b[200~abc\x1b[201~") events.push(...parser.parse(ch));
+  const paste = events.find((e) => e.type === "paste");
+  assert.equal(paste?.type === "paste" && paste.text, "abc");
+  const key = parser.parse("z")[0];
+  assert.equal(key?.type === "key" && key.key, "z");
+});
+
+test("paste content that resembles the end marker is kept", () => {
+  const parser = new InputParser();
+  const events = [
+    ...parser.parse("\x1b[200~a\x1b[20"),
+    ...parser.parse("0~b\x1b[201~"),
+  ];
+  const paste = events.find((e) => e.type === "paste");
+  // ESC[200~ inside a paste is content; only ESC[201~ ends it.
+  assert.equal(paste?.type === "paste" && paste.text, "a\x1b[200~b");
+});

--- a/packages/hqtui/test/render.test.ts
+++ b/packages/hqtui/test/render.test.ts
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { renderToScreen, renderToText, renderToHtml } from "../src/testing.ts";
+import type { Container } from "../src/ui.ts";
 import { themes } from "../src/theme.ts";
 import { hex } from "../src/color.ts";
 
@@ -273,4 +274,24 @@ test("escape hatch drawing reaches the buffer", () => {
     ui.draw((surface) => surface.text(0, 0, "raw"));
   }, { width: 10, height: 2 });
   assert.ok(screen.contains("raw"));
+});
+
+test("a non-finite axis bound does not hang the renderer", () => {
+  // `sum / count` with no samples is NaN. NaN compares false against
+  // everything, so it slipped every bounds test in BrailleCanvas.pixel and
+  // left Bresenham's only exit condition unreachable — the render loop never
+  // returned, so the app could not be quit and the terminal was never restored.
+  const views: ((ui: Container) => void)[] = [
+    (ui) => ui.graph({ values: [1, 2, 3], max: Number.NaN }),
+    (ui) => ui.graph({ values: [1, 2, 3], min: Number.NaN }),
+    (ui) => ui.graph({ values: [1, 2, 3], min: Number.NaN, max: Number.NaN }),
+    (ui) => ui.graph({ values: [1, 2, 3], max: Number.POSITIVE_INFINITY }),
+    (ui) => ui.graph({ values: [Number.NaN, 1, Number.NaN] }),
+    (ui) => ui.sparkline({ values: [1, Number.NaN, 3] }),
+    (ui) => ui.histogram({ values: [1, 2], max: Number.NaN }),
+  ];
+  for (const view of views) {
+    const screen = renderToScreen(({ ui }) => view(ui), { width: 30, height: 6 });
+    assert.equal(typeof screen.text(), "string");
+  }
 });


### PR DESCRIPTION
Two ways to make the library stop responding while it owns the terminal. Both break the CONTRIBUTING guarantee that terminal state is always restored — in each case the process ignores Ctrl+C with the alternate screen and raw mode still active, so the user's shell is left unusable.

## 1. A non-finite axis bound hangs the renderer

```js
ui.graph({ values: [1, 2, 3], max: 0 / 0 })   // never returns
```

`extent` (`graphics/plot.ts`) took `options.min` / `options.max` on trust. A bound computed as `sum / count` with no samples is `NaN` — ordinary code, no adversarial input needed.

`NaN` compares false against everything, so it slipped every bounds test in `BrailleCanvas.pixel` — which documents that "out-of-range coordinates are ignored" — and wrote to cell 0. Worse, `line`'s only exit is `x === ex && y === ey`, which a `NaN` endpoint makes unreachable:

```
calling line(0,0,5,NaN) ...
  dx = 5  dy = NaN  err = NaN  ey = NaN
  still looping after 5,000,000 iterations
```

Three fixes, defence in depth:
- `extent` falls back to the computed extent when a supplied bound is not finite
- the braille bounds tests are written positively (`if (!(px >= 0 && … ))`) so `NaN` is excluded rather than slipping through
- `line` returns early on a non-finite endpoint

## 2. A paste terminator split across two reads wedges the input parser permanently

`InputParser`'s docstring promises that "a sequence split across two reads (common over SSH) still decodes correctly". For the bracketed-paste end marker it did not:

```
chunk1 tail: "llo\x1b[2"   chunk2: "01~"
events(chunk1): []
events(chunk2): []
events('q'):    []
events(ctrl+c): []
```

When `data.indexOf("\x1b[201~")` missed, the whole chunk — including the partial `ESC[201` prefix — was appended to the paste buffer and dropped from the scan. The next chunk started fresh, so the terminator was never seen again. The paste never ended, and every later keystroke including Ctrl+C went into the buffer instead of being dispatched.

The parser now holds back the longest suffix that could still begin the end marker and re-examines it with the next chunk. Those bytes live in their own field rather than `pending`, so they cannot look like an unterminated escape and trip the Escape-key timeout; `flush` folds them into the paste if nothing more arrives.

## Verification

- The paste is recovered at **all 7 split positions** of the end marker, and when delivered **one byte at a time**
- `ESC[200~` appearing inside a paste is still treated as content, not as an end marker
- The parser stays usable afterwards — the following keypress dispatches normally
- `NaN` / `Infinity` through `graph`, `sparkline`, `histogram`, `meter`, `gauge` and `donut` all return

Tests added to `test/input.test.ts`, `test/render.test.ts` and `test/braille.test.ts`. `bun run typecheck && bun test` pass (104 tests).

## Performance

Paired before/after, two passes each:

| benchmark | before | after |
|---|---|---|
| `renderer.frame.100pct` | 0.438ms / 0.435ms | 0.435ms / 0.428ms |
| `graphics.braille.polyline` | 0.003ms | 0.003ms |
| `graphics.graph.braille` | 0.075ms / 0.074ms | 0.076ms / 0.074ms |
| `widgets.dashboard` | 0.121ms / 0.119ms | 0.128ms / 0.117ms |

No measurable cost — the guards are per `line()` call, not per pixel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
