### PR TITLE
Typecheck every workspace, build the site in CI, sign the releases

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+## What this changes
+
+<!-- One or two sentences. If it fixes an issue, link it. -->
+
+## Why
+
+<!-- What was wrong, and how you know. A reproduction beats a description. -->
+
+## Checklist
+
+CONTRIBUTING has the full list; these are the ones that come up most.
+
+- [ ] `bun run typecheck && bun test` pass
+- [ ] Tests added or updated, using the headless renderer — no real terminal needed
+- [ ] `packages/hqtui` still has zero runtime dependencies
+- [ ] No network access, telemetry or subprocesses in the library
+- [ ] Nothing allocates per cell in a hot path
+- [ ] Every widget touched still survives a 1x1 terminal without throwing or
+      drawing outside its rect
+- [ ] The terminal is still restored on Ctrl+C, SIGTERM, an uncaught exception
+      and normal exit
+
+## Benchmarks
+
+<!-- Required for render-path changes. Paste `bun run bench` before and after. -->
+
+```
+```

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  # Nothing currently watches the resolved dependency tree or the action
+  # versions pinned in the workflows.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: ci
+
+  - package-ecosystem: npm
+    directories:
+      - /
+      - /packages/hqtui
+      - /apps/web
+      - /apps/demo
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: deps
+    groups:
+      types:
+        patterns: ["@types/*"]
+      next:
+        patterns: ["next", "react", "react-dom", "@types/react", "@types/react-dom"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,14 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
+# A new push supersedes the run in flight for the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     name: test (${{ matrix.os }})
@@ -41,6 +49,25 @@ jobs:
       - run: bun install --frozen-lockfile
       - name: Test under Node
         run: node --test packages/hqtui/test/*.test.ts apps/demo/test/*.test.ts
+
+  # apps/web is the deployed artifact and the largest TypeScript surface in the
+  # repo, but nothing built or typechecked it — a broken site reached Railway
+  # before it reached CI. `next build` does both.
+  site:
+    name: build site
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install --frozen-lockfile
+      - name: Build the library the site imports
+        run: bun run build
+      - name: Build site
+        run: bun run --cwd apps/web build
+        env:
+          NEXT_TELEMETRY_DISABLED: "1"
 
   benchmark:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,13 +24,22 @@ jobs:
           registry-url: https://registry.npmjs.org
       - run: bun install --frozen-lockfile
       - run: bun run typecheck && bun test packages/hqtui/test && bun run build
+      # `id-token: write` above is what provenance needs, but without the flag
+      # nothing is attested — the permission was granted and unused.
+      #
+      # The dist-tag goes through the environment rather than being
+      # interpolated into the shell: `${{ inputs.tag }}` is attacker-controlled
+      # text on a workflow_dispatch, and expressions are substituted before the
+      # shell ever sees them.
       - name: Publish library
-        run: npm publish --access public --tag ${{ inputs.tag || 'latest' }}
+        run: npm publish --access public --provenance --tag "$DIST_TAG"
         working-directory: packages/hqtui
         env:
+          DIST_TAG: ${{ inputs.tag || 'latest' }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish demo
-        run: npm publish --access public --tag ${{ inputs.tag || 'latest' }}
+        run: npm publish --access public --provenance --tag "$DIST_TAG"
         working-directory: apps/demo
         env:
+          DIST_TAG: ${{ inputs.tag || 'latest' }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/apps/demo/tsconfig.check.json
+++ b/apps/demo/tsconfig.check.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -56,6 +56,13 @@
         "typescript": "^5",
       },
     },
+    "examples": {
+      "name": "@profullstack/hqtui-examples",
+      "version": "0.1.0",
+      "dependencies": {
+        "@profullstack/hqtui": "^0.1.9",
+      },
+    },
     "packages/hqtui": {
       "name": "@profullstack/hqtui",
       "version": "0.1.9",
@@ -243,6 +250,8 @@
     "@profullstack/hqtui-benchmark": ["@profullstack/hqtui-benchmark@workspace:apps/benchmark"],
 
     "@profullstack/hqtui-demo": ["@profullstack/hqtui-demo@workspace:apps/demo"],
+
+    "@profullstack/hqtui-examples": ["@profullstack/hqtui-examples@workspace:examples"],
 
     "@profullstack/hqtui-web": ["@profullstack/hqtui-web@workspace:apps/web"],
 

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["*.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "workspaces": [
     "packages/*",
     "apps/*",
-    "examples/*"
+    "examples"
   ],
   "engines": {
     "bun": ">=1.1",
@@ -18,7 +18,10 @@
     "bench": "bun apps/benchmark/src/main.ts",
     "test": "bun test packages/hqtui/test apps/demo/test",
     "test:node": "node --test packages/hqtui/test/*.test.ts apps/demo/test/*.test.ts",
-    "typecheck": "cd packages/hqtui && bun run typecheck"
+    "typecheck": "bun run typecheck:lib && bun run typecheck:demo && bun run typecheck:examples",
+    "typecheck:lib": "cd packages/hqtui && bun run typecheck",
+    "typecheck:demo": "cd apps/demo && bun x tsc -p tsconfig.check.json",
+    "typecheck:examples": "cd examples && bun x tsc -p tsconfig.json"
   },
   "devDependencies": {
     "@types/node": "^22",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
 packages:
   - packages/*
   - apps/*
-  - examples/*
+  - examples


### PR DESCRIPTION
Four CI and packaging gaps, plus a workspace glob that never matched anything.

## `examples/` was never a workspace member

`package.json:8` and `pnpm-workspace.yaml:4` both list `examples/*`. The manifest lives at `examples/package.json`, so that glob matches `examples/<dir>/package.json` — which doesn't exist. The lockfile confirms it:

```
workspace keys: ['', 'apps/benchmark', 'apps/demo', 'apps/web', 'packages/hqtui']
```

So the `"@profullstack/hqtui": "^0.1.9"` dependency declared at `examples/package.json:7` was never installed, and every example failed to resolve its own import:

```
dashboard.ts(2,27): error TS2307: Cannot find module '@profullstack/hqtui'
```

Glob corrected to `examples`. After `bun install`, `examples/node_modules/@profullstack/hqtui` exists and all seven examples typecheck clean.

## `typecheck` covered about a third of the code

```json
"typecheck": "cd packages/hqtui && bun run typecheck"
```

That's exactly what `ci.yml:23` runs — so `apps/demo`, `examples/` and `apps/web` were never typechecked by anything.

It now runs over the library, the demo (`src` **and** `test`, via a check-only config that leaves the build's `rootDir` intact), and the examples.

`apps/web` is typechecked by `next build`, which **CI now runs as its own job**. It's the deployed artifact and the largest TypeScript surface in the repo, and a broken site previously reached Railway before it reached CI.

## Releases asked for provenance and didn't produce it

`publish.yml:15-17` grants `id-token: write` — the permission provenance needs — but neither `npm publish` passed `--provenance`, so nothing was ever attested. The permission was granted and unused.

The dist-tag also went straight into the shell:

```yaml
run: npm publish --access public --tag ${{ inputs.tag || 'latest' }}
```

Expressions are substituted before the shell sees them, and `inputs.tag` is free text on a `workflow_dispatch`, so this is the standard Actions script-injection shape. It now travels via `env:` and is quoted.

## Also

- **A concurrency group** on CI, so a new push supersedes the run in flight instead of stacking another full three-OS matrix behind it.
- **`permissions: contents: read`** declared explicitly on CI.
- **Dependabot** for the npm trees and the action versions — nothing watched either, and `actions/checkout@v4` is already a major behind.
- **A PR template** carrying the CONTRIBUTING rules that are easiest to miss, including the before/after `bun run bench` output required for render-path changes.

## Verified locally

```
bun install --frozen-lockfile   ->  ok (lockfile gains the examples workspace)
bun run typecheck               ->  library + demo + examples, clean
bun test                        ->  99 pass, 0 fail
bun run build                   ->  ok
bun run --cwd apps/web build    ->  ✓ Compiled successfully
```

## Deliberately not included

- **A linter.** There is none in the repo at any path, and choosing between ESLint, Biome and oxlint is a decision rather than a fix. Say which you'd like and I'll follow up — it'll also want a formatter, since `components/ui/*.tsx` are semicolon-less while `app/` and `lib/` use semicolons.
- **`apps/benchmark`** is still unchecked; it uses the `Bun` global, so it needs `bun-types` as a devDependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
