### PR TITLE
Keep the site up when the database is not

### DIFF
--- a/apps/web/app/api/vote/route.ts
+++ b/apps/web/app/api/vote/route.ts
@@ -19,5 +19,8 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "unknown theme" }, { status: 400 });
   }
   const votes = await voteForTheme(theme);
+  if (votes === null) {
+    return NextResponse.json({ error: "vote not recorded" }, { status: 503 });
+  }
   return NextResponse.json({ theme, votes });
 }

--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { SiteNav } from "@/components/site/nav";
+
+/**
+ * Without this, any error thrown while rendering — most likely an unreachable
+ * database — replaces the site with Next's unstyled framework page.
+ */
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("hqtui: render failed", error);
+  }, [error]);
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <SiteNav />
+      <main className="mx-auto flex max-w-2xl flex-col items-start px-4 py-24 sm:px-6">
+        <p className="font-mono text-sm text-white/50">something went wrong</p>
+        <h1 className="mt-3 text-3xl font-bold tracking-tight">This page did not render</h1>
+        <p className="mt-4 text-white/60">
+          The library itself is unaffected — this is the website. Try again, or read the docs.
+        </p>
+        {error.digest ? (
+          <p className="mt-4 font-mono text-xs text-white/50">digest: {error.digest}</p>
+        ) : null}
+        <div className="mt-8 flex gap-3">
+          <button
+            type="button"
+            onClick={reset}
+            className="rounded-lg border border-white/15 px-4 py-2 text-sm hover:bg-white/5"
+          >
+            Try again
+          </button>
+          <Link
+            href="/docs"
+            className="rounded-lg border border-white/15 px-4 py-2 text-sm hover:bg-white/5"
+          >
+            Docs
+          </Link>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/apps/web/app/global-error.tsx
+++ b/apps/web/app/global-error.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+/**
+ * The last resort: an error in the root layout itself, where `error.tsx` cannot
+ * help because the layout that renders it is the thing that failed. This one
+ * must supply its own <html> and <body>.
+ */
+export default function GlobalError({ error }: { error: Error & { digest?: string } }) {
+  return (
+    <html lang="en" className="dark">
+      <body
+        style={{
+          margin: 0,
+          minHeight: "100vh",
+          display: "grid",
+          placeItems: "center",
+          background: "#0a0a0a",
+          color: "#e8edf2",
+          fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+        }}
+      >
+        <main style={{ padding: "2rem", textAlign: "center" }}>
+          <h1 style={{ fontSize: "1.25rem", fontWeight: 600 }}>hqtui.com is having a problem</h1>
+          <p style={{ marginTop: "0.75rem", color: "#9aa4ad" }}>
+            Please try again shortly.
+            {error.digest ? ` (digest: ${error.digest})` : ""}
+          </p>
+        </main>
+      </body>
+    </html>
+  );
+}

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link";
+import { SiteNav } from "@/components/site/nav";
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <SiteNav />
+      <main className="mx-auto flex max-w-2xl flex-col items-start px-4 py-24 sm:px-6">
+        <p className="font-mono text-sm text-white/50">404</p>
+        <h1 className="mt-3 text-3xl font-bold tracking-tight">No such page</h1>
+        <p className="mt-4 text-white/60">
+          The link may be out of date. Everything lives off the home page or the docs.
+        </p>
+        <div className="mt-8 flex gap-3">
+          <Link
+            href="/"
+            className="rounded-lg border border-white/15 px-4 py-2 text-sm hover:bg-white/5"
+          >
+            Home
+          </Link>
+          <Link
+            href="/docs"
+            className="rounded-lg border border-white/15 px-4 py-2 text-sm hover:bg-white/5"
+          >
+            Docs
+          </Link>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -153,18 +153,26 @@ export async function themeVotes(): Promise<ThemeVote[]> {
   }
 }
 
-export async function voteForTheme(theme: string): Promise<number> {
+export async function voteForTheme(theme: string): Promise<number | null> {
   if (!configured()) return 0;
-  await migrate();
-  const [, rows] = await execute([
-    {
-      sql: `INSERT INTO theme_votes (theme, votes) VALUES (?, 1)
-            ON CONFLICT(theme) DO UPDATE SET votes = votes + 1, updated_at = datetime('now')`,
-      args: [theme],
-    },
-    { sql: "SELECT votes FROM theme_votes WHERE theme = ?", args: [theme] },
-  ]);
-  return Number(rows[0]?.votes ?? 0);
+  try {
+    await migrate();
+    const [, rows] = await execute([
+      {
+        sql: `INSERT INTO theme_votes (theme, votes) VALUES (?, 1)
+              ON CONFLICT(theme) DO UPDATE SET votes = votes + 1, updated_at = datetime('now')`,
+        args: [theme],
+      },
+      { sql: "SELECT votes FROM theme_votes WHERE theme = ?", args: [theme] },
+    ]);
+    return Number(rows[0]?.votes ?? 0);
+  } catch (error) {
+    // The same rule the rest of this module follows: an unreachable database
+    // must never take the site down. Null distinguishes "not recorded" from a
+    // genuine zero, so the caller can answer honestly.
+    console.error("hqtui: voteForTheme failed", error);
+    return null;
+  }
 }
 
 export async function recordView(path: string): Promise<void> {


### PR DESCRIPTION
`lib/db.ts` states the rule itself, in a comment on `migrate`:

> An unreachable database must never take the marketing site down.

Three of its four public functions follow it. `themeVotes` (`:150`), `recordView` (`:181`) and `totalViews` (`:192`) each catch and degrade. `voteForTheme` (`:156`) has no `try`/`catch` at all.

`execute` throws on any non-2xx response (`:83-85`) and on any statement-level error (`:98`), and `app/api/vote/route.ts:21` awaits it bare. So any Turso hiccup becomes an unhandled rejection and a 500 on an endpoint whose entire job is incrementing a vanity counter.

It now degrades like its siblings and returns `null`, which the route turns into a **503** — deliberately distinguishable from a genuine zero, so the response is never a lie. `components/site/theme-gallery.tsx:44` already does `if (!response.ok) return;`, so the client needs no change.

## No error boundaries anywhere

`app/` had no `error.tsx`, no `global-error.tsx` and no `not-found.tsx`. Combined with the above, a database outage during render replaced the whole site with Next's unstyled framework error page.

All three are added, matching the site's existing dark styling and reusing `SiteNav`:

- **`error.tsx`** — recoverable render errors, with a `reset()` button and the error digest when present
- **`not-found.tsx`** — a real 404 instead of the framework default
- **`global-error.tsx`** — the last resort, for an error in the root layout itself. It supplies its own `<html>`/`<body>` and inline styles, since the layout that would normally provide them is the thing that failed

## Verification

`next build` — which, worth noting, CI never runs:

```
✓ Compiled successfully in 2.6s
  Running TypeScript ...
  Finished TypeScript in 1286ms
✓ Generating static pages (4/4)

Route (app)
┌ ƒ /
├ ○ /_not-found        <- now present
├ ƒ /api/vote
├ ƒ /docs
└ ƒ /showcase
```

## Two related things I did not change

Both need a decision rather than a fix, so I've left them:

- **`recordView` runs on every request, bots included.** All three pages pair it with `export const dynamic = "force-dynamic"`, and `execute` sets `cache: "no-store"`, so nothing collapses it. `railway.json` sets `healthcheckPath: "/"`, so every deploy probe increments the counter that `nav.tsx:91` displays.
- **Three blocking Turso round trips before the first byte of `/`** — `await recordView("/")` serially, then `Promise.all([themeVotes(), totalViews()])`. There is no `revalidate` or `unstable_cache` anywhere in `app/`, so ~400 lines of static marketing content re-render per request to bump a counter. The two reads could also batch into one `execute([...])`, which the pipeline API already supports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
