### PR TITLE
Meet WCAG AA on body text, and announce which theme is selected

### DIFF
--- a/apps/web/app/docs/page.tsx
+++ b/apps/web/app/docs/page.tsx
@@ -43,7 +43,7 @@ export default async function Docs() {
       <SiteNav />
       <div className="mx-auto flex max-w-7xl gap-10 px-4 py-12 sm:px-6">
         <aside className="sticky top-20 hidden h-fit w-52 shrink-0 lg:block">
-          <p className="mb-3 font-mono text-xs uppercase tracking-wide text-white/35">On this page</p>
+          <p className="mb-3 font-mono text-xs uppercase tracking-wide text-white/50">On this page</p>
           <nav className="space-y-1.5 text-sm">
             {SECTIONS.map((section) => (
               <a
@@ -314,7 +314,7 @@ widgets.dashboard            0.425ms      6 panels`}
           </P>
 
           <Separator className="my-10 bg-white/10" />
-          <p className="text-sm text-white/45">
+          <p className="text-sm text-white/50">
             Full API reference in the{" "}
             <a className="text-white/80 underline" href="https://github.com/profullstack/hqtui">
               repository

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -179,7 +179,7 @@ export default async function Home() {
               alt="HQTUI dashboard: CPU, memory, network and processes"
               priority
             />
-            <p className="mt-3 text-center font-mono text-xs text-white/30">
+            <p className="mt-3 text-center font-mono text-xs text-white/50">
               A screenshot of <code className="font-mono">hqtui-demo</code> on a laptop, reading
               its own sensors. Not a mockup.
             </p>
@@ -194,7 +194,7 @@ export default async function Home() {
             ].map(([value, label]) => (
               <div key={label} className="rounded-xl border border-white/10 bg-white/[0.02] px-4 py-5">
                 <div className="font-mono text-2xl font-bold text-[#5fff87]">{value}</div>
-                <div className="mt-1 text-xs text-white/45">{label}</div>
+                <div className="mt-1 text-xs text-white/50">{label}</div>
               </div>
             ))}
           </div>
@@ -342,14 +342,14 @@ export default async function Home() {
               <code className="font-mono text-white/80">CPU 73%</code> writes a single character.
             </p>
             <Separator className="my-6 bg-white/10" />
-            <p className="font-mono text-xs text-white/35">
+            <p className="font-mono text-xs text-white/50">
               160x50 (8,000 cells) · bun 1.4 · linux x64 · reproduce with{" "}
               <span className="text-white/60">bun run bench</span>
             </p>
           </div>
           <div className="overflow-hidden rounded-xl border border-white/10">
             <table className="w-full text-sm">
-              <thead className="bg-white/[0.04] text-left font-mono text-xs uppercase tracking-wide text-white/40">
+              <thead className="bg-white/[0.04] text-left font-mono text-xs uppercase tracking-wide text-white/50">
                 <tr>
                   <th className="px-4 py-3">Benchmark</th>
                   <th className="px-4 py-3 text-right">Mean</th>
@@ -361,7 +361,7 @@ export default async function Home() {
                   <tr key={row.name} className="border-t border-white/[0.06]">
                     <td className="px-4 py-3 text-white/75">{row.name}</td>
                     <td className="px-4 py-3 text-right font-mono text-[#5fff87]">{row.mean}</td>
-                    <td className="px-4 py-3 text-right font-mono text-xs text-white/40">{row.note}</td>
+                    <td className="px-4 py-3 text-right font-mono text-xs text-white/50">{row.note}</td>
                   </tr>
                 ))}
               </tbody>
@@ -385,7 +385,7 @@ export default async function Home() {
                 <InstallCommand command="bunx @profullstack/hqtui-demo" />
                 <InstallCommand command="bunx @profullstack/hqtui-demo --sim" />
               </div>
-              <p className="mt-4 text-sm text-white/40">
+              <p className="mt-4 text-sm text-white/50">
                 Ten screens: dashboard, sessions, network, traffic, services, components,
                 graphics, themes, input visualizer, stress test.
               </p>

--- a/apps/web/components/site/code.tsx
+++ b/apps/web/components/site/code.tsx
@@ -3,7 +3,7 @@ import { cn } from "@/lib/utils";
 type Rule = { pattern: RegExp; className: string };
 
 const RULES: Rule[] = [
-  { pattern: /\/\/[^\n]*/g, className: "text-white/30" },
+  { pattern: /\/\/[^\n]*/g, className: "text-white/50" },
   { pattern: /"[^"\n]*"|'[^'\n]*'|`[^`\n]*`/g, className: "text-[#f1fa8c]" },
   {
     pattern: /\b(?:import|from|const|let|await|async|return|function|export|new|if|else|for|of|type|interface)\b/g,
@@ -65,7 +65,7 @@ export function Code({
   return (
     <div className={cn("overflow-hidden rounded-xl border border-white/10 bg-[#0a0e14]", className)}>
       {filename ? (
-        <div className="border-b border-white/10 px-4 py-2 font-mono text-[11px] text-white/40">
+        <div className="border-b border-white/10 px-4 py-2 font-mono text-[11px] text-white/50">
           {filename}
         </div>
       ) : null}

--- a/apps/web/components/site/nav.tsx
+++ b/apps/web/components/site/nav.tsx
@@ -76,10 +76,10 @@ export function SiteNav() {
 export function SiteFooter({ views }: { views?: number }) {
   return (
     <footer className="border-t border-white/10 py-10">
-      <div className="mx-auto flex max-w-7xl flex-col gap-4 px-4 text-sm text-white/40 sm:flex-row sm:items-center sm:px-6">
+      <div className="mx-auto flex max-w-7xl flex-col gap-4 px-4 text-sm text-white/50 sm:flex-row sm:items-center sm:px-6">
         <div className="flex items-center gap-2 font-mono">
           <Image src="/icons/icon-512x512.png" alt="HQTUI" width={512} height={512} className="h-4 w-4 opacity-70" />
-          <span className="text-white/20">·</span>
+          <span className="text-white/50">·</span>
           <span>MIT</span>
         </div>
         <div className="flex flex-wrap gap-4 sm:ml-auto">
@@ -88,7 +88,7 @@ export function SiteFooter({ views }: { views?: number }) {
           <Link className="hover:text-white" href="/docs">Docs</Link>
           <a className="hover:text-white" href="https://github.com/profullstack/hqtui/blob/main/docs/PRD.md">PRD</a>
         </div>
-        {views ? <span className="font-mono text-xs text-white/25">{views.toLocaleString()} views</span> : null}
+        {views ? <span className="font-mono text-xs text-white/50">{views.toLocaleString()} views</span> : null}
       </div>
     </footer>
   );

--- a/apps/web/components/site/terminal.tsx
+++ b/apps/web/components/site/terminal.tsx
@@ -42,7 +42,7 @@ export function Terminal({ shot, title, className, bare, priority, alt }: Termin
           <span className="terminal-frame__dot bg-[#ff5f57]" />
           <span className="terminal-frame__dot bg-[#febc2e]" />
           <span className="terminal-frame__dot bg-[#28c840]" />
-          <span className="ml-2 font-mono text-[11px] text-white/40">{title ?? "hqtui"}</span>
+          <span className="ml-2 font-mono text-[11px] text-white/50">{title ?? "hqtui"}</span>
         </div>
       )}
       <Image

--- a/apps/web/components/site/theme-gallery.tsx
+++ b/apps/web/components/site/theme-gallery.tsx
@@ -54,10 +54,21 @@ export function ThemeGallery({ themes }: { themes: ThemeCard[] }) {
 
   return (
     <div className="grid gap-6 lg:grid-cols-[220px_1fr]">
-      <div className="flex flex-row gap-2 overflow-x-auto lg:flex-col lg:overflow-visible">
+      <div
+        role="tablist"
+        aria-label="Theme"
+        className="flex flex-row gap-2 overflow-x-auto lg:flex-col lg:overflow-visible"
+      >
         {themes.map((theme) => (
           <button
             key={theme.name}
+            type="button"
+            role="tab"
+            // Which theme is selected was conveyed by border and background
+            // colour alone, so it was invisible to a screen reader and to
+            // anyone in a high-contrast or forced-colours mode.
+            aria-selected={theme.name === active}
+            aria-controls="theme-preview"
             onClick={() => setActive(theme.name)}
             className={cn(
               "flex shrink-0 items-center justify-between gap-3 rounded-lg border px-3 py-2 text-left text-sm transition-colors",
@@ -67,18 +78,21 @@ export function ThemeGallery({ themes }: { themes: ThemeCard[] }) {
             )}
           >
             <span className="font-mono">{theme.label}</span>
-            <span className="font-mono text-xs text-white/30">{votes[theme.name] ?? 0}</span>
+            <span className="font-mono text-xs text-white/50">
+              <span className="sr-only">votes: </span>
+              {votes[theme.name] ?? 0}
+            </span>
           </button>
         ))}
       </div>
 
-      <div className="space-y-3">
+      <div id="theme-preview" role="tabpanel" aria-live="polite" className="space-y-3">
         <div className="terminal-frame">
           <div className="terminal-frame__bar">
             <span className="terminal-frame__dot bg-[#ff5f57]" />
             <span className="terminal-frame__dot bg-[#febc2e]" />
             <span className="terminal-frame__dot bg-[#28c840]" />
-            <span className="ml-2 font-mono text-[11px] text-white/40">theme: {current?.label}</span>
+            <span className="ml-2 font-mono text-[11px] text-white/50">theme: {current?.label}</span>
           </div>
           <Image
             key={current?.name}
@@ -105,7 +119,7 @@ export function ThemeGallery({ themes }: { themes: ThemeCard[] }) {
         >
           {voted === active ? <Check className="h-4 w-4" /> : <ThumbsUp className="h-4 w-4" />}
           {voted === active ? "Voted" : `Vote for ${current?.label}`}
-          <span className="font-mono text-xs text-white/40">{votes[active] ?? 0}</span>
+          <span className="font-mono text-xs text-white/50">{votes[active] ?? 0}</span>
         </button>
       </div>
     </div>


### PR DESCRIPTION
Two accessibility problems on the site. Text colour only — no borders, backgrounds or layout are touched.

## Seventeen text styles fail WCAG AA

`globals.css:87` sets `--background: oklch(0.145 0 0)` and `layout.tsx:58` applies `className="dark"`, so the real background is `#0a0a0a`. Contrast measured against it:

| class | ratio | AA (4.5:1) | used for |
|---|---|---|---|
| `text-white/20` | 1.77:1 | fail | the footer separator |
| `text-white/25` | 2.13:1 | fail | the view counter |
| `text-white/30` | 2.61:1 | fail | code comments, vote counts |
| `text-white/35` | 3.15:1 | fail | section labels |
| `text-white/40` | 3.77:1 | fail | table headers, captions, panel titles |
| `text-white/45` | 4.48:1 | fail | stat labels, the docs footer |
| `text-white/50` | 5.37:1 | **pass** | |

Every one is small text — `text-xs`, `text-sm`, `text-[11px]` — so the 3:1 large-text exemption doesn't apply.

All seventeen move to `text-white/50`. **They collapse to a single value because there is no compliant value below it**: on this background, white below 50% alpha cannot reach 4.5:1 at these sizes. Keeping the dim tiers would mean raising font sizes instead, which is a larger design decision and yours to make — happy to redo it that way if you'd prefer the hierarchy back.

`border-white/10`, `border-white/25` and `bg-white/[0.04]` are deliberately left alone: non-text contrast has a 3:1 threshold and different rules.

## The theme picker's selection was colour-only

`theme-gallery.tsx:59-71` distinguished the active theme by border and background colour alone — no `aria-pressed`, no `aria-current`, no tab semantics. A screen reader user, or anyone in a forced-colours / high-contrast mode, could not tell which of the six was selected.

It's now a proper `tablist` / `tab` / `tabpanel`:

- `role="tablist"` with `aria-label="Theme"` on the container
- `role="tab"` + `aria-selected` on each button, plus `type="button"`
- `aria-controls` pointing at the preview, which gets `role="tabpanel"` and `aria-live="polite"` so switching themes is announced
- the bare vote count gets a `sr-only` "votes:" label, since a lone number reads as meaningless

Keyboard operability was already fine — they are real `<button>`s and there's no focus trap anywhere on the site.

Verified with `next build`: compiles and typechecks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
