### PR TITLE
Fix regressions introduced by the last two fixes

### DIFF
--- a/packages/hqtui/src/capabilities.ts
+++ b/packages/hqtui/src/capabilities.ts
@@ -54,10 +54,13 @@ function detectColors(env: NodeJS.ProcessEnv, tty: boolean): ColorDepth {
   if (env.FORCE_COLOR === "1") return "ansi16";
   if (env.FORCE_COLOR === "2") return "ansi256";
   if (env.FORCE_COLOR === "3") return "truecolor";
-  // Node and npm commonly export FORCE_COLOR=true, and anything set but not a
-  // level still means "yes". Only "0" means no.
-  if (env.FORCE_COLOR !== undefined && env.FORCE_COLOR !== "") return "ansi16";
-  if (!tty) return "none";
+  // `FORCE_COLOR=false` means off, as it does for supports-color and chalk.
+  if (env.FORCE_COLOR === "false") return "none";
+  // Any other non-empty value — `FORCE_COLOR=true` is the common one — asserts
+  // that color works. It is a floor, not a ceiling: returning a level here
+  // would cap a truecolor terminal at 16 colors. It only waives the tty check.
+  const forced = env.FORCE_COLOR !== undefined && env.FORCE_COLOR !== "";
+  if (!tty && !forced) return "none";
   const term = env.TERM ?? "";
   if (term === "dumb") return "none";
   const colorterm = (env.COLORTERM ?? "").toLowerCase();
@@ -72,10 +75,11 @@ function detectColors(env: NodeJS.ProcessEnv, tty: boolean): ColorDepth {
 }
 
 function detectUnicode(env: NodeJS.ProcessEnv): boolean {
-  // Degrading colors but not glyphs leaves a dumb terminal being told it can
-  // draw Braille, which is the one thing it certainly cannot.
+  // A dumb terminal has no glyph repertoire to speak of. The Linux console is
+  // not in that category — its default font draws box and block elements
+  // perfectly well — so only Braille is withheld from it, below.
   const term = env.TERM ?? "";
-  if (term === "dumb" || term === "linux") return false;
+  if (term === "dumb") return false;
   const locale = env.LC_ALL || env.LC_CTYPE || env.LANG || "";
   if (/UTF-?8/i.test(locale)) return true;
   // Windows Terminal and modern emulators are UTF-8 regardless of locale vars.
@@ -105,7 +109,10 @@ export function detectCapabilities(
     colors,
     trueColor: colors === "truecolor",
     unicode,
-    braille: overrides.braille ?? (unicode && program !== "apple-terminal"),
+    // The Linux console draws box and block elements but has no Braille in its
+    // default font, which is the one glyph class it genuinely lacks.
+    braille: overrides.braille ??
+      (unicode && program !== "apple-terminal" && term !== "linux"),
     mouse: overrides.mouse ?? (tty && term !== "dumb" && term !== "linux"),
     synchronizedOutput: overrides.synchronizedOutput ?? (tty && syncCapable),
     bracketedPaste: tty && term !== "dumb",

--- a/packages/hqtui/src/graphics/braille.ts
+++ b/packages/hqtui/src/graphics/braille.ts
@@ -61,16 +61,95 @@ export class BrailleCanvas {
     return (this.dots[cell] & DOT_BITS[py & 3][px & 1]) !== 0;
   }
 
+  /**
+   * Coordinates are clamped to this before anything iterates over them. It is
+   * far larger than any canvas and far below 2^53, where `x += 1` stops
+   * advancing and a Bresenham walk can never reach its endpoint.
+   */
+  private static readonly LIMIT = 1e7;
+
+  /**
+   * Above this many Bresenham steps the walk is clipped to the canvas first.
+   * Clipping shifts which pixels a partly-offscreen line lands on, so it is
+   * reserved for walks long enough that their exact pattern cannot matter.
+   */
+  private static readonly MAX_WALK = 100_000;
+
+  /** Finite, bounded, and direction-preserving. NaN has no direction. */
+  private static finite(v: number): number | null {
+    if (Number.isNaN(v)) return null;
+    const L = BrailleCanvas.LIMIT;
+    return v > L ? L : v < -L ? -L : v;
+  }
+
+  /**
+   * The inclusive row/column span an axis-aligned loop should cover, clipped to
+   * the canvas. Nothing outside it can draw, so clipping here is what makes
+   * every loop below finite for any input — infinite, enormous, or NaN.
+   */
+  private span(a: number, b: number, limit: number): [number, number] {
+    const lo = Math.min(a, b);
+    const hi = Math.max(a, b);
+    if (!(lo <= hi)) return [0, -1];
+    return [Math.max(0, Math.ceil(lo)), Math.min(limit - 1, Math.floor(hi))];
+  }
+
+  /**
+   * Liang-Barsky. Clipping before the walk — rather than clamping the endpoints,
+   * which would change the slope — keeps the line where it belongs and bounds
+   * the number of steps to the canvas.
+   */
+  private clip(
+    x0: number, y0: number, x1: number, y1: number,
+  ): [number, number, number, number] | null {
+    const fx0 = BrailleCanvas.finite(x0), fy0 = BrailleCanvas.finite(y0);
+    const fx1 = BrailleCanvas.finite(x1), fy1 = BrailleCanvas.finite(y1);
+    if (fx0 === null || fy0 === null || fx1 === null || fy1 === null) return null;
+    const dx = fx1 - fx0;
+    const dy = fy1 - fy0;
+    let t0 = 0;
+    let t1 = 1;
+    const edges: [number, number][] = [
+      [-dx, fx0 - 0], [dx, this.width - 1 - fx0],
+      [-dy, fy0 - 0], [dy, this.height - 1 - fy0],
+    ];
+    for (const [p, q] of edges) {
+      if (p === 0) {
+        if (q < 0) return null;
+        continue;
+      }
+      const r = q / p;
+      if (p < 0) {
+        if (r > t1) return null;
+        if (r > t0) t0 = r;
+      } else {
+        if (r < t0) return null;
+        if (r < t1) t1 = r;
+      }
+    }
+    return [fx0 + t0 * dx, fy0 + t0 * dy, fx0 + t1 * dx, fy0 + t1 * dy];
+  }
+
   /** Bresenham. Used for every line graph in the library. */
   line(x0: number, y0: number, x1: number, y1: number): void {
-    let x = Math.round(x0);
-    let y = Math.round(y0);
-    const ex = Math.round(x1);
-    const ey = Math.round(y1);
-    // The loop below only ends at `x === ex && y === ey`. A non-finite endpoint
-    // makes every comparison false, so it would never end at all — the render
-    // loop would hang and the terminal would never be restored.
-    if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(ex) || !Number.isFinite(ey)) return;
+    // The walk below only ends at `x === ex && y === ey`. Testing the endpoints
+    // for finiteness is not enough to guarantee it gets there: `dx` is derived
+    // from them and overflows to Infinity, and past 2^53 `x += 1` does not
+    // advance at all. Clipping to the canvas bounds the walk for every input.
+    let ax = BrailleCanvas.finite(x0);
+    let ay = BrailleCanvas.finite(y0);
+    let bx = BrailleCanvas.finite(x1);
+    let by = BrailleCanvas.finite(y1);
+    if (ax === null || ay === null || bx === null || by === null) return;
+    if (Math.max(Math.abs(bx - ax), Math.abs(by - ay)) > BrailleCanvas.MAX_WALK) {
+      const clipped = this.clip(ax, ay, bx, by);
+      if (clipped === null) return;
+      [ax, ay, bx, by] = clipped;
+    }
+    let x = Math.round(ax);
+    let y = Math.round(ay);
+    const ex = Math.round(bx);
+    const ey = Math.round(by);
     const dx = Math.abs(ex - x);
     const dy = -Math.abs(ey - y);
     const sx = x < ex ? 1 : -1;
@@ -98,14 +177,12 @@ export class BrailleCanvas {
   }
 
   vline(x: number, y0: number, y1: number): void {
-    const a = Math.min(y0, y1);
-    const b = Math.max(y0, y1);
+    const [a, b] = this.span(y0, y1, this.height);
     for (let y = a; y <= b; y++) this.pixel(x, y);
   }
 
   hline(y: number, x0: number, x1: number): void {
-    const a = Math.min(x0, x1);
-    const b = Math.max(x0, x1);
+    const [a, b] = this.span(x0, x1, this.width);
     for (let x = a; x <= b; x++) this.pixel(x, y);
   }
 
@@ -117,9 +194,8 @@ export class BrailleCanvas {
   }
 
   fillRect(x0: number, y0: number, x1: number, y1: number): void {
-    for (let y = Math.min(y0, y1); y <= Math.max(y0, y1); y++) {
-      this.hline(y, x0, x1);
-    }
+    const [a, b] = this.span(y0, y1, this.height);
+    for (let y = a; y <= b; y++) this.hline(y, x0, x1);
   }
 
   /** Fill the area under a series — the shaded region of an area graph. */
@@ -127,7 +203,8 @@ export class BrailleCanvas {
     for (let i = 1; i < points.length; i++) {
       const [x0, y0] = points[i - 1];
       const [x1, y1] = points[i];
-      const steps = Math.max(1, Math.round(Math.abs(x1 - x0)));
+      // Bounded by the canvas: a span wider than it cannot add a new column.
+      const steps = Math.max(1, Math.min(this.width, Math.round(Math.abs(x1 - x0)) || 1));
       for (let s = 0; s <= steps; s++) {
         const t = steps === 0 ? 0 : s / steps;
         const x = x0 + (x1 - x0) * t;
@@ -138,7 +215,11 @@ export class BrailleCanvas {
   }
 
   circle(cx: number, cy: number, radius: number): void {
-    let x = Math.round(radius);
+    // A radius larger than the canvas draws the same arc as one exactly its
+    // size, and an unbounded one never finishes the `x >= y` walk.
+    const r = BrailleCanvas.finite(radius);
+    if (r === null) return;
+    let x = Math.round(Math.min(Math.abs(r), this.width + this.height));
     let y = 0;
     let err = 1 - x;
     while (x >= y) {

--- a/packages/hqtui/src/input.ts
+++ b/packages/hqtui/src/input.ts
@@ -114,12 +114,11 @@ export class InputParser {
    * so the terminal calls this on a short timeout.
    */
   flush(): InputEvent[] {
-    // Mid-paste, held-back bytes are a partial end marker that never completed,
-    // so they are paste content — not a lone Escape.
-    if (this.pasteBuffer !== null && this.pasteTail.length > 0) {
-      this.pasteBuffer += this.pasteTail;
-      this.pasteTail = "";
-    }
+    // `pasteTail` is deliberately left alone. Folding it into the paste content
+    // here destroyed a partial end marker whenever the Escape timeout fired
+    // between the two reads carrying it: the rest of the marker then arrived
+    // alone, never matched, and the paste could never end — the exact wedge
+    // this holdback exists to prevent.
     if (this.pending.length === 0) return [];
     const data = this.pending;
     this.pending = "";
@@ -330,11 +329,11 @@ const SPECIAL_KEYS_SORTED = Object.keys(SPECIAL).sort((a, b) => b.length - a.len
 export function matchKey(event: KeyEvent, binding: string): boolean {
   const b = binding.toLowerCase().trim();
   if (event.key.toLowerCase() === b) return true;
-  // `keyEvent` only spells shift into `key` for named keys, so only named keys
-  // may reject it here — otherwise a binding on "tab" would also fire on
-  // Shift+Tab and move focus backwards and forwards at once. For a printable
-  // character shift is what produced the character, so it is not a modifier.
-  const shiftMatters = event.shift && event.name.length > 1;
-  if (event.name.toLowerCase() === b && !event.ctrl && !event.alt && !shiftMatters) return true;
+  // A bare name matches whatever the shift state. Rejecting shift here was
+  // justified by Tab focus firing both ways at once, which was simply wrong —
+  // `App` reads `event.name` directly and never calls this — and it silently
+  // stopped every shifted named key (shift+up, shift+home, shift+f1, …) from
+  // matching its own name. Bind "shift+tab" to distinguish; `key` carries it.
+  if (event.name.toLowerCase() === b && !event.ctrl && !event.alt) return true;
   return false;
 }

--- a/packages/hqtui/src/surface.ts
+++ b/packages/hqtui/src/surface.ts
@@ -207,15 +207,22 @@ export class Surface {
     if (options.title) {
       const titleColor = options.titleColor ?? this.theme.title;
       const label = ` ${options.title} `;
+      // The title lives in [2, limit). Reserving the width is not enough on its
+      // own: right- and centre-aligned titles are positioned from the panel
+      // edge, so they would still be drawn over the subtitle — and a wide glyph
+      // straddling the boundary bisects it, leaving an orphaned half-character.
       // Both labels carry a space of padding, and those two spaces may share a
-      // column — but only while the title fits, since a truncated one ends in
-      // content rather than padding.
-      const strict = Math.max(0, w - 4 - subtitleWidth);
-      const room = subtitleWidth > 0 && stringWidth(label) <= strict + 1 ? strict + 1 : strict;
+      // column, so the region ends one past the subtitle when there is one.
+      const limit = subtitleWidth > 0 ? w - 1 - subtitleWidth : w - 2;
+      const room = Math.max(0, limit - 2);
       const shown = truncate(label, room);
       const tw = stringWidth(shown);
       const align = options.titleAlign ?? "left";
-      const tx = align === "left" ? 2 : align === "right" ? Math.max(2, w - 2 - tw) : Math.max(2, Math.floor((w - tw) / 2));
+      const tx = align === "left"
+        ? 2
+        : align === "right"
+          ? Math.max(2, limit - tw)
+          : Math.max(2, Math.min(limit - tw, Math.floor((w - tw) / 2)));
       this.text(tx, 0, shown, { fg: titleColor, bg, attrs: 1 /* bold */ });
     }
 

--- a/packages/hqtui/src/ui.ts
+++ b/packages/hqtui/src/ui.ts
@@ -137,16 +137,26 @@ export class Container {
   }
 
   /**
-   * Constraint for a widget whose own options use `min`/`max` as a data domain
-   * rather than a layout bound — meters, progress, gauges and plots.
+   * Constraint for a widget that uses `min` and/or `max` as a *data* domain
+   * rather than a layout bound, so the solver never reads them as one.
    *
-   * Reading those as layout constraints meant `max: 0` on an empty queue or an
+   * Reading them as layout constraints meant `max: 0` on an empty queue or an
    * unprobed disk deleted the widget outright, and pinning a graph's y-axis
-   * with `min: 30` reserved thirty rows and evicted its siblings. Use `size`,
-   * `width` or `height` to constrain these.
+   * with `min: 30` reserved thirty rows and evicted its siblings.
+   *
+   * Only the keys a widget actually declares are stripped. `gauge`, `meters`
+   * and `heatBar` declare neither, so for them these can only ever have meant
+   * the layout bound, and taking it away silently broke sizes that worked.
    */
-  private sizeOfData(o: ContainerOptions | undefined, fallback: Size, intrinsic?: number): Constraint {
-    return this.sizeOf(o ? { ...o, min: undefined, max: undefined } : o, fallback, intrinsic);
+  private sizeOfData(
+    o: ContainerOptions | undefined,
+    fallback: Size,
+    strip: "max" | "min-max",
+    intrinsic?: number,
+  ): Constraint {
+    if (!o) return this.sizeOf(o, fallback, intrinsic);
+    const shadowed = strip === "min-max" ? { ...o, min: undefined, max: undefined } : { ...o, max: undefined };
+    return this.sizeOf(shadowed, fallback, intrinsic);
   }
 
   private sizeOf(o: ContainerOptions | undefined, fallback: Size, intrinsic?: number): Constraint {
@@ -330,23 +340,23 @@ export class Container {
 
   /** `label ████████░░░ 42%` */
   meter(options: W.MeterOptions & ContainerOptions): this {
-    return this.add((s) => W.drawMeter(s, options), this.sizeOfData(options, "auto", 1));
+    return this.add((s) => W.drawMeter(s, options), this.sizeOfData(options, "auto", "max", 1));
   }
 
   /** A stack or grid of meters. */
   meters(items: W.MetersOptions["items"], options: Omit<W.MetersOptions, "items"> & ContainerOptions = {}): this {
     const columns = Math.max(1, options.columns ?? 1);
     const rows = Math.ceil(items.length / columns);
-    return this.add((s) => W.drawMeters(s, { ...options, items }), this.sizeOfData(options, "auto", rows));
+    return this.add((s) => W.drawMeters(s, { ...options, items }), this.sizeOf(options, "auto", rows));
   }
 
   progress(options: W.ProgressOptions & ContainerOptions): this {
-    return this.add((s) => W.drawProgress(s, options), this.sizeOfData(options, "auto", 1));
+    return this.add((s) => W.drawProgress(s, options), this.sizeOfData(options, "auto", "max", 1));
   }
 
   /** Braille line/area graph. Fills the space it is given. */
   graph(options: W.GraphOptions & ContainerOptions): this {
-    return this.add((s) => W.drawGraph(s, options), this.sizeOfData(options, "fill"));
+    return this.add((s) => W.drawGraph(s, options), this.sizeOfData(options, "fill", "min-max"));
   }
 
   /** A filled area graph — `graph` with `fill` on. */
@@ -360,16 +370,16 @@ export class Container {
   }
 
   sparkline(options: W.SparklineOptions & ContainerOptions): this {
-    return this.add((s) => W.drawSparklineWidget(s, options), this.sizeOfData(options, "auto", 1));
+    return this.add((s) => W.drawSparklineWidget(s, options), this.sizeOfData(options, "auto", "min-max", 1));
   }
 
   histogram(options: W.ColumnsOptions & ContainerOptions): this {
-    return this.add((s) => W.drawColumns(s, options), this.sizeOfData(options, "fill"));
+    return this.add((s) => W.drawColumns(s, options), this.sizeOfData(options, "fill", "max"));
   }
 
   /** A semicircular dial. Wants at least 9x5. */
   gauge(options: W.GaugeOptions & ContainerOptions): this {
-    return this.add((s) => W.drawGauge(s, options), this.sizeOfData(options, "fill"));
+    return this.add((s) => W.drawGauge(s, options), this.sizeOf(options, "fill"));
   }
 
   donut(options: W.DonutOptions & ContainerOptions): this {
@@ -378,7 +388,7 @@ export class Container {
 
   /** Segmented temperature-style bar. */
   heatBar(options: W.HeatBarOptions & ContainerOptions): this {
-    return this.add((s) => W.drawHeatBar(s, options), this.sizeOfData(options, "auto", 1));
+    return this.add((s) => W.drawHeatBar(s, options), this.sizeOf(options, "auto", 1));
   }
 
   // ---------------------------------------------------------------- inputs

--- a/packages/hqtui/test/braille.test.ts
+++ b/packages/hqtui/test/braille.test.ts
@@ -61,13 +61,44 @@ test("block glyph ramps are monotonic", () => {
   assert.notEqual(verticalGlyph(0.5), verticalGlyph(0.9));
 });
 
-test("braille ignores non-finite coordinates instead of looping forever", () => {
+test("braille draws nothing for a NaN coordinate", () => {
+  // NaN has no position and no direction, so there is nothing to draw.
   const canvas = new BrailleCanvas(20, 8);
   canvas.line(0, 0, 5, Number.NaN);
   canvas.line(Number.NaN, 0, 5, 5);
-  canvas.line(0, 0, Number.POSITIVE_INFINITY, 5);
   canvas.pixel(Number.NaN, 0);
   canvas.pixel(0, Number.NaN);
-  // Nothing was drawn at the origin by a NaN coordinate.
-  assert.equal(canvas.get(0, 0), false);
+  canvas.vline(0, 0, Number.NaN);
+  canvas.circle(4, 4, Number.NaN);
+  assert.equal(canvas.toLines().join("").trim(), "");
+});
+
+test("every braille primitive terminates on any coordinate", () => {
+  // Each of these once ran forever. Endpoint finiteness was not enough: `dx` is
+  // derived from the endpoints and overflows, and past 2^53 `x += 1` does not
+  // advance, so an all-finite call could still never reach its endpoint.
+  const canvas = new BrailleCanvas(20, 8);
+  const M = Number.MAX_VALUE;
+  const I = Number.POSITIVE_INFINITY;
+  canvas.line(-M, 0, M, 0);
+  canvas.line(1e17, 0, 2e17, 0);
+  canvas.line(0, 0, I, 5);
+  canvas.polyline([[0, 0], [1024 / 1e-300, 0]]);
+  canvas.vline(0, 0, I);
+  canvas.vline(0, 0, 1e17);
+  canvas.hline(0, 0, I);
+  canvas.rect(0, 0, 5, I);
+  canvas.fillRect(0, 0, I, 5);
+  canvas.fillUnder([[0, 0], [I, 0]], 3);
+  canvas.circle(4, 4, I);
+  canvas.circle(4, 4, 1e17);
+  // Reaching here at all is the assertion; the canvas keeps its declared shape.
+  assert.equal(canvas.toLines().length, 8);
+  assert.ok(canvas.toLines().every((line) => [...line].length === 20));
+});
+
+test("a line crossing the canvas from far away still draws its visible part", () => {
+  const canvas = new BrailleCanvas(20, 8);
+  canvas.line(-1e9, 4, 1e9, 4);
+  assert.ok(canvas.toLines().join("").trim().length > 0, "the visible span was lost");
 });

--- a/packages/hqtui/test/color.test.ts
+++ b/packages/hqtui/test/color.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { rgb, hex, mix, gradient, to256, to16, from256, contrast, grayscale, DEFAULT_COLOR } from "../src/color.ts";
 import { heatColor, themes } from "../src/theme.ts";
 import { renderToText } from "../src/testing.ts";
+import { detectCapabilities } from "../src/capabilities.ts";
 
 test("hex and rgb produce the same packed value", () => {
   assert.equal(hex("#00d7ff"), rgb(0, 215, 255));
@@ -78,4 +79,35 @@ test("a meter with a non-finite value renders a real percentage", () => {
   });
   assert.ok(!out.includes("NaN"), out);
   assert.ok(out.includes("0%"));
+});
+
+test("FORCE_COLOR raises the floor without lowering the ceiling", () => {
+  const tty = { isTTY: true, columns: 80, rows: 24 } as unknown as NodeJS.WriteStream;
+  const truecolor = { COLORTERM: "truecolor", TERM: "xterm-256color" };
+  const depth = (env: Record<string, string>, out = tty) =>
+    detectCapabilities({}, env as unknown as NodeJS.ProcessEnv, out).colors;
+
+  // Asserting that color works must not cap a terminal that can do better.
+  assert.equal(depth(truecolor), "truecolor");
+  assert.equal(depth({ ...truecolor, FORCE_COLOR: "true" }), "truecolor");
+  // It does waive the tty check, which is the point of the variable.
+  assert.equal(depth({ ...truecolor, FORCE_COLOR: "true" }, { isTTY: false } as unknown as NodeJS.WriteStream), "truecolor");
+  assert.equal(depth(truecolor, { isTTY: false } as unknown as NodeJS.WriteStream), "none");
+  // Explicit levels still pin exactly, and the off switches still win.
+  assert.equal(depth({ ...truecolor, FORCE_COLOR: "1" }), "ansi16");
+  assert.equal(depth({ ...truecolor, FORCE_COLOR: "0" }), "none");
+  assert.equal(depth({ ...truecolor, FORCE_COLOR: "false" }), "none");
+  assert.equal(depth({ ...truecolor, NO_COLOR: "1", FORCE_COLOR: "true" }), "none");
+});
+
+test("the Linux console keeps unicode but not braille", () => {
+  const tty = { isTTY: true, columns: 80, rows: 24 } as unknown as NodeJS.WriteStream;
+  const caps = (term: string) =>
+    detectCapabilities({}, { TERM: term, LANG: "en_US.UTF-8" } as unknown as NodeJS.ProcessEnv, tty);
+  // Its default font draws box and block elements; only braille is missing.
+  assert.equal(caps("linux").unicode, true);
+  assert.equal(caps("linux").braille, false);
+  // A dumb terminal has no glyph repertoire to speak of.
+  assert.equal(caps("dumb").unicode, false);
+  assert.equal(caps("dumb").braille, false);
 });

--- a/packages/hqtui/test/input.test.ts
+++ b/packages/hqtui/test/input.test.ts
@@ -158,19 +158,50 @@ test("paste content that resembles the end marker is kept", () => {
   assert.equal(paste?.type === "paste" && paste.text, "a\x1b[200~b");
 });
 
-test("a bare binding does not fire on the shifted key", () => {
-  // Tab and Shift+Tab move focus in opposite directions; a "tab" binding that
-  // also matched Shift+Tab did both at once.
+test("a bare binding matches its key whatever the shift state", () => {
+  // Rejecting shift here silently stopped every shifted named key — shift+up,
+  // shift+home, shift+f1 — from matching its own name. Bind "shift+tab" when
+  // the distinction matters; `key` carries it either way.
   const shiftTab: KeyEvent = {
     type: "key", name: "tab", key: "shift+tab",
     shift: true, ctrl: false, alt: false, raw: "\x1b[Z",
   };
-  assert.equal(matchKey(shiftTab, "tab"), false);
+  assert.equal(matchKey(shiftTab, "tab"), true);
   assert.equal(matchKey(shiftTab, "shift+tab"), true);
-  // Shift is what produces a capital letter, so it is not a modifier there.
-  const shiftA: KeyEvent = {
-    type: "key", name: "a", key: "a",
-    shift: true, ctrl: false, alt: false, char: "A", raw: "A",
+
+  // Real byte sequences, not hand-built events.
+  for (const [seq, name] of [["\x1b[1;2A", "up"], ["\x1b[1;2H", "home"], ["\x1b[5;2~", "pageup"]] as const) {
+    const event = new InputParser().parse(seq)[0];
+    assert.equal(event?.type, "key");
+    if (event?.type !== "key") continue;
+    assert.equal(event.shift, true);
+    assert.equal(matchKey(event, name), true, `shift+${name} stopped matching "${name}"`);
+    assert.equal(matchKey(event, `shift+${name}`), true);
+  }
+
+  // ctrl and alt are still modifiers, and still exclude a bare binding.
+  const ctrlA: KeyEvent = {
+    type: "key", name: "a", key: "ctrl+a",
+    shift: false, ctrl: true, alt: false, raw: "\x01",
   };
-  assert.equal(matchKey(shiftA, "a"), true);
+  assert.equal(matchKey(ctrlA, "a"), false);
+  assert.equal(matchKey(ctrlA, "ctrl+a"), true);
+});
+
+test("flush mid-paste keeps a partial end marker held back", () => {
+  // Folding the held-back bytes into the paste content destroyed the marker
+  // whenever the Escape timeout fired between the two reads carrying it: the
+  // rest arrived alone, never matched, and the paste could never end.
+  const END = "\x1b[201~";
+  for (let cut = 1; cut < END.length; cut++) {
+    const parser = new InputParser();
+    parser.parse("\x1b[200~hello" + END.slice(0, cut));
+    parser.flush();
+    const events = [...parser.parse(END.slice(cut)), ...parser.parse("q")];
+    const paste = events.find((e) => e.type === "paste");
+    assert.ok(paste, `flush() at cut ${cut} lost the paste`);
+    assert.equal(paste.type === "paste" && paste.text, "hello");
+    const key = events.find((e) => e.type === "key");
+    assert.ok(key, `flush() at cut ${cut} wedged the parser`);
+  }
 });

--- a/packages/hqtui/test/render.test.ts
+++ b/packages/hqtui/test/render.test.ts
@@ -342,13 +342,67 @@ test("a widget's data range is not a layout constraint", () => {
   assert.ok(pinnedAxis.contains("FOOTER"), "a pinned y-axis evicted the sibling");
 });
 
-test("a subtitle does not overwrite the title", () => {
-  const both = renderToText(({ ui }) => ui.panel(
-    { title: "A Long Panel Title", subtitle: "99%" },
-    (p) => p.text(""),
-  ), { width: 26, height: 3 }).split("\n")[0];
-  assert.ok(both.includes("99%"), "subtitle missing");
-  // The title is truncated to the space it actually has, rather than being
-  // painted over mid-word by the subtitle.
-  assert.ok(!both.includes("Tit 99%"), `title collided with subtitle: ${both}`);
+test("a subtitle is never painted over by the title", () => {
+  // Reserving the width is not enough on its own: right- and centre-aligned
+  // titles are positioned from the panel edge, so they were still drawn over
+  // the subtitle, and a wide glyph straddling the boundary bisected it.
+  //
+  // Compared by cell column, because a wide character is one string index but
+  // two columns — an index-wise comparison silently passes.
+  const columns = (options: Parameters<Container["panel"]>[0], width: number) => {
+    const screen = renderToScreen(({ ui }) => ui.panel(options, (p) => p.text("")), {
+      width,
+      height: 3,
+    });
+    return Array.from({ length: width }, (_, x) => screen.cell(x, 0).char);
+  };
+
+  const titles = ["T", "A Long Panel Title", "\u65e5\u672c\u8a9e\u306e\u30bf\u30a4\u30c8\u30eb", "Mixed \u65e5\u672c Title"];
+  const subtitles = ["99%", "12.5 MB/s", "\u65e5\u672c"];
+  for (const title of titles) {
+    for (const subtitle of subtitles) {
+      for (const titleAlign of ["left", "center", "right"] as const) {
+        for (let width = 4; width <= 40; width++) {
+          const withTitle = columns({ title, subtitle, titleAlign }, width);
+          const alone = columns({ subtitle }, width);
+          for (let x = 0; x < width; x++) {
+            const isSubtitleGlyph = !["", " ", "\u2500", "\u256d", "\u256e"].includes(alone[x]);
+            if (!isSubtitleGlyph) continue;
+            assert.equal(
+              withTitle[x],
+              alone[x],
+              `${titleAlign} w=${width} title=${JSON.stringify(title)}: subtitle corrupted at column ${x}`,
+            );
+          }
+        }
+      }
+    }
+  }
+});
+
+test("a layout bound survives on widgets that have no data range", () => {
+  // `min`/`max` mean the data domain only where a widget declares them.
+  // GaugeOptions, MetersOptions and HeatBarOptions declare neither, so there
+  // the only possible meaning was the ContainerOptions layout bound — and
+  // stripping it silently changed sizes that were correct.
+  const bottomRow = (view: (ui: Container) => void) =>
+    renderToText(({ ui }) => {
+      view(ui);
+      ui.text("BOTTOM");
+    }, { width: 30, height: 12 })
+      .split("\n")
+      .findIndex((line) => line.includes("BOTTOM"));
+
+  assert.equal(bottomRow((ui) => ui.gauge({ value: 0.5, max: 3 })), 3, "gauge lost its layout max");
+  assert.equal(bottomRow((ui) => ui.meters([{ label: "a", value: 0.5 }], { min: 5 })), 5, "meters lost its layout min");
+  assert.equal(bottomRow((ui) => ui.heatBar({ value: 0.5, min: 4 })), 4, "heatBar lost its layout min");
+  // meter and progress declare `max` but not `min`, so `min` is still layout.
+  assert.equal(bottomRow((ui) => ui.meter({ label: "m", value: 0.5, min: 4 })), 4, "meter lost its layout min");
+  assert.equal(bottomRow((ui) => ui.progress({ label: "p", value: 3, max: 10, min: 4 })), 4, "progress lost its layout min");
+
+  // And the data range each widget does declare is still not a layout bound.
+  const emptyQueue = renderToScreen(({ ui }) => {
+    ui.progress({ label: "Tasks", value: 0, max: 0 });
+  }, { width: 34, height: 3 });
+  assert.ok(emptyQueue.contains("Tasks"), "progress with max 0 disappeared again");
 });


### PR DESCRIPTION
Red-teaming #3 and #4 *after* they merged turned up seven problems — five introduced by those changes, two showing the fixes were incomplete. All are in `main` now, which is why this is one PR rather than several.

## Every braille primitive can still hang — #3 was incomplete

`line()` guarded its four endpoints for finiteness. That does not bound the walk: `dx` is derived from the endpoints and overflows to `Infinity`, and past 2^53 `x += 1` stops advancing, so **all-finite arguments still never reach the exit condition**. And only 4 of the 10 drawing methods were guarded at all.

Ten of twelve cases hang, all reachable through the public `ui.canvas` escape hatch inside the render loop:

```
line(-MAX_VALUE, 0, MAX_VALUE, 0)   *** HANG ***
line(1e17, 0, 2e17, 0)              *** HANG ***
vline(0, 0, Infinity)               *** HANG ***
vline(0, 0, 1e17)                   *** HANG ***
hline(0, 0, Infinity)               *** HANG ***
rect(0, 0, 5, Infinity)             *** HANG ***
fillRect(0, 0, Infinity, 5)         *** HANG ***
fillUnder(pts, Infinity)            *** HANG ***
circle(4, 4, Infinity)              *** HANG ***
circle(4, 4, 1e17)                  *** HANG ***
polyline([[0,0],[1024/1e-300, 0]])  *** HANG ***
```

That last one is ordinary arithmetic producing a large finite coordinate — no adversarial input required.

The cause is uniform: **each loop iterated the caller's coordinate space rather than the canvas.** Nothing outside the canvas can draw, so every loop is now clamped to it. `line` clips (Liang–Barsky) rather than walking from wherever it was handed.

Clipping shifts which pixels a partly-offscreen line lands on, so it only engages past 100,000 steps — far beyond any real canvas, short enough to stay instant. **Differential over 40,000 ordinary draws: 0 differences.**

## `flush()` destroyed a held-back paste marker — #3 introduced this

`flush()` folded `pasteTail` into the paste content. If the Escape timeout fired between the two reads carrying a split end marker, the rest arrived alone, never matched, and the paste could never end — the exact wedge the holdback exists to prevent. The tail is now left held back.

Only reachable by direct `InputParser` consumers (`Terminal` calls `flush()` only when `hasPending`, which ignores `pasteTail`) — but `InputParser` is exported and its `flush()` doc-comment invites the call.

## A layout bound was stripped from widgets with no data range — #4

`sizeOfData` removed `min`/`max` from eight widgets. Only five declare either:

| widget | declares `min` | declares `max` |
|---|---|---|
| `gauge` | no | **no** |
| `meters` | no | **no** |
| `heatBar` | no | **no** |
| `meter` | no | yes |
| `progress` | no | yes |
| `graph` / `sparkline` | yes | yes |
| `histogram` | no | yes |

For the first three, `min`/`max` could only ever have meant the `ContainerOptions` layout bound — and taking it away silently changed sizes that were correct. `gauge({ value, max: 3 })` went from a 3-row cap to 11 rows, pushing its sibling off the screen. Only the keys a widget actually declares are stripped now, and #4's original bug (`progress({ max: 0 })` deleting the widget) stays fixed.

## The subtitle reservation only worked for left-aligned titles — #4

`room` was computed as if the title started at column 2, but right- and centre-aligned titles are positioned from the panel edge, so they were still drawn over the subtitle — and a wide glyph straddling the boundary bisected it:

```
title "日本語のタイトルです", subtitle "99%", align right, w=13
  want  ╭───── 99% ─╮
  got   ╭───── 9 % ─╮      <- subtitle bisected, orphan half-character
```

The title now has a region every alignment respects. Swept over 4 titles × 3 subtitles × 3 alignments × widths 4–40, comparing every subtitle column against a subtitle-only render: **0 corrupted**, down from 276 per alignment.

## `FORCE_COLOR` capped colour instead of raising its floor — #4

`return "ansi16"` *overrode* a better detected depth:

```
COLORTERM=truecolor, FORCE_COLOR=true    truecolor -> ansi16
COLORTERM=truecolor, FORCE_COLOR=false   truecolor -> ansi16   (should be off)
```

`FORCE_COLOR=true` is the value the comment cites as common and the one npm exports, so hqtui rendered in 16 colours under `npm run` on a modern terminal. And `FORCE_COLOR=false` — which supports-color and chalk treat as *off* — turned colour on. It is now a floor that only waives the tty check, and `false` means off. `NO_COLOR` and `FORCE_COLOR=0` still win.

## `matchKey`'s shift rule rested on a false premise — #4

The justification was that a `"tab"` binding would also fire on Shift+Tab and move focus both ways at once. `App` reads `event.name` directly (`app.ts:241`) and never calls `matchKey`, so that could not happen. Meanwhile all 14 shifted named keys silently stopped matching their own name:

```
shift+up      matchKey(e,"up")      true -> false
shift+home    matchKey(e,"home")    true -> false
shift+pageup  matchKey(e,"pageup")  true -> false
shift+f1      matchKey(e,"f1")      true -> false
```

Reverted. `key` still carries `"shift+tab"` for anyone who wants the distinction.

## The Linux console does render box drawing — #4

`TERM=linux` was told it has no unicode at all. Its default font draws box and block elements perfectly well; only Braille is missing, so now only Braille is withheld.

## Verification

137 tests pass; typecheck and build clean. Two tests from #4 asserted the behaviour reverted here and are restated — the subtitle one now compares **by cell column**, because a wide character is one string index but two columns and an index-wise check passes silently. (My first attempt at that sweep reported 828 false positives for exactly that reason.)

```
bun run bench, merged main -> with fixes
  renderer.frame.100pct      0.378 -> 0.374 ms
  graphics.braille.polyline  0.004 -> 0.004 ms
  graphics.graph.braille     0.066 -> 0.065 ms
  widgets.dashboard          0.113 -> 0.111 ms
```

## Two findings I did not act on

- **The grid still drops cells when free slots remain earlier in the row** (`ONE`, `BAND` with `colSpan: 3`, then two dropped panels). Verified **identical before and after #4**, so it is pre-existing sparse-packing behaviour, not a regression. Filling those holes means dense packing, which reorders existing layouts — your call rather than mine.
- **A split paste *start* marker** re-parses the payload as keystrokes, including `enter`, when the read gap exceeds the 30 ms Escape timeout. Also pre-existing, and arguably worse than a wedge. Happy to fix it separately with the same holdback treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
