### PR TITLE
Add the scaffolding a repo taking outside PRs needs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Review is requested automatically from the owners listed here.
+# Adjust or remove as suits — this file only exists because nothing did.
+
+*                       @ralyodio
+
+# The library's public surface and its rendering core: changes here reach every
+# consumer, and CONTRIBUTING's rules (zero dependencies, no allocation per cell,
+# survives a 1x1 terminal, always restores the terminal) apply most sharply.
+/packages/hqtui/        @ralyodio
+
+# The promises in these are the ones people rely on when auditing.
+/SECURITY.md            @ralyodio
+/.github/workflows/     @ralyodio

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,54 @@
+name: Bug report
+description: Something renders wrong, throws, hangs, or leaves the terminal broken.
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        A reproduction beats a description. The headless renderer needs no TTY:
+
+        ```ts
+        import { renderToText } from "@profullstack/hqtui";
+        console.log(renderToText(({ ui }) => ui.text("CPU 72%"), { width: 40, height: 3 }));
+        ```
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened
+      description: What you saw, and what you expected instead.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction
+      description: The smallest view that shows it, or the exact commands.
+      render: ts
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: hqtui version
+      placeholder: "0.1.9"
+    validations:
+      required: true
+  - type: input
+    id: runtime
+    attributes:
+      label: Runtime and OS
+      placeholder: "bun 1.4.0, macOS 15 / node 22.6, Ubuntu 24.04"
+    validations:
+      required: true
+  - type: input
+    id: terminal
+    attributes:
+      label: Terminal
+      description: The output of `hqtui doctor` is ideal.
+      placeholder: "iTerm2, TERM=xterm-256color, truecolor"
+  - type: checkboxes
+    id: terminal-state
+    attributes:
+      label: Did the terminal survive?
+      options:
+        - label: The terminal was left unusable (raw mode, alternate screen, hidden cursor)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/profullstack/hqtui/security/advisories/new
+    about: Report privately. Please do not open a public issue — see SECURITY.md.
+  - name: Documentation
+    url: https://hqtui.com/docs
+    about: The API reference and guides.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,21 @@
+name: Feature request
+description: A widget, an option, or a capability that is missing.
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What are you trying to build
+      description: The dashboard or app you have in mind, not the API you imagine for it.
+    validations:
+      required: true
+  - type: textarea
+    id: today
+    attributes:
+      label: What you do today
+      description: The workaround, if there is one — including drawing straight onto the surface.
+  - type: textarea
+    id: shape
+    attributes:
+      label: What the API might look like
+      render: ts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,52 @@ jobs:
           registry-url: https://registry.npmjs.org
       - run: bun install --frozen-lockfile
       - run: bun run typecheck && bun test packages/hqtui/test && bun run build
+      # Nothing tied the release tag to what actually gets published, so a tag
+      # could ship a version it does not name. This runs on every trigger, not
+      # only `release`: a workflow_dispatch publishes just as readily, and
+      # gating the check on the event left that path unchecked. The ref goes
+      # through the environment rather than the shell, as the dist-tag does.
+      - name: Check the versions being published
+        env:
+          RELEASE_REF: ${{ github.ref_name }}
+          EVENT: ${{ github.event_name }}
+          DIST_TAG: ${{ inputs.tag || 'latest' }}
+        run: |
+          lib="$(node -p "require('./packages/hqtui/package.json').version")"
+          demo="$(node -p "require('./apps/demo/package.json').version")"
+
+          # Both are published together from one commit, on every trigger.
+          if [ "$lib" != "$demo" ]; then
+            echo "the two packages disagree about the version being published:"
+            echo "  packages/hqtui  $lib"
+            echo "  apps/demo       $demo"
+            exit 1
+          fi
+
+          # A prerelease must not become what `npm install` resolves to.
+          case "$lib" in
+            *-*)
+              if [ "$DIST_TAG" = "latest" ]; then
+                echo "$lib is a prerelease and would be published as 'latest'."
+                echo "re-run with a dist-tag such as 'next'."
+                exit 1
+              fi
+              echo "prerelease $lib publishing under dist-tag '$DIST_TAG'"
+              ;;
+          esac
+
+          # On a release the tag names the version; on a dispatch ref_name is a
+          # branch, so there is nothing to compare it against.
+          if [ "$EVENT" = "release" ]; then
+            tag="${RELEASE_REF#v}"
+            if [ "$tag" != "$lib" ]; then
+              echo "release tag '$RELEASE_REF' does not name the version it would publish ($lib)"
+              exit 1
+            fi
+            echo "tag '$RELEASE_REF' matches both packages at $lib"
+          else
+            echo "$EVENT: publishing $lib under dist-tag '$DIST_TAG'"
+          fi
       # `id-token: write` above is what provenance needs, but without the flag
       # nothing is attested — the permission was granted and unused.
       #


### PR DESCRIPTION
`.github/` held two workflows and nothing else.

## A release could ship a version it does not name

Nothing tied the tag to the packages being published, so tagging `v0.2.0` with `package.json` still at `0.1.9` published `0.1.9` under that release.

The check runs on **every trigger**, not only `release`. Gating it on the event left `workflow_dispatch` — the ordinary republish path, and unguarded on both publish steps — publishing whatever the manifests happened to say. On a dispatch there's no tag to compare against, so what it *can* check there is that the two packages agree and that a prerelease isn't about to become `latest`.

That last one matters: `DIST_TAG` resolves to `latest` on a release event, so a GitHub pre-release of `v0.2.0-rc.1` previously passed a version-equality check and became what `npm install` gives you. It now requires an explicit dist-tag.

Exercised across every path:

```
release v0.1.9, both at 0.1.9            pass
release v0.2.0, packages at 0.1.9        fail — tag does not name 0.1.9
release v0.1.9, packages disagree        fail — packages disagree
release v0.2.0-rc.1 -> latest            fail — prerelease would take latest
release v0.2.0-rc.1 -> next              pass
workflow_dispatch (previously skipped)   pass
workflow_dispatch, packages disagree     fail
workflow_dispatch prerelease -> latest   fail
```

The ref travels through `env:` rather than the shell, as the dist-tag already does.

## Issue templates

A bug form asking for the four things every terminal bug needs — version, runtime, terminal, and whether the terminal was left unusable — leading with the headless renderer, since a reproduction that needs no TTY is the one a maintainer can actually run. A feature form asking what someone is building rather than what API they imagine. A config routing vulnerabilities to the private advisory form SECURITY.md names, rather than a public issue.

## CODEOWNERS

Nothing requested review from anyone. This names `@ralyodio`, with the library and the security-relevant files called out separately. It's a guess at what you want — adjust or delete it.

`bun run typecheck && bun test` pass (131 tests); all workflow and template YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
