### PR TITLE
Correct documentation claims that no longer match the code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Thanks for helping. HQTUI is MIT licensed and permanently open source.
 git clone https://github.com/profullstack/hqtui
 cd hqtui
 bun install
-bun test                  # 80+ tests, no TTY required
+bun test                  # ~100 tests, no TTY required
 bun run typecheck
 bun run demo -- --sim     # the reference dashboard
 bun run bench             # renderer benchmarks

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ btop-grade dashboards with a one-import API, dark by default, zero runtime depen
 <p align="center">
   <a href="https://hqtui.com">hqtui.com</a> ·
   <a href="https://www.npmjs.com/package/@profullstack/hqtui">npm</a> ·
-  <a href="./docs">docs</a>
+  <a href="https://hqtui.com/docs">docs</a>
 </p>
 
 ![HQTUI dashboard](./assets/screens/dashboard.png)
@@ -191,7 +191,7 @@ packages/hqtui   the library
 apps/demo        the reference dashboard (real + simulated data)
 apps/web         hqtui.com
 examples/        small, focused programs
-docs/            guides and the original PRD
+docs/            the original PRD
 ```
 
 ## Runtimes

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,36 +1,43 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# hqtui.com
 
-## Getting Started
+The HQTUI marketing site and documentation. Next.js App Router, Tailwind v4,
+deployed to Railway from the `Dockerfile` at the repository root.
 
-First, run the development server:
+## Development
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+bun install          # from the repository root
+bun run --cwd apps/web dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+The site imports `@profullstack/hqtui` from the workspace, so build the library
+first if you have not already:
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+```bash
+bun run build
+```
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+## Screenshots
 
-## Learn More
+The terminal frames on the site are real captures of `hqtui-demo` running on
+real machines, not browser-rendered mockups. Regenerate them with:
 
-To learn more about Next.js, take a look at the following resources:
+```bash
+bun run --cwd apps/web shots
+```
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+That writes intermediate HTML and pre-crop frames into `apps/web/.shots-tmp/`,
+which is ignored, and finished PNGs into `public/shots/`.
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+## Analytics
 
-## Deploy on Vercel
+Theme votes and page views are stored in Turso and read through a small
+`fetch`-based client in `lib/db.ts`. Both are optional: with
+`TURSO_DATABASE_URL` and `TURSO_AUTH_TOKEN` unset the site renders normally
+and the counters read zero.
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+## Deployment
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+Railway builds the root `Dockerfile`, which compiles the library, builds the
+site in standalone mode, and serves it with `bun apps/web/server.js`. See
+`railway.json`.

--- a/apps/web/app/docs/page.tsx
+++ b/apps/web/app/docs/page.tsx
@@ -260,9 +260,9 @@ expect(screen.cell(0, 4).bg).toBe(theme.selection);
 expect(renderToText(view, { width: 40, height: 10 })).toMatchSnapshot();`}
           />
           <P>
-            Every frame on this website is produced by{" "}
-            <code className="font-mono text-white/80">renderToHtml()</code> at build time — the
-            same renderer, the same output, just emitted as HTML instead of ANSI.
+            <code className="font-mono text-white/80">renderToHtml()</code> emits the same
+            frame as HTML instead of ANSI — the same renderer and the same output, which is what
+            makes a rendered frame reviewable in a browser or a pull request.
           </P>
 
           <H2 id="escape-hatches">Escape hatches</H2>

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -28,7 +28,7 @@ export const metadata: Metadata = {
     description,
     siteName: "HQTUI",
     images: [
-      { url: "/shots/dashboard.png", width: 3302, height: 1709, alt: "HQTUI dashboard" },
+      { url: "/shots/dashboard.png", width: 1892, height: 947, alt: "HQTUI dashboard" },
     ],
   },
   appleWebApp: { title: "HQTUI", statusBarStyle: "black-translucent" },

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -303,7 +303,7 @@ export default async function Home() {
                   or the raw cell grid with per-cell colours and attributes.
                 </p>
                 <p className="mt-3">
-                  The 83 tests in this repository run in 65 ms under both{" "}
+                  The 99 tests in this repository run in well under a second under both{" "}
                   <code className="font-mono text-white/80">bun test</code> and{" "}
                   <code className="font-mono text-white/80">node --test</code>.
                 </p>
@@ -386,7 +386,8 @@ export default async function Home() {
                 <InstallCommand command="bunx @profullstack/hqtui-demo --sim" />
               </div>
               <p className="mt-4 text-sm text-white/40">
-                Six screens: dashboard, components, graphics, themes, input visualizer, stress test.
+                Ten screens: dashboard, sessions, network, traffic, services, components,
+                graphics, themes, input visualizer, stress test.
               </p>
             </div>
             <Terminal

--- a/apps/web/app/showcase/page.tsx
+++ b/apps/web/app/showcase/page.tsx
@@ -26,7 +26,7 @@ export default async function Showcase() {
       <main className="mx-auto max-w-[1640px] px-4 py-14 sm:px-6">
         <div className="max-w-3xl">
           <Badge variant="secondary" className="mb-4 font-mono text-xs">
-            live frames, not screenshots
+            real machines, not mockups
           </Badge>
           <h1 className="text-4xl font-bold tracking-tight">Showcase</h1>
           <p className="mt-4 text-lg text-white/60">


### PR DESCRIPTION
Six documentation claims that are checkable and currently wrong. No behaviour changes.

| claim | where | reality |
|---|---|---|
| "The 83 tests in this repository" | `app/page.tsx:306` | **99** (`bun test packages/hqtui/test apps/demo/test`) |
| "80+ tests" | `CONTRIBUTING.md:11` | true but stale by a quarter |
| "Six screens: …" | `app/page.tsx:389` | **ten** in `screens/index.ts` |
| OG image `3302x1709` | `app/layout.tsx:31` | the PNG's IHDR says **1892x947** |
| "live frames, not screenshots" | `showcase/page.tsx:29` | they are screenshots |
| "Every frame … produced by `renderToHtml()` at build time" | `docs/page.tsx:264` | every frame is `<Image src="/shots/*.png">` |

## Notes on a few

**Screens.** The six listed omit sessions, network, traffic and services — which are the four the README and the showcase page lead with.

**OpenGraph.** Crawlers that trust the declared aspect ratio will letterbox or crop the card. Read straight from the file:

```
actual dashboard.png: 1892 x 947
```

**The showcase contradiction** is two adjacent elements disagreeing:

```
:29   live frames, not screenshots          <- badge
:33   Screenshots of hqtui-demo running on real machines
```

`components/site/terminal.tsx:18-28` already explains why it's the second one ("a live HTML frame stops looking like a terminal; the real thing is served as an image instead"). Commits 4522799 and 4b5f245 made that switch and this copy wasn't updated. I changed the badge to "real machines, not mockups", which is both true and the point the paragraph is making.

The docs-page sentence is reworded to describe what `renderToHtml()` is genuinely for — reviewing a rendered frame in a browser or a PR — rather than claiming it built this website.

**Test timing.** "run in 65 ms" is machine-specific; I measured 52 ms and 148 ms on the same laptop minutes apart. Replaced with "well under a second" so it can't go stale.

**The README's `docs` link** points at `./docs` and the layout section calls it "guides and the original PRD". `docs/` contains exactly one file, `PRD.md` — and it's still titled "VTTUI", the pre-rename name. The link now goes to hqtui.com/docs, which is the actual documentation.

**`apps/web/README.md`** was untouched create-next-app boilerplate, instructing readers to deploy on Vercel a site that Railway builds from the root `Dockerfile`. Replaced with the real workflow.

`bun run typecheck && bun test` pass (99 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
