### PR TITLE
Stop the demo reading whole logs, and losing usable output

### DIFF
--- a/apps/demo/src/format.ts
+++ b/apps/demo/src/format.ts
@@ -1,8 +1,21 @@
+/**
+ * Every value here arrives from a parser reading a file or a command that may
+ * be absent, truncated or in an unexpected shape, so this is the last place a
+ * non-finite number can be stopped before it reaches the screen. `nvidia-smi`
+ * prints "[N/A]", a partial `df` yields "-", and both become NaN.
+ */
+const UNAVAILABLE = "\u2014";
+
+function finite(value: number): number | null {
+  return Number.isFinite(value) ? value : null;
+}
+
 /** Presentation helpers. Numbers in a dashboard must never jitter in width. */
 
 const UNITS = ["B", "KiB", "MiB", "GiB", "TiB", "PiB"];
 
 export function bytes(value: number, digits = 2): string {
+  if (finite(value) === null) return UNAVAILABLE;
   let v = Math.max(0, value);
   let unit = 0;
   while (v >= 1024 && unit < UNITS.length - 1) {
@@ -13,6 +26,7 @@ export function bytes(value: number, digits = 2): string {
 }
 
 export function bitRate(bytesPerSecond: number): string {
+  if (finite(bytesPerSecond) === null) return UNAVAILABLE;
   const bits = Math.max(0, bytesPerSecond) * 8;
   if (bits >= 1e9) return `${(bits / 1e9).toFixed(1)} Gb/s`;
   if (bits >= 1e6) return `${(bits / 1e6).toFixed(1)} Mb/s`;
@@ -21,6 +35,7 @@ export function bitRate(bytesPerSecond: number): string {
 }
 
 export function byteRate(bytesPerSecond: number): string {
+  if (finite(bytesPerSecond) === null) return UNAVAILABLE;
   const v = Math.max(0, bytesPerSecond);
   if (v >= 1e9) return `${(v / 1e9).toFixed(1)} GB/s`;
   if (v >= 1e6) return `${(v / 1e6).toFixed(1)} MB/s`;
@@ -29,10 +44,12 @@ export function byteRate(bytesPerSecond: number): string {
 }
 
 export function percent(ratio: number, digits = 0): string {
+  if (finite(ratio) === null) return UNAVAILABLE;
   return `${(Math.max(0, Math.min(1, ratio)) * 100).toFixed(digits)}%`;
 }
 
 export function duration(seconds: number): string {
+  if (finite(seconds) === null) return UNAVAILABLE;
   const s = Math.max(0, Math.floor(seconds));
   const d = Math.floor(s / 86400);
   const h = Math.floor((s % 86400) / 3600);

--- a/apps/demo/src/system/common.ts
+++ b/apps/demo/src/system/common.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { open, stat } from "node:fs/promises";
 import { promisify } from "node:util";
 import os from "node:os";
 import type { SystemSample } from "../simulation.ts";
@@ -6,11 +7,48 @@ import { emptyTelemetry } from "./telemetry.ts";
 
 const run = promisify(execFile);
 
-/** Run a command, returning "" instead of throwing when it is unavailable. */
+/**
+ * Run a command, returning "" instead of throwing when it is unavailable.
+ *
+ * Whatever it managed to write is kept even when it exits non-zero. `df` exits
+ * 1 if any single mount is unreadable while still reporting every other one, so
+ * discarding stdout on failure zeroed the capacity of every disk on the machine
+ * whenever one stale automount or a departed removable drive was listed.
+ */
 export async function sh(command: string, args: string[], timeout = 4000): Promise<string> {
   try {
     const { stdout } = await run(command, args, { timeout, maxBuffer: 8 * 1024 * 1024 });
     return stdout;
+  } catch (error) {
+    const partial = (error as { stdout?: string }).stdout;
+    return typeof partial === "string" ? partial : "";
+  }
+}
+
+/**
+ * The last `bytes` of a file, as text.
+ *
+ * Log files are read for their tail, and reading one whole to keep 40 lines is
+ * a habit that only shows up in production: a brute-forced auth.log reaching a
+ * few hundred MB blocks the event loop for the better part of a second on every
+ * refresh, and above the maximum string length it throws and the panel silently
+ * empties.
+ */
+export async function tailFile(path: string, bytes = 256 * 1024): Promise<string> {
+  try {
+    const info = await stat(path);
+    if (info.size === 0) return "";
+    const handle = await open(path, "r");
+    try {
+      const length = Math.min(bytes, info.size);
+      const buffer = Buffer.alloc(length);
+      // `bytesRead` matters: the file can be rotated or truncated between the
+      // stat and the read, and the untouched tail of the buffer is NUL bytes.
+      const { bytesRead } = await handle.read(buffer, 0, length, Math.max(0, info.size - length));
+      return buffer.subarray(0, bytesRead).toString("utf8");
+    } finally {
+      await handle.close();
+    }
   } catch {
     return "";
   }

--- a/apps/demo/src/system/linux-telemetry.ts
+++ b/apps/demo/src/system/linux-telemetry.ts
@@ -1,6 +1,6 @@
 import { readFile, readdir } from "node:fs/promises";
 import os from "node:os";
-import { sh, push } from "./common.ts";
+import { sh, push, tailFile } from "./common.ts";
 import type {
   Connection, Container, Filesystem, Interface, JournalEntry, KernelStats,
   Listener, LoginEvent, ProcessStates, PowerStats, ServiceUnit, Session, Telemetry, GpuStats,
@@ -542,7 +542,8 @@ export async function journal(limit = 60): Promise<JournalEntry[]> {
   }
 
   for (const path of ["/var/log/syslog", "/var/log/messages"]) {
-    const raw = await read(path);
+    // Tailed, not read whole; only the last `limit` lines are used anyway.
+    const raw = await tailFile(path);
     if (!raw) continue;
     return raw.trim().split("\n").slice(-limit).map((line) => {
       const match = /^(\w+\s+\d+\s+[\d:]+)\s+\S+\s+([^:[]+)/.exec(line);

--- a/apps/demo/src/system/linux-traffic.ts
+++ b/apps/demo/src/system/linux-traffic.ts
@@ -1,6 +1,5 @@
 import { readFile, stat } from "node:fs/promises";
-import { open } from "node:fs/promises";
-import { sh } from "./common.ts";
+import { sh, tailFile } from "./common.ts";
 
 /**
  * Protocol-level visibility without root: socket classification, kernel
@@ -224,7 +223,8 @@ export async function sshEvents(limit = 40): Promise<SshEvent[]> {
   const text = await sh("journalctl", [
     "-u", "ssh", "-u", "sshd", "-n", String(limit * 2), "--no-pager", "--output=short-iso",
   ], 5000);
-  const source = text || (await read("/var/log/auth.log"));
+  // Tailed, not read whole: this file grows without bound under a brute force.
+  const source = text || (await tailFile("/var/log/auth.log"));
   if (!source) return [];
 
   const events: SshEvent[] = [];
@@ -302,17 +302,11 @@ export async function http(tailBytes = 256 * 1024): Promise<HttpStats | null> {
   }
   if (!path) return null;
 
-  let text = "";
-  try {
-    const handle = await open(path, "r");
-    const start = Math.max(0, size - tailBytes);
-    const buffer = Buffer.alloc(Math.min(tailBytes, size));
-    await handle.read(buffer, 0, buffer.length, start);
-    await handle.close();
-    text = buffer.toString("utf8");
-  } catch {
-    return null;
-  }
+  // Shares `tailFile`'s handling of a rotation between the stat and the read,
+  // which otherwise leaves the tail of the buffer as NUL bytes — and those flow
+  // into `split("\n")` and into the request-rate denominator below.
+  const text = await tailFile(path, tailBytes);
+  if (!text) return null;
 
   const lines = text.split("\n").slice(1).filter(Boolean);
   const statusClasses = new Map<string, number>();

--- a/apps/demo/src/system/linux.ts
+++ b/apps/demo/src/system/linux.ts
@@ -1,6 +1,7 @@
 import { readFile, readdir } from "node:fs/promises";
 import os from "node:os";
 import type { Collector, SystemSample } from "./types.ts";
+import { bitRate } from "../format.ts";
 import {
   baseSample, loadAverage, primaryInterface, processName, push, ratePerSecond, sh,
 } from "./common.ts";
@@ -174,7 +175,10 @@ export class LinuxCollector implements Collector {
     s.network.downPeak = Math.max(s.network.downPeak, s.network.downRate);
     s.network.upPeak = Math.max(s.network.upPeak, s.network.upRate);
     const speed = await read(`/sys/class/net/${iface.name}/speed`);
-    s.network.speed = speed.trim() && Number(speed) > 0 ? `${Number(speed) / 1000} Gb/s` : "-";
+    // /sys reports Mb/s. Dividing unconditionally rendered a 100 Mb/s NIC as
+    // "0.1 Gb/s"; bitRate picks the unit the number belongs in.
+    const mbps = Number(speed);
+    s.network.speed = speed.trim() && mbps > 0 ? bitRate((mbps * 1e6) / 8) : "-";
 
     await Promise.all([this.updateProcesses(), this.updateTemperatures()]);
     await this.updateTelemetry(dt);

--- a/apps/demo/test/format.test.ts
+++ b/apps/demo/test/format.test.ts
@@ -1,0 +1,63 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { bytes, bitRate, byteRate, percent, duration } from "../src/format.ts";
+import { sh, tailFile } from "../src/system/common.ts";
+
+test("formatters refuse to print a non-finite number", () => {
+  // Every value here comes from a parser reading a file or command that may be
+  // absent or truncated. `nvidia-smi` prints "[N/A]" and a partial `df` prints
+  // "-", both of which become NaN, and this is the last place to stop them.
+  for (const value of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+    for (const format of [bytes, bitRate, byteRate, percent, duration]) {
+      const out = format(value);
+      assert.ok(!/NaN|Infinity/.test(out), `${format.name}(${value}) = ${out}`);
+    }
+  }
+  // Finite values are untouched.
+  assert.equal(bytes(1536), "1.50 KiB");
+  assert.equal(percent(0.5), "50%");
+  assert.equal(duration(3725), "1h 2m");
+});
+
+test("a rate is shown in the unit it belongs in", () => {
+  // /sys reports Mb/s; dividing unconditionally rendered a 100 Mb/s NIC as
+  // "0.1 Gb/s".
+  assert.equal(bitRate((100 * 1e6) / 8), "100.0 Mb/s");
+  assert.equal(bitRate((1000 * 1e6) / 8), "1.0 Gb/s");
+  assert.equal(bitRate((2500 * 1e6) / 8), "2.5 Gb/s");
+});
+
+test("tailFile reads only the tail, whatever the file's size", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "hqtui-tail-"));
+  try {
+    const line = "Sep  2 10:00:00 host sshd[1]: Failed password for root from 10.0.0.9\n";
+    await writeFile(join(dir, "big.log"), line.repeat(200_000));
+    const tail = await tailFile(join(dir, "big.log"), 64 * 1024);
+    assert.ok(tail.length <= 64 * 1024, `read ${tail.length} bytes`);
+    assert.ok(tail.endsWith(line), "the tail is not the end of the file");
+
+    // A file shorter than the window is returned whole, with no NUL padding —
+    // the buffer is sized from a stat that the file may have outrun.
+    await writeFile(join(dir, "small.log"), "aaaa\n");
+    const small = await tailFile(join(dir, "small.log"), 64 * 1024);
+    assert.equal(small, "aaaa\n");
+    assert.equal(small.includes(String.fromCharCode(0)), false);
+
+    assert.equal(await tailFile(join(dir, "absent.log")), "");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("sh keeps what a failing command still produced", { skip: process.platform === "win32" }, async () => {
+  // `df` exits 1 when any single mount is unreadable while still reporting
+  // every other one. Discarding stdout zeroed the capacity of every disk on
+  // the machine whenever one stale automount was listed.
+  const partial = await sh("df", ["-kP", ".", "/nonexistent-mount-hqtui"]);
+  assert.ok(partial.trim().split("\n").length >= 2, "usable df output was discarded");
+  // A command that produces nothing at all still yields "".
+  assert.equal(await sh("hqtui-command-that-does-not-exist", []), "");
+});


### PR DESCRIPTION
Four problems in the paths that read real system state. All confirmed against a real Linux `/proc` in a container.

## Logs were read whole to keep forty lines

`sshEvents` read all of `/var/log/auth.log`, and `journal` all of `/var/log/syslog`, then kept the last few dozen lines. `http()` sitting beside them already tails 256 KiB — these two did not.

A brute-forced `auth.log` reaching a few hundred MB is ordinary, and this runs every few seconds inside a 30fps TUI:

```
before:  300 MB file -> ~600ms of blocked event loop, ~684 MB RSS
after :  300 MB file -> 262144 chars in 0ms, 79 MB RSS
```

Above the maximum string length it threw outright, the `catch` swallowed it, and the panel silently emptied — the failure mode being least visible exactly when the log is largest.

All three now share a `tailFile` helper. That also fixes `http()` discarding `bytesRead`: the file can be rotated or truncated between the `stat` and the `read`, and the untouched tail of the buffer is NUL bytes, which flowed into `split("\n")` and into the request-rate denominator.

## One unreadable mount zeroed every disk

`sh()` returned `""` on any non-zero exit. `df` exits 1 if a single mount is unreadable **while still reporting every other one**, and `updateCapacity` passes all mount points in a single call.

So one stale automount, or a removable drive that had been unplugged, zeroed the capacity of every disk on the machine until restart:

```
df -kPT / /nonexistent-mount   exit=1, 2 usable data lines on stdout
old sh() -> ""                 every disk reads 0
new sh() -> both rows kept
```

`sh()` now keeps whatever a command managed to write. One that produces nothing at all still returns `""`, so callers that treat empty as "unavailable" are unaffected.

## Non-finite numbers reached the screen

`bytes`, `bitRate`, `byteRate`, `percent` and `duration` clamped negatives but not NaN or Infinity:

```
bytes(NaN)         "NaN B"
percent(NaN)       "NaN%"
duration(NaN)      "NaNm NaNs"
bytes(Infinity)    "Infinity PiB"
duration(Infinity) "Infinityd NaNh NaNm"
```

These are the last line of defence for every parser above them — `nvidia-smi` prints `[N/A]` for `power.draw` and `utilization.gpu` on many consumer and virtualised GPUs, and a partial `df` prints `-` — both of which become NaN. They now render an em dash.

## A 100 Mb/s NIC read "0.1 Gb/s"

`/sys/class/net/*/speed` is in Mb/s and was divided by 1000 unconditionally. It now goes through `bitRate`:

```
100   -> 100.0 Mb/s      (was "0.1 Gb/s")
1000  -> 1.0 Gb/s
2500  -> 2.5 Gb/s
```

## Verification

135 tests pass on **macOS** and **Linux aarch64**; typecheck clean. New tests in `apps/demo/test/format.test.ts` cover the formatters against all three non-finite values, `tailFile` against a 13 MB file and a short one (asserting no NUL padding), and `sh` retaining partial `df` output — skipped on Windows, where `df` does not exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
