### PR TITLE
Fix layout and widget bugs that silently drop content

### DIFF
--- a/packages/hqtui/src/capabilities.ts
+++ b/packages/hqtui/src/capabilities.ts
@@ -54,6 +54,9 @@ function detectColors(env: NodeJS.ProcessEnv, tty: boolean): ColorDepth {
   if (env.FORCE_COLOR === "1") return "ansi16";
   if (env.FORCE_COLOR === "2") return "ansi256";
   if (env.FORCE_COLOR === "3") return "truecolor";
+  // Node and npm commonly export FORCE_COLOR=true, and anything set but not a
+  // level still means "yes". Only "0" means no.
+  if (env.FORCE_COLOR !== undefined && env.FORCE_COLOR !== "") return "ansi16";
   if (!tty) return "none";
   const term = env.TERM ?? "";
   if (term === "dumb") return "none";
@@ -69,6 +72,10 @@ function detectColors(env: NodeJS.ProcessEnv, tty: boolean): ColorDepth {
 }
 
 function detectUnicode(env: NodeJS.ProcessEnv): boolean {
+  // Degrading colors but not glyphs leaves a dumb terminal being told it can
+  // draw Braille, which is the one thing it certainly cannot.
+  const term = env.TERM ?? "";
+  if (term === "dumb" || term === "linux") return false;
   const locale = env.LC_ALL || env.LC_CTYPE || env.LANG || "";
   if (/UTF-?8/i.test(locale)) return true;
   // Windows Terminal and modern emulators are UTF-8 regardless of locale vars.

--- a/packages/hqtui/src/color.ts
+++ b/packages/hqtui/src/color.ts
@@ -95,7 +95,10 @@ export function gradient(stops: (Color | string)[]): (t: number) => Color {
   if (cols.length === 0) return () => DEFAULT_COLOR;
   if (cols.length === 1) return () => cols[0];
   return (t: number) => {
-    const k = t < 0 ? 0 : t > 1 ? 1 : t;
+    // Ordered so NaN falls through to 0. Written the other way round it
+    // compares false against both bounds and reaches `cols[NaN]`, which `mix`
+    // coerced to black. Infinities still clamp to the ends.
+    const k = t > 1 ? 1 : t > 0 ? t : 0;
     const pos = k * (cols.length - 1);
     const i = Math.min(Math.floor(pos), cols.length - 2);
     return mix(cols[i], cols[i + 1], pos - i);

--- a/packages/hqtui/src/input.ts
+++ b/packages/hqtui/src/input.ts
@@ -330,6 +330,11 @@ const SPECIAL_KEYS_SORTED = Object.keys(SPECIAL).sort((a, b) => b.length - a.len
 export function matchKey(event: KeyEvent, binding: string): boolean {
   const b = binding.toLowerCase().trim();
   if (event.key.toLowerCase() === b) return true;
-  if (event.name.toLowerCase() === b && !event.ctrl && !event.alt) return true;
+  // `keyEvent` only spells shift into `key` for named keys, so only named keys
+  // may reject it here — otherwise a binding on "tab" would also fire on
+  // Shift+Tab and move focus backwards and forwards at once. For a printable
+  // character shift is what produced the character, so it is not a modifier.
+  const shiftMatters = event.shift && event.name.length > 1;
+  if (event.name.toLowerCase() === b && !event.ctrl && !event.alt && !shiftMatters) return true;
   return false;
 }

--- a/packages/hqtui/src/surface.ts
+++ b/packages/hqtui/src/surface.ts
@@ -198,23 +198,32 @@ export class Surface {
       this.vline(w - 1, 1, h - 2, b.v, borderStyle);
     }
 
+    // Measured before the title is drawn: both share the top border row, and
+    // the title used to be truncated against the full width and then painted
+    // over by the subtitle.
+    const subtitle = options.subtitle ? ` ${options.subtitle} ` : "";
+    const subtitleWidth = subtitle && stringWidth(subtitle) + 4 < w ? stringWidth(subtitle) : 0;
+
     if (options.title) {
       const titleColor = options.titleColor ?? this.theme.title;
       const label = ` ${options.title} `;
-      const maxLabel = Math.max(0, w - 4);
-      const shown = truncate(label, maxLabel);
+      // Both labels carry a space of padding, and those two spaces may share a
+      // column — but only while the title fits, since a truncated one ends in
+      // content rather than padding.
+      const strict = Math.max(0, w - 4 - subtitleWidth);
+      const room = subtitleWidth > 0 && stringWidth(label) <= strict + 1 ? strict + 1 : strict;
+      const shown = truncate(label, room);
       const tw = stringWidth(shown);
       const align = options.titleAlign ?? "left";
       const tx = align === "left" ? 2 : align === "right" ? Math.max(2, w - 2 - tw) : Math.max(2, Math.floor((w - tw) / 2));
       this.text(tx, 0, shown, { fg: titleColor, bg, attrs: 1 /* bold */ });
     }
 
-    if (options.subtitle) {
-      const sub = ` ${options.subtitle} `;
-      const sw = stringWidth(sub);
-      if (sw + 4 < w) {
-        this.text(w - 2 - sw, 0, sub, { fg: options.subtitleColor ?? this.theme.muted, bg });
-      }
+    if (subtitleWidth > 0) {
+      this.text(w - 2 - subtitleWidth, 0, subtitle, {
+        fg: options.subtitleColor ?? this.theme.muted,
+        bg,
+      });
     }
 
     if (options.footer && h > 2) {

--- a/packages/hqtui/src/ui.ts
+++ b/packages/hqtui/src/ui.ts
@@ -136,6 +136,19 @@ export class Container {
     return this;
   }
 
+  /**
+   * Constraint for a widget whose own options use `min`/`max` as a data domain
+   * rather than a layout bound — meters, progress, gauges and plots.
+   *
+   * Reading those as layout constraints meant `max: 0` on an empty queue or an
+   * unprobed disk deleted the widget outright, and pinning a graph's y-axis
+   * with `min: 30` reserved thirty rows and evicted its siblings. Use `size`,
+   * `width` or `height` to constrain these.
+   */
+  private sizeOfData(o: ContainerOptions | undefined, fallback: Size, intrinsic?: number): Constraint {
+    return this.sizeOf(o ? { ...o, min: undefined, max: undefined } : o, fallback, intrinsic);
+  }
+
   private sizeOf(o: ContainerOptions | undefined, fallback: Size, intrinsic?: number): Constraint {
     const explicit = o?.size ?? (this.direction === "column" ? o?.height : o?.width);
     if (explicit !== undefined) return { size: explicit, min: o?.min, max: o?.max, intrinsic };
@@ -317,23 +330,23 @@ export class Container {
 
   /** `label ████████░░░ 42%` */
   meter(options: W.MeterOptions & ContainerOptions): this {
-    return this.add((s) => W.drawMeter(s, options), this.sizeOf(options, "auto", 1));
+    return this.add((s) => W.drawMeter(s, options), this.sizeOfData(options, "auto", 1));
   }
 
   /** A stack or grid of meters. */
   meters(items: W.MetersOptions["items"], options: Omit<W.MetersOptions, "items"> & ContainerOptions = {}): this {
     const columns = Math.max(1, options.columns ?? 1);
     const rows = Math.ceil(items.length / columns);
-    return this.add((s) => W.drawMeters(s, { ...options, items }), this.sizeOf(options, "auto", rows));
+    return this.add((s) => W.drawMeters(s, { ...options, items }), this.sizeOfData(options, "auto", rows));
   }
 
   progress(options: W.ProgressOptions & ContainerOptions): this {
-    return this.add((s) => W.drawProgress(s, options), this.sizeOf(options, "auto", 1));
+    return this.add((s) => W.drawProgress(s, options), this.sizeOfData(options, "auto", 1));
   }
 
   /** Braille line/area graph. Fills the space it is given. */
   graph(options: W.GraphOptions & ContainerOptions): this {
-    return this.add((s) => W.drawGraph(s, options), this.sizeOf(options, "fill"));
+    return this.add((s) => W.drawGraph(s, options), this.sizeOfData(options, "fill"));
   }
 
   /** A filled area graph — `graph` with `fill` on. */
@@ -347,16 +360,16 @@ export class Container {
   }
 
   sparkline(options: W.SparklineOptions & ContainerOptions): this {
-    return this.add((s) => W.drawSparklineWidget(s, options), this.sizeOf(options, "auto", 1));
+    return this.add((s) => W.drawSparklineWidget(s, options), this.sizeOfData(options, "auto", 1));
   }
 
   histogram(options: W.ColumnsOptions & ContainerOptions): this {
-    return this.add((s) => W.drawColumns(s, options), this.sizeOf(options, "fill"));
+    return this.add((s) => W.drawColumns(s, options), this.sizeOfData(options, "fill"));
   }
 
   /** A semicircular dial. Wants at least 9x5. */
   gauge(options: W.GaugeOptions & ContainerOptions): this {
-    return this.add((s) => W.drawGauge(s, options), this.sizeOf(options, "fill"));
+    return this.add((s) => W.drawGauge(s, options), this.sizeOfData(options, "fill"));
   }
 
   donut(options: W.DonutOptions & ContainerOptions): this {
@@ -365,7 +378,7 @@ export class Container {
 
   /** Segmented temperature-style bar. */
   heatBar(options: W.HeatBarOptions & ContainerOptions): this {
-    return this.add((s) => W.drawHeatBar(s, options), this.sizeOf(options, "auto", 1));
+    return this.add((s) => W.drawHeatBar(s, options), this.sizeOfData(options, "auto", 1));
   }
 
   // ---------------------------------------------------------------- inputs
@@ -579,11 +592,19 @@ export class GridContainer {
     let cursor = 0;
 
     for (const cell of this.cells) {
-      const colSpan = Math.max(1, cell.options.colSpan ?? 1);
-      const rowSpan = Math.max(1, cell.options.rowSpan ?? 1);
+      // Clamp to the grid. A span wider than the track count can never satisfy
+      // `col + colSpan <= colWidths.length`, so the placement loop below used to
+      // burn the shared cursor to exhaustion — dropping this cell and every one
+      // after it. A responsive layout collapsing to one column made a
+      // full-width `colSpan: 2` header blank the whole grid.
+      const colSpan = Math.min(Math.max(1, cell.options.colSpan ?? 1), colWidths.length);
+      const rowSpan = Math.min(Math.max(1, cell.options.rowSpan ?? 1), rowHeights.length);
 
-      // Find the next free slot that fits the span.
+      // Find the next free slot that fits the span. The cursor is shared across
+      // cells, so a cell that cannot be placed must hand it back — otherwise it
+      // burns the cursor to exhaustion and every later cell disappears too.
       let placed = false;
+      const searchFrom = cursor;
       while (!placed && cursor < colWidths.length * rowHeights.length + colWidths.length) {
         const col = cursor % colWidths.length;
         const row = Math.floor(cursor / colWidths.length);
@@ -620,6 +641,7 @@ export class GridContainer {
         placed = true;
         cursor++;
       }
+      if (!placed) cursor = searchFrom;
     }
     this.cells.length = 0;
   }

--- a/packages/hqtui/src/widgets/meters.ts
+++ b/packages/hqtui/src/widgets/meters.ts
@@ -24,11 +24,21 @@ export interface MeterOptions {
   showValue?: boolean;
 }
 
+/**
+ * A 0-1 ratio. Ordered so NaN falls through to 0 — `Math.min`/`Math.max`
+ * propagate it, which rendered "NaN%" in black on black.
+ */
+export function clampRatio(value: number): number {
+  return value > 1 ? 1 : value > 0 ? value : 0;
+}
+
 /** `label ████████░░░░ 42%` on a single row. The most-used widget here. */
 export function drawMeter(surface: Surface, options: MeterOptions): void {
   if (surface.empty) return;
   const theme = surface.theme;
-  const ratio = Math.max(0, Math.min(1, options.max ? options.value / options.max : options.value));
+  // `Math.min`/`Math.max` propagate NaN, so a non-finite value used to render
+  // as "NaN%" in black on black.
+  const ratio = clampRatio(options.max ? options.value / options.max : options.value);
   const label = options.label ?? "";
   const labelWidth = label ? (options.labelWidth ?? stringWidth(label) + 1) : 0;
   const valueText = options.showValue === false ? "" : options.text ?? `${Math.round(ratio * 100)}%`;

--- a/packages/hqtui/test/color.test.ts
+++ b/packages/hqtui/test/color.test.ts
@@ -1,6 +1,8 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { rgb, hex, mix, gradient, to256, to16, from256, contrast, grayscale, DEFAULT_COLOR } from "../src/color.ts";
+import { heatColor, themes } from "../src/theme.ts";
+import { renderToText } from "../src/testing.ts";
 
 test("hex and rgb produce the same packed value", () => {
   assert.equal(hex("#00d7ff"), rgb(0, 215, 255));
@@ -57,4 +59,23 @@ test("grayscale keeps luminance ordering", () => {
   const dark = grayscale(hex("#102030"));
   const light = grayscale(hex("#e0e0e0"));
   assert.ok((dark & 255) < (light & 255));
+});
+
+test("a non-finite ratio does not become black", () => {
+  // The clamp compared false against both bounds, so NaN reached cols[NaN] and
+  // mix() coerced undefined to rgb(0,0,0) — black on black in a meter.
+  const ramp = gradient(["#ffffff", "#000000"]);
+  assert.equal(ramp(Number.NaN), ramp(0));
+  assert.equal(ramp(Number.POSITIVE_INFINITY), ramp(1));
+  assert.equal(ramp(Number.NEGATIVE_INFINITY), ramp(0));
+  assert.equal(heatColor(themes.dark, Number.NaN), heatColor(themes.dark, 0));
+});
+
+test("a meter with a non-finite value renders a real percentage", () => {
+  const out = renderToText(({ ui }) => ui.meter({ label: "CPU", value: Number.NaN }), {
+    width: 28,
+    height: 1,
+  });
+  assert.ok(!out.includes("NaN"), out);
+  assert.ok(out.includes("0%"));
 });

--- a/packages/hqtui/test/input.test.ts
+++ b/packages/hqtui/test/input.test.ts
@@ -157,3 +157,20 @@ test("paste content that resembles the end marker is kept", () => {
   // ESC[200~ inside a paste is content; only ESC[201~ ends it.
   assert.equal(paste?.type === "paste" && paste.text, "a\x1b[200~b");
 });
+
+test("a bare binding does not fire on the shifted key", () => {
+  // Tab and Shift+Tab move focus in opposite directions; a "tab" binding that
+  // also matched Shift+Tab did both at once.
+  const shiftTab: KeyEvent = {
+    type: "key", name: "tab", key: "shift+tab",
+    shift: true, ctrl: false, alt: false, raw: "\x1b[Z",
+  };
+  assert.equal(matchKey(shiftTab, "tab"), false);
+  assert.equal(matchKey(shiftTab, "shift+tab"), true);
+  // Shift is what produces a capital letter, so it is not a modifier there.
+  const shiftA: KeyEvent = {
+    type: "key", name: "a", key: "a",
+    shift: true, ctrl: false, alt: false, char: "A", raw: "A",
+  };
+  assert.equal(matchKey(shiftA, "a"), true);
+});

--- a/packages/hqtui/test/render.test.ts
+++ b/packages/hqtui/test/render.test.ts
@@ -295,3 +295,60 @@ test("a non-finite axis bound does not hang the renderer", () => {
     assert.equal(typeof screen.text(), "string");
   }
 });
+test("a cell that does not fit does not delete the cells after it", () => {
+  // The placement cursor is shared, so a cell that could never be placed used
+  // to burn it to exhaustion and drop every later cell too.
+  const screen = renderToScreen(({ ui }) => {
+    ui.grid({ columns: 3, rows: 1 }, (g) => {
+      g.panel({ title: "A" }, (p) => p.text("a"));
+      g.panel({ title: "WIDE", colSpan: 5 }, (p) => p.text("w"));
+      g.panel({ title: "C" }, (p) => p.text("c"));
+    });
+  }, { width: 44, height: 4 });
+  assert.ok(screen.contains("A"), "first cell lost");
+  assert.ok(screen.contains("C"), "cell after an unplaceable one was dropped");
+});
+
+test("a colSpan wider than a collapsed grid still renders every panel", () => {
+  // The realistic trigger: a full-width header in a responsive layout that
+  // narrows to a single column.
+  const screen = renderToScreen(({ ui }) => {
+    ui.grid({ columns: 1, rows: 3 }, (g) => {
+      g.panel({ title: "HEADER", colSpan: 2 }, (p) => p.text("h"));
+      g.panel({ title: "LEFT" }, (p) => p.text("l"));
+      g.panel({ title: "RIGHT" }, (p) => p.text("r"));
+    });
+  }, { width: 24, height: 9 });
+  for (const label of ["HEADER", "LEFT", "RIGHT"]) {
+    assert.ok(screen.contains(label), `${label} vanished`);
+  }
+});
+
+test("a widget's data range is not a layout constraint", () => {
+  // `min`/`max` mean the data domain on meters, progress and plots. Reading
+  // them as layout bounds deleted a progress bar whose max was 0 (an empty
+  // queue), and let a graph's pinned y-axis evict its siblings.
+  const emptyQueue = renderToScreen(({ ui }) => {
+    ui.text("BEFORE");
+    ui.progress({ label: "Tasks", value: 0, max: 0 });
+    ui.text("AFTER");
+  }, { width: 34, height: 3 });
+  assert.ok(emptyQueue.contains("Tasks"), "progress with max 0 disappeared");
+
+  const pinnedAxis = renderToScreen(({ ui }) => {
+    ui.graph({ values: [40, 50, 60], min: 30, max: 90 });
+    ui.text("FOOTER");
+  }, { width: 30, height: 10 });
+  assert.ok(pinnedAxis.contains("FOOTER"), "a pinned y-axis evicted the sibling");
+});
+
+test("a subtitle does not overwrite the title", () => {
+  const both = renderToText(({ ui }) => ui.panel(
+    { title: "A Long Panel Title", subtitle: "99%" },
+    (p) => p.text(""),
+  ), { width: 26, height: 3 }).split("\n")[0];
+  assert.ok(both.includes("99%"), "subtitle missing");
+  // The title is truncated to the space it actually has, rather than being
+  // painted over mid-word by the subtitle.
+  assert.ok(!both.includes("Tit 99%"), `title collided with subtitle: ${both}`);
+});


### PR DESCRIPTION
Six defects that quietly remove or corrupt content rather than failing loudly. Each is verified with a runnable reproduction; tests added for all of them.

## A cell that cannot be placed deletes every cell after it

The grid's placement cursor is shared across cells (`ui.ts`), so a cell that could never fit burned it to exhaustion and took the rest of the grid with it. A `colSpan` wider than the track count can never satisfy `col + colSpan <= colWidths.length`.

```
3-column grid, middle panel has colSpan 5:

  before                       after
  ╭─ A ───────╮                ╭─ A ────────╮╭─ C ────────╮
  │ a         │                │ a          ││ c          │
  ╰───────────╯                ╰────────────╯╰────────────╯
```

The realistic trigger is a responsive layout: a full-width `colSpan: 2` header in a grid that collapses to one column blanked the **entire** grid — every panel gone.

Spans are now clamped to the grid, and a cell that cannot be placed hands the cursor back instead of consuming it.

## A widget's data range was also a layout constraint

`ContainerOptions.min` / `max` are layout bounds, but `MeterOptions`, `ProgressOptions` and `PlotOptions` use the same two names for the **data domain** — and the intersection types (`MeterOptions & ContainerOptions`) passed them straight to the solver.

```js
ui.progress({ label: "Tasks", value: 0, max: 0 })   // widget vanished entirely
ui.graph({ values, min: 30, max: 90 })              // reserved 30 rows, evicted siblings
```

An empty queue or an unprobed disk (`max: 0`) deleted the widget. Pinning a graph's y-axis reserved that many rows of layout.

Meters, progress, gauges and plots no longer read `min`/`max` as layout bounds. `size`, `width` and `height` still work for constraining them. Worth noting the demo's own `components.ts:82` passes `progress({ max: 120 })` — benign only because 120 happens to exceed the available rows.

## Four more

- **`box()` let the subtitle overwrite the title.** It measured the title against the full width, then drew the subtitle on the same row: `╭─ A Long Panel Tit 99% ─╮`, chopped mid-word with no ellipsis. The title now reserves the subtitle's columns — while still letting the two padding spaces share one column, so nothing that previously fit gets truncated.
- **`matchKey` ignored shift.** A binding on `"tab"` also fired on Shift+Tab, so an app moved focus forwards and backwards at once. Named keys now reject it, matching how `keyEvent` spells `key`. A printable character is unaffected — there, shift is what produced the character.
- **`gradient(NaN)` returned pure black.** The clamp `t < 0 ? 0 : t > 1 ? 1 : t` passes NaN through, so it reached `cols[NaN]` and `mix` coerced `undefined` to `rgb(0,0,0)`. `ui.meter({ value: NaN })` rendered `NaN%` in black on black. Both clamps are reordered so NaN falls through to 0, and infinities still clamp to the ends.
- **Capability detection misfired.** `detectUnicode` never consulted `TERM`, so `TERM=dumb` was told it could draw Braille — the module's stated goal is to degrade colours *and glyphs*. And `FORCE_COLOR` was honoured only as `"0"`–`"3"`, missing the `FORCE_COLOR=true` that Node and npm commonly export.

## Verification

Beyond the unit tests, I rendered **all ten demo screens at three terminal sizes** before and after (timestamps masked, since the simulation uses wall-clock time):

```
renders compared        : 30
differing (time-masked) : 1
```

The single difference is the subtitle fix: a panel too narrow for both labels now shows `╭─ … 36 in / 31 out ─╮` instead of `╭─ P 36 in / 31 out ─╮` — the honest ellipsis rather than the misleading fragment left behind when the subtitle painted over the title.

`bun run typecheck && bun test` pass (106 tests).

## Performance

| benchmark | before | after |
|---|---|---|
| `renderer.frame.100pct` | 0.431ms | 0.437ms |
| `buffer.writeScreen` | 0.122ms | 0.123ms |
| `layout.solve` | 0.001ms | 0.001ms |
| `widgets.dashboard` | 0.140ms | 0.134ms |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
