### PR TITLE
Release terminal subscriptions on stop, and let the host own the exit

### DIFF
--- a/packages/hqtui/src/app.ts
+++ b/packages/hqtui/src/app.ts
@@ -89,6 +89,8 @@ export class App {
   private frameCount = 0;
   private lastFrameAt = 0;
   private exitResolve: (() => void) | null = null;
+  /** Terminal subscriptions, released on stop so a restart does not double them. */
+  private subscriptions: (() => void)[] = [];
 
   private focusIndex = 0;
   private focusCount = 0;
@@ -183,15 +185,21 @@ export class App {
     this.startedAt = Date.now();
     this.terminal.enter();
 
-    this.terminal.onInput((event) => this.handleInput(event));
-    this.terminal.onResizeEvent(({ columns, rows }) => {
+    // Kept so `stop()` can release them. `Terminal.restore()` detaches from the
+    // stream but keeps its listener sets, so discarding these meant a second
+    // `start()` handled every keystroke twice, and again for every restart.
+    // If an exit handler tears the terminal down and hands the decision to the
+    // host, the render loop must not keep drawing into the restored shell.
+    this.subscriptions.push(this.terminal.onTeardown(() => this.stop()));
+    this.subscriptions.push(this.terminal.onInput((event) => this.handleInput(event)));
+    this.subscriptions.push(this.terminal.onResizeEvent(({ columns, rows }) => {
       this.current.resize(columns, rows);
       this.previous.resize(columns, rows);
       this.forceRepaint = true;
       this.dirty = true;
       this.emit("resize", { width: columns, height: rows });
       this.frame();
-    });
+    }));
 
     const fps = this.targetFps();
     const interval = Math.max(8, Math.floor(1000 / fps));
@@ -218,6 +226,8 @@ export class App {
     this.running = false;
     if (this.timer) clearInterval(this.timer);
     this.timer = null;
+    for (const off of this.subscriptions) off();
+    this.subscriptions = [];
     this.terminal.restore();
     this.emit("exit", undefined);
     this.exitResolve?.();

--- a/packages/hqtui/src/terminal.ts
+++ b/packages/hqtui/src/terminal.ts
@@ -43,6 +43,7 @@ export class Terminal {
   private inputListeners = new Set<Listener<InputEvent>>();
   private resizeListeners = new Set<Listener<TerminalSize>>();
   private cleanupHandlers: (() => void)[] = [];
+  private teardownListeners = new Set<() => void>();
   private escapeTimer: NodeJS.Timeout | null = null;
   private onData = (chunk: Buffer | string): void => {
     const text = typeof chunk === "string" ? chunk : chunk.toString("utf8");
@@ -168,6 +169,16 @@ export class Terminal {
     return () => this.resizeListeners.delete(listener);
   }
 
+  /**
+   * Called when an exit handler tears the terminal down without the owner
+   * asking. Whoever is driving a render loop has to know: the alternate screen
+   * is gone, so anything it draws next lands in the user's live shell.
+   */
+  onTeardown(listener: () => void): () => void {
+    this.teardownListeners.add(listener);
+    return () => this.teardownListeners.delete(listener);
+  }
+
   private installExitHandlers(): void {
     const restore = () => this.restore();
 
@@ -176,12 +187,26 @@ export class Terminal {
       process.exit(signal === "SIGINT" ? 130 : 143);
     };
     const onExit = () => restore();
-    const onError = (error: unknown) => {
+    // Restoring is not negotiable — a crash must not leave an unusable shell —
+    // but deciding the process should die is the host's call, not a rendering
+    // library's. If the embedding app installed its own handler, hand over once
+    // the terminal is safe; only act as the last resort when nobody else will.
+    const onError = (event: "uncaughtException" | "unhandledRejection") => (error: unknown) => {
+      // Counted before restoring: `restore()` runs the cleanup handlers, and
+      // those remove this very listener — so asking afterwards excludes us and
+      // one host handler reads as none.
+      const handedOver = process.listenerCount(event) > 1;
       restore();
+      // Anything still rendering must stop, or it paints into the shell the
+      // alternate screen just gave back.
+      for (const listener of this.teardownListeners) listener();
+      if (handedOver) return;
       // The terminal is usable again, so the stack trace is actually readable.
       console.error(error);
       process.exit(1);
     };
+    const onUncaught = onError("uncaughtException");
+    const onRejection = onError("unhandledRejection");
 
     const sigint = onSignal("SIGINT");
     const sigterm = onSignal("SIGTERM");
@@ -191,16 +216,16 @@ export class Terminal {
     process.on("SIGTERM", sigterm);
     process.on("SIGHUP", sighup);
     process.on("exit", onExit);
-    process.on("uncaughtException", onError);
-    process.on("unhandledRejection", onError);
+    process.on("uncaughtException", onUncaught);
+    process.on("unhandledRejection", onRejection);
 
     this.cleanupHandlers.push(() => {
       process.off("SIGINT", sigint);
       process.off("SIGTERM", sigterm);
       process.off("SIGHUP", sighup);
       process.off("exit", onExit);
-      process.off("uncaughtException", onError);
-      process.off("unhandledRejection", onError);
+      process.off("uncaughtException", onUncaught);
+      process.off("unhandledRejection", onRejection);
     });
   }
 }

--- a/packages/hqtui/test/lifecycle.test.ts
+++ b/packages/hqtui/test/lifecycle.test.ts
@@ -1,0 +1,111 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { PassThrough } from "node:stream";
+import { App } from "../src/app.ts";
+
+function fakeTty() {
+  const input = new PassThrough() as unknown as NodeJS.ReadStream;
+  const output = new PassThrough() as unknown as NodeJS.WriteStream;
+  // Swallow the escape sequences the terminal writes so they do not accumulate.
+  (output as unknown as PassThrough).resume();
+  Object.assign(output, { columns: 40, rows: 10 });
+  return { input, output };
+}
+
+test("restarting an app does not double its input handling", async () => {
+  const { input, output } = fakeTty();
+  const app = new App({
+    input,
+    output,
+    installExitHandlers: false,
+    quitKeys: [],
+    capabilities: { mouse: false },
+    bracketedPaste: false,
+    focusEvents: false,
+  });
+  app.render(({ ui }) => ui.text("x"));
+
+  let keys = 0;
+  app.on("key", () => keys++);
+
+  // Three start/stop cycles. `Terminal.restore()` detaches from the stream but
+  // keeps its listener sets, so an app that discarded its unsubscribes handled
+  // each keystroke once more per cycle: 1, then 2, then 3.
+  for (let cycle = 1; cycle <= 3; cycle++) {
+    keys = 0;
+    void app.start();
+    (input as unknown as PassThrough).write("a");
+    await new Promise((r) => setImmediate(r));
+    app.stop();
+    assert.equal(keys, 1, `cycle ${cycle} dispatched ${keys} events for one keypress`);
+  }
+});
+
+test("stopping an app releases its terminal subscriptions", async () => {
+  const { input, output } = fakeTty();
+  const app = new App({
+    input,
+    output,
+    installExitHandlers: false,
+    quitKeys: [],
+    capabilities: { mouse: false },
+    bracketedPaste: false,
+    focusEvents: false,
+  });
+  app.render(({ ui }) => ui.text("x"));
+
+  let keys = 0;
+  app.on("key", () => keys++);
+  void app.start();
+  app.stop();
+
+  // Nothing is listening now, so a late chunk on the stream reaches no one.
+  (input as unknown as PassThrough).write("z");
+  await new Promise((r) => setImmediate(r));
+  assert.equal(keys, 0);
+});
+
+test("a fatal error hands the decision to a host that has its own handler", async () => {
+  // Counting listeners after `restore()` excludes hqtui's own — it is removed
+  // by the cleanup handlers restore() runs — so one host handler read as none
+  // and the library exited anyway, which was the whole point of the change.
+  const { spawn } = await import("node:child_process");
+  const program = (hosts: number) => `
+    const { createApp } = await import(${JSON.stringify(new URL("../src/app.ts", import.meta.url).pathname)});
+    const { PassThrough } = await import("node:stream");
+    const input = new PassThrough(); const output = new PassThrough();
+    let after = 0, armed = false;
+    output.on("data", (c) => { if (armed) after += c.length; });
+    Object.assign(output, { columns: 40, rows: 10 });
+    ${Array.from({ length: hosts }, () => 'process.on("uncaughtException", () => {});').join("")}
+    const app = await createApp({ input, output, quitKeys: [], fps: 120 });
+    let n = 0;
+    app.render(({ ui }) => ui.text("frame " + (n++)));
+    void app.start();
+    setImmediate(() => { armed = true; throw new Error("boom"); });
+    setTimeout(() => { console.log("FRAMES_AFTER=" + (n - 1)); process.exit(0); }, 300);
+  `;
+  const run = (hosts: number) =>
+    new Promise<{ code: number | null; out: string }>((resolve) => {
+      const child = spawn(process.execPath, ["--experimental-strip-types", "--input-type=module", "-e", program(hosts)], {
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      let out = "";
+      child.stdout.on("data", (d) => (out += d));
+      child.stderr.on("data", (d) => (out += d));
+      const kill = setTimeout(() => child.kill("SIGKILL"), 15_000);
+      child.on("exit", (code) => {
+        clearTimeout(kill);
+        resolve({ code, out });
+      });
+    });
+
+  // With no host handler the library is the last resort and still exits.
+  assert.equal((await run(0)).code, 1);
+
+  // With one, the host decides — and the render loop stops rather than
+  // painting into the shell the alternate screen just gave back.
+  const handed = await run(1);
+  assert.equal(handed.code, 0, "the library exited despite a host handler");
+  assert.match(handed.out, /FRAMES_AFTER=0/, "the app kept rendering after teardown");
+});

--- a/packages/hqtui/test/lifecycle.test.ts
+++ b/packages/hqtui/test/lifecycle.test.ts
@@ -71,7 +71,7 @@ test("a fatal error hands the decision to a host that has its own handler", asyn
   // and the library exited anyway, which was the whole point of the change.
   const { spawn } = await import("node:child_process");
   const program = (hosts: number) => `
-    const { createApp } = await import(${JSON.stringify(new URL("../src/app.ts", import.meta.url).pathname)});
+    const { createApp } = await import(${JSON.stringify(new URL("../src/app.ts", import.meta.url).href)});
     const { PassThrough } = await import("node:stream");
     const input = new PassThrough(); const output = new PassThrough();
     let after = 0, armed = false;


### PR DESCRIPTION
Two lifecycle problems in `App` and `Terminal`.

## A restarted app handled every keystroke twice

`App.start()` discarded the unsubscribe functions from `terminal.onInput` and `onResizeEvent`, and `Terminal.restore()` detaches from the stream without clearing its listener sets. A stop/start cycle therefore left the previous subscription in place:

```
cycle 1 dispatched 1 event for one keypress
cycle 2 dispatched 2 events for one keypress
cycle 3 dispatched 3 events
```

The framebuffer was resized once per stale subscription too. They're kept now and released in `stop()`. Verified by removing the release again — the test fails with exactly that message.

## A rendering library decided the process should die

`installExitHandlers` registers process-wide `uncaughtException` and `unhandledRejection` handlers, on by default because rule 5 requires the terminal be restored however the process ends. But the handler also called `process.exit(1)`, so an unrelated rejection anywhere in an embedding application terminated it — and registering a listener at all suppresses Node's default, so a host with its own handler never saw the error either way.

Restoring stays unconditional. Deciding to exit does not.

**Two details, both found by red-teaming a first attempt that didn't work:**

- The listener count is taken **before** `restore()`. Restore runs the cleanup handlers, and those remove this very listener — so counting afterwards excludes hqtui, and one host handler reads as none. The guard was off by one and the change did nothing in the case that motivated it:

  ```
  host registered BEFORE start:  hostLogged=true  survived=false  exit=1
  host registered AFTER start:   hostLogged=false survived=false  exit=1
  ```

- The terminal **announces the teardown** and `App` stops on it. Handing the decision over while still rendering leaves the loop painting into the shell the alternate screen just gave back — a new failure mode the first attempt introduced.

After:

```
0 host handlers:  exit=1  (library is the last resort, unchanged)
1 host handler:   exit=0, host ran, FRAMES_AFTER=0
```

The only bytes written after the crash are the 18-byte teardown sequence `<ESC>[0m<ESC>[?25h<ESC>[?1049l`. At 120fps over 600ms a zombie would have rendered ~70 frames.

## Verified

Every exit path still restores — SIGINT/SIGTERM/SIGHUP/normal exit/crash all leave `rawMode=false inAltScreen=false`; two Apps in one process both restore; `start();start();stop()`, double `stop()`, 50 cycles and `stop()` from inside the dispatch loop leave no dangling subscription or leaked process listener.

`bun run typecheck && bun test` pass (134 tests).

## One thing I did not fix

`enter()` writes the alternate-screen sequence before installing the exit handlers, so a throw in between — a revoked tty makes `setRawMode` fail with `EIO` — leaves the terminal in the alternate screen with no handler to restore it. It's pre-existing rather than introduced here, but given this PR is about crash-safety, say the word and I'll move the installation ahead of the first write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
