### PR TITLE
Report real process metrics instead of derived or fabricated ones

### DIFF
--- a/apps/demo/src/screens/dashboard.ts
+++ b/apps/demo/src/screens/dashboard.ts
@@ -119,8 +119,10 @@ function systemPanel(ui: Container, state: DemoState, theme: Theme): void {
           q.keyValues([
             { label: "Uptime", value: duration(s.system.uptime), color: theme.accent },
             { label: "Procs", value: String(s.system.processCount || s.processes.length), color: theme.accent },
-            { label: "Threads", value: String(s.system.threadCount), color: theme.accent },
-            { label: "Ctx/s", value: `${(s.system.contextSwitches / 1000).toFixed(1)}K`, color: theme.accent },
+            { label: "Threads", value: s.system.threadCount ? String(s.system.threadCount) : "—", color: theme.accent },
+            // contextSwitches is cumulative since boot; the per-second rate is
+            // what the label claims, and what the Services screen already uses.
+            { label: "Ctx/s", value: `${(s.telemetry.kernel.contextSwitchRate / 1000).toFixed(1)}K`, color: theme.accent },
           ]);
         });
         r.panel({ title: "Memory" }, (q) => {

--- a/apps/demo/src/system/common.ts
+++ b/apps/demo/src/system/common.ts
@@ -16,6 +16,22 @@ export async function sh(command: string, args: string[], timeout = 4000): Promi
   }
 }
 
+/**
+ * A process name from its command line.
+ *
+ * `ps -o comm` is not usable for this: Linux truncates it to 15 bytes and it
+ * may contain spaces (Firefox ships "Web Content", "Isolated Web Co"), which
+ * shifts every whitespace-split column after it; macOS emits the full path
+ * truncated to 16 characters, so the tail is a fragment rather than a name.
+ * argv[0] has neither problem.
+ */
+export function processName(args: string): string {
+  const argv0 = args.trim().split(/\s+/)[0] ?? "";
+  // Kernel threads are already bracketed names, not paths.
+  if (argv0.startsWith("[")) return argv0;
+  return argv0.split("/").pop() || argv0 || "-";
+}
+
 export function push(history: number[], value: number, limit = 240): void {
   history.push(value);
   if (history.length > limit) history.shift();

--- a/apps/demo/src/system/darwin.ts
+++ b/apps/demo/src/system/darwin.ts
@@ -1,6 +1,8 @@
 import os from "node:os";
 import type { Collector, SystemSample } from "./types.ts";
-import { baseSample, loadAverage, primaryInterface, push, ratePerSecond, sh } from "./common.ts";
+import {
+  baseSample, loadAverage, primaryInterface, processName, push, ratePerSecond, sh,
+} from "./common.ts";
 
 /**
  * macOS has no /proc, so everything comes from small command-line tools that
@@ -8,7 +10,7 @@ import { baseSample, loadAverage, primaryInterface, push, ratePerSecond, sh } fr
  */
 export class DarwinCollector implements Collector {
   source = "macOS sysctl";
-  unavailable = ["temperatures", "fan speed"];
+  unavailable = ["temperatures", "fan speed", "per-core CPU", "thread count"];
   private sample = baseSample();
   private prevCpu: { idle: number; total: number } | null = null;
   private prevNet: [number, number] | null = null;
@@ -28,12 +30,12 @@ export class DarwinCollector implements Collector {
     }
     const load = loadAverage();
     s.cpu.load = load;
+    // `top` reports one aggregate figure. Per-core detail would need
+    // host_processor_info, so every core shows the measured total rather than
+    // a synthesised spread around it — the README promises that anything a
+    // platform cannot provide is reported as unavailable, not fabricated.
     const cores = Math.max(1, os.cpus().length);
-    s.cpu.cores = Array.from({ length: cores }, (_, i) => {
-      // Spread total load across cores with a stable per-core offset.
-      const jitter = ((i * 37) % 17) / 100;
-      return Math.max(0, Math.min(1, s.cpu.total + jitter - 0.08));
-    });
+    s.cpu.cores = new Array(cores).fill(s.cpu.total);
     push(s.cpu.history, s.cpu.total * 100);
 
     // Memory via vm_stat page counts.
@@ -133,25 +135,32 @@ export class DarwinCollector implements Collector {
   }
 
   private async updateProcesses(): Promise<void> {
-    const text = await sh("ps", ["-Ao", "pid,comm,pcpu,pmem,rss,user,state,args", "-r"]);
-    if (!text) return;
-    const lines = text.trim().split("\n").slice(1, 60);
-    this.sample.processes = lines.map((line) => {
+    // `comm` is omitted: macOS truncates it to 16 characters, so taking the
+    // last path segment yields a fragment — "/System/Applicat" became
+    // "Applicat", and a 16-character path ending in "/" became "".
+    const text = await sh("ps", ["-Ao", "pid,pcpu,pmem,rss,user,state,args", "-r"]);
+    if (!text) {
+      if (!this.unavailable.includes("processes")) this.unavailable.push("processes");
+      return;
+    }
+    const rows = text.trim().split("\n").slice(1);
+    this.sample.processes = rows.slice(0, 59).map((line) => {
       const parts = line.trim().split(/\s+/);
-      const name = (parts[1] ?? "-").split("/").pop() ?? "-";
+      const command = parts.slice(6).join(" ");
       return {
         pid: Number(parts[0]),
-        name,
-        cpu: Number(parts[2]) || 0,
-        mem: Number(parts[3]) || 0,
-        rss: (Number(parts[4]) || 0) * 1024,
+        name: processName(command),
+        cpu: Number(parts[1]) || 0,
+        mem: Number(parts[2]) || 0,
+        rss: (Number(parts[3]) || 0) * 1024,
         threads: 1,
-        user: parts[5] ?? "-",
-        state: parts[6] ?? "-",
-        command: parts.slice(7).join(" "),
+        user: parts[4] ?? "-",
+        state: parts[5] ?? "-",
+        command,
       };
     });
-    this.sample.system.processCount = this.sample.processes.length;
+    // Every row, not the truncated table.
+    this.sample.system.processCount = rows.length;
   }
 
   current(): SystemSample {

--- a/apps/demo/src/system/linux.ts
+++ b/apps/demo/src/system/linux.ts
@@ -1,7 +1,9 @@
 import { readFile, readdir } from "node:fs/promises";
 import os from "node:os";
 import type { Collector, SystemSample } from "./types.ts";
-import { baseSample, loadAverage, primaryInterface, push, ratePerSecond, sh } from "./common.ts";
+import {
+  baseSample, loadAverage, primaryInterface, processName, push, ratePerSecond, sh,
+} from "./common.ts";
 import type { Interface } from "./telemetry.ts";
 import * as telemetry from "./linux-telemetry.ts";
 import * as traffic from "./linux-traffic.ts";
@@ -92,7 +94,7 @@ export class LinuxCollector implements Collector {
     const ctxt = /^ctxt (\d+)/m.exec(stat);
     if (ctxt) s.system.contextSwitches = Number(ctxt[1]);
     const procs = /^procs_running (\d+)/m.exec(stat);
-    if (procs) s.system.threadCount = Number(procs[1]);
+    // `procs_running` is runnable processes; the thread total comes from ps.
 
     // Memory.
     const mem = parseMeminfo(meminfo);
@@ -294,27 +296,37 @@ export class LinuxCollector implements Collector {
   }
 
   private async updateProcesses(): Promise<void> {
-    const text = await sh("ps", ["-eo", "pid,comm,pcpu,pmem,rss,nlwp,user,state,args", "--sort=-pcpu"]);
+    // `comm` is deliberately absent: it can contain spaces, which shifts every
+    // column parsed after it. Every field here is space-free, so `args` — which
+    // may contain anything — is the only free-form one and it comes last.
+    const text = await sh("ps", ["-eo", "pid,pcpu,pmem,rss,nlwp,user,state,args", "--sort=-pcpu"]);
     if (!text) {
       if (!this.unavailable.includes("processes")) this.unavailable.push("processes");
       return;
     }
-    const lines = text.trim().split("\n").slice(1, 60);
-    this.sample.processes = lines.map((line) => {
+    const rows = text.trim().split("\n").slice(1);
+    this.sample.processes = rows.slice(0, 59).map((line) => {
       const parts = line.trim().split(/\s+/);
+      const command = parts.slice(7).join(" ");
       return {
         pid: Number(parts[0]),
-        name: parts[1] ?? "-",
-        cpu: Number(parts[2]) || 0,
-        mem: Number(parts[3]) || 0,
-        rss: (Number(parts[4]) || 0) * 1024,
-        threads: Number(parts[5]) || 1,
-        user: parts[6] ?? "-",
-        state: parts[7] ?? "-",
-        command: parts.slice(8).join(" "),
+        name: processName(command),
+        cpu: Number(parts[1]) || 0,
+        mem: Number(parts[2]) || 0,
+        rss: (Number(parts[3]) || 0) * 1024,
+        threads: Number(parts[4]) || 1,
+        user: parts[5] ?? "-",
+        state: parts[6] ?? "-",
+        command,
       };
     });
-    this.sample.system.processCount = this.sample.processes.length;
+    // Count every row, not the truncated table: this used to overwrite the real
+    // total from /proc with at most 59, so the figure alternated every tick.
+    this.sample.system.processCount = rows.length;
+    this.sample.system.threadCount = rows.reduce(
+      (total, line) => total + (Number(line.trim().split(/\s+/)[4]) || 0),
+      0,
+    );
   }
 
   private async updateTemperatures(): Promise<void> {


### PR DESCRIPTION
Five figures on the dashboard that are wrong on every run. All verified live on macOS; the Linux paths verified with fixtures against a shimmed `ps`.

## Process names were fragments, and one bad name shifted every column

Both collectors ask `ps` for `comm` and parse by splitting on whitespace at fixed indices. `comm` suits neither job.

**macOS** emits the full path truncated to 16 characters, so `split("/").pop()` returns a fragment. Live on this machine, before:

```
{"pid":442,"name":"Applicat"}      <- /System/Applicat…
{"pid":63133,"name":"Br"}
{"pid":66046,"name":"Sp"}
{"pid":170,"name":""}              <- truncated path ended in "/"
```

**Linux** `comm` is 15 bytes of arbitrary text that may contain **spaces** — Firefox ships `Web Content`, `Isolated Web Co`, `RDD Process`, `Utility Process`. One such row shifts every field after it:

```
{"pid":1234,"name":"Web","cpu":0,"mem":12.5,"rss":3174.4,
 "threads":51200,"user":"9","state":"alice", ...}

rendered CPU% column: [ '0.0', '0.5' ]     <- 12.5% became 0.0
rendered RSS column : [ '3 KiB', '8 MiB' ] <- 50 MiB became 3 KiB
```

CPU, RSS, threads, user and state are all one column out. Both collectors now omit `comm` and take the name from argv[0], so every parsed field is space-free and `args` — the only free-form one — comes last. Kernel threads (`[kworker/0:1]`) are passed through unchanged.

After, live:

```
 63294 opencode      79.1%
   442 Terminal      42.3%
 66046 Spotify       18.9%
 98545 Brave            3%
   170 WindowServer   2.8%
```

## The process count alternated between the real total and at most 59

`updateTelemetry` set the true count from `/proc`, then `updateProcesses` overwrote it with the length of the table — capped at 59 by `slice(1, 60)`. The two run on different tick cadences, so the figure flipped every second:

```
tick 1: Processes = 400
tick 2: Processes = 2
tick 3: Processes = 400
```

macOS had the cap with no real total at all — 59 against an actual 465. Both now count every row of the `ps` output rather than the truncated table:

```
processCount reported : 463
actual `ps -A | wc -l`: 466      (includes the header; the rest is churn between the two calls)
```

## `Ctx/s` was a since-boot counter

`dashboard.ts` rendered `system.contextSwitches` — `/proc/stat`'s cumulative `ctxt` — under a per-second label:

```
Ctx/s = 4812339.6K
```

The rate is already computed as `telemetry.kernel.contextSwitchRate`, and `services.ts:56` uses it correctly. The dashboard now does too.

## `Threads` was runnable processes, and zero everywhere else

Linux assigned `/proc/stat`'s `procs_running` — runnable **processes** — to `threadCount`, so a 400-process/2000-thread box showed `2`. It's now the sum of `nlwp` across the `ps` output, which we already fetch.

macOS and Windows never set it at all, so the dashboard showed a confident `Threads: 0`. It now shows an em dash, and the collector declares it unavailable.

## macOS per-core CPU was synthesised

`top -l 1` reports one aggregate figure. The collector spread it across cores with a fixed ladder:

```js
const jitter = ((i * 37) % 17) / 100;
return Math.max(0, Math.min(1, s.cpu.total + jitter - 0.08));
```

Observed cores `[13, 16, 19, 22]` for a 20.8% total. The README promises that anything a platform cannot provide is "reported as unavailable rather than fabricated", and `darwin.ts` listed only temperatures and fan speed.

Every core now shows the measured total, and the collector declares per-core CPU unavailable so the F1 overlay says so:

```
distinct per-core values: 1     (was: one per core, a fixed +3 ladder)
unavailable: temperatures, fan speed, per-core CPU, thread count
```

Real per-core figures would need `host_processor_info`, which is a bigger change and a separate discussion.

`bun run typecheck && bun test` pass (99 tests); `apps/demo` builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
