### PR TITLE
Take process names from the accounting name, not argv[0] alone

### DIFF
--- a/apps/demo/src/system/common.ts
+++ b/apps/demo/src/system/common.ts
@@ -17,19 +17,62 @@ export async function sh(command: string, args: string[], timeout = 4000): Promi
 }
 
 /**
- * A process name from its command line.
+ * A process name from its command line, used when `comm` is unavailable.
  *
- * `ps -o comm` is not usable for this: Linux truncates it to 15 bytes and it
- * may contain spaces (Firefox ships "Web Content", "Isolated Web Co"), which
- * shifts every whitespace-split column after it; macOS emits the full path
- * truncated to 16 characters, so the tail is a fragment rather than a name.
- * argv[0] has neither problem.
+ * `args` is argv joined by spaces, so an executable whose own path contains a
+ * space is ambiguous: "/tmp/Google Chrome 60" could be argv0 "/tmp/Google"
+ * with an argument, or "/tmp/Google Chrome" with one. Nothing in the string
+ * resolves it, which is why `comm` is read separately and preferred.
  */
 export function processName(args: string): string {
   const argv0 = args.trim().split(/\s+/)[0] ?? "";
   // Kernel threads are already bracketed names, not paths.
   if (argv0.startsWith("[")) return argv0;
   return argv0.split("/").pop() || argv0 || "-";
+}
+
+/**
+ * Reconcile the two names a process has, neither of which is reliable alone.
+ *
+ * The accounting name (`comm` on Linux, `ucomm` on macOS) keeps spaces but is
+ * truncated — to 15 bytes on Linux, 16 on macOS. The name derived from argv[0]
+ * is untruncated but splits at the first space, because `args` is argv joined
+ * by spaces and nothing in it says where argv[0] ended.
+ *
+ * So: trust argv[0], and take the accounting name only when it *extends* it —
+ * which is exactly the case where argv[0] was cut at a space. Anything else the
+ * accounting name says is not corroborated, and it is not always a name at all:
+ * on macOS `ucomm` for one live process here reads "2.1.243".
+ *
+ *   argv0 "Web"                      comm  "Web Content"      -> "Web Content"
+ *   argv0 "StorageManagementService" ucomm "StorageManagemen" -> argv0's
+ *   argv0 "claude"                   ucomm "2.1.243"          -> argv0's
+ */
+export function bestName(accounting: string | undefined, fromArgs: string): string {
+  if (!fromArgs || fromArgs === "-") return accounting || fromArgs;
+  if (!accounting) return fromArgs;
+  return accounting.length > fromArgs.length && accounting.startsWith(fromArgs)
+    ? accounting
+    : fromArgs;
+}
+
+/**
+ * pid -> accounting name, read with that name as the only free-form column so
+ * its spaces cannot shift anything. Parsing it out of a combined `ps` row is
+ * what corrupted every column after it.
+ */
+export async function processNames(psArgs: string[]): Promise<Map<number, string>> {
+  const names = new Map<number, string>();
+  const text = await sh("ps", psArgs);
+  for (const line of text.trim().split("\n").slice(1)) {
+    const trimmed = line.trim();
+    const gap = trimmed.indexOf(" ");
+    if (gap < 0) continue;
+    const pid = Number(trimmed.slice(0, gap));
+    const comm = trimmed.slice(gap + 1).trim();
+    if (Number.isFinite(pid) && comm) names.set(pid, comm);
+  }
+  return names;
 }
 
 export function push(history: number[], value: number, limit = 240): void {

--- a/apps/demo/src/system/darwin.ts
+++ b/apps/demo/src/system/darwin.ts
@@ -1,7 +1,7 @@
 import os from "node:os";
 import type { Collector, SystemSample } from "./types.ts";
 import {
-  baseSample, loadAverage, primaryInterface, processName, push, ratePerSecond, sh,
+  baseSample, loadAverage, primaryInterface, bestName, processName, processNames, push, ratePerSecond, sh,
 } from "./common.ts";
 
 /**
@@ -143,13 +143,17 @@ export class DarwinCollector implements Collector {
       if (!this.unavailable.includes("processes")) this.unavailable.push("processes");
       return;
     }
+    // `comm` in its own read, where its spaces cannot shift a column.
+    // macOS `comm` is the full path truncated to 16 characters; `ucomm` is the
+    // accounting name, which is what a process table wants.
+    const names = await processNames(["-Ao", "pid,ucomm"]);
     const rows = text.trim().split("\n").slice(1);
     this.sample.processes = rows.slice(0, 59).map((line) => {
       const parts = line.trim().split(/\s+/);
       const command = parts.slice(6).join(" ");
       return {
         pid: Number(parts[0]),
-        name: processName(command),
+        name: bestName(names.get(Number(parts[0])), processName(command)),
         cpu: Number(parts[1]) || 0,
         mem: Number(parts[2]) || 0,
         rss: (Number(parts[3]) || 0) * 1024,

--- a/apps/demo/src/system/linux.ts
+++ b/apps/demo/src/system/linux.ts
@@ -2,7 +2,7 @@ import { readFile, readdir } from "node:fs/promises";
 import os from "node:os";
 import type { Collector, SystemSample } from "./types.ts";
 import {
-  baseSample, loadAverage, primaryInterface, processName, push, ratePerSecond, sh,
+  baseSample, loadAverage, primaryInterface, bestName, processName, processNames, push, ratePerSecond, sh,
 } from "./common.ts";
 import type { Interface } from "./telemetry.ts";
 import * as telemetry from "./linux-telemetry.ts";
@@ -304,13 +304,15 @@ export class LinuxCollector implements Collector {
       if (!this.unavailable.includes("processes")) this.unavailable.push("processes");
       return;
     }
+    // `comm` in its own read, where its spaces cannot shift a column.
+    const names = await processNames(["-eo", "pid,comm"]);
     const rows = text.trim().split("\n").slice(1);
     this.sample.processes = rows.slice(0, 59).map((line) => {
       const parts = line.trim().split(/\s+/);
       const command = parts.slice(7).join(" ");
       return {
         pid: Number(parts[0]),
-        name: processName(command),
+        name: bestName(names.get(Number(parts[0])), processName(command)),
         cpu: Number(parts[1]) || 0,
         mem: Number(parts[2]) || 0,
         rss: (Number(parts[3]) || 0) * 1024,


### PR DESCRIPTION
Found by running #7's parser against a real Linux `/proc` in a container — the validation I could not do when that PR was written.

## What #7 got right

With an executable genuinely named `Web Content`, the pre-#7 single-call parse corrupts every column after `comm`:

```
ps -eo pid,comm,pcpu,pmem,rss,nlwp,user,state,args
  name="Web"  cpu="Content"  mem="0.0"  rss="0.0"  thr="1112"  user="1"  state="root"
```

CPU reads the word `Content`, RSS reads the thread count, `state` reads `root`. #7's fix holds — the numeric columns are correct now.

## What it got wrong

Deriving the name from argv[0] cuts it at the first space. `args` is argv joined by spaces, and nothing in the string says where argv[0] ended — `/tmp/Google Chrome 60` could be argv0 `/tmp/Google` with an argument, or `/tmp/Google Chrome` with one. So:

```
Firefox   "Web Content"    -> "Web"
Chrome    "Google Chrome"  -> "Google"
```

## The fix

`comm` is read in its own `ps` call, where it is the only free-form column and its spaces cannot shift anything, then joined by pid.

Neither name is reliable alone, so `bestName` reconciles them: **argv[0] is trusted, and the accounting name is taken only when it extends it** — exactly the case where argv[0] was cut at a space.

```
argv0 "Web"                      comm  "Web Content"      -> "Web Content"
argv0 "StorageManagementService" ucomm "StorageManagemen" -> argv0's
argv0 "claude"                   ucomm "2.1.243"          -> argv0's
```

That last row is not hypothetical — macOS reports `ucomm` as `2.1.243` for a live process on my machine, so preferring the accounting name unconditionally puts a version string in the process table. I had the rule the other way round first and this caught it.

macOS also needs a different column: its `comm` is the **full path truncated to 16 characters** (the fragment #7 removed), so it reads `ucomm`, which is what Linux calls `comm`.

## Verification

**Linux aarch64**, real `/proc`, executables created with spaces in their names:

```
name="Web Content"    cpu=0 user=root state=S
name="Google Chrome"  cpu=0 user=root state=S
```

**macOS**, live: `ApplicationsStorageExtension`, `StorageManagementService`, `WindowServer`, `Terminal` — all in full, where argv[0] alone truncated the first two.

131 tests pass on both platforms; typecheck clean.

## Known ceiling

A process whose real name exceeds 16 characters *and* contains a space still truncates — `Brave Browser Helper` renders as `Brave Browser He`. The accounting name is capped at 16 on macOS and argv[0] is ambiguous, so there is no third source to appeal to. Still better than `Brave` (argv[0]) or `Br` (pre-#7).

## Cost

One extra `ps` invocation per refresh, alongside the existing one. Both are `execFile` with an argument array, no shell. If you would rather not pay that on the refresh path, the alternative on Linux is reading `/proc/<pid>/comm` for the ~59 displayed rows, which is platform-specific but avoids the subprocess — happy to switch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
