### PR TITLE
Stop refreshes stacking, bound the interval, and prune departed interfaces

### DIFF
--- a/apps/demo/src/main.ts
+++ b/apps/demo/src/main.ts
@@ -9,6 +9,7 @@
  */
 import { createApp, themeList, themes, type KeyEvent } from "@profullstack/hqtui";
 import { createCollector } from "./system/index.ts";
+import { intervalMs } from "./options.ts";
 import { createState, focusedPane, moveSelection, SCREENS, type ScreenName } from "./state.ts";
 import {
   componentsScreen, dashboardScreen, graphicsScreen, inputScreen, networkScreen, servicesScreen,
@@ -46,7 +47,7 @@ function parseArgs(argv: string[]): Options {
       case "--fps": options.fps = Number(value) || 30; i++; break;
       case "--theme": options.theme = value ?? "dark"; i++; break;
       case "--screen": options.screen = (value as ScreenName) ?? "dashboard"; i++; break;
-      case "--interval": options.interval = Number(value) || 1000; i++; break;
+      case "--interval": options.interval = intervalMs(value); i++; break;
       case "-h":
       case "--help": printHelp(); process.exit(0);
       case "-v":
@@ -112,14 +113,33 @@ async function main(): Promise<void> {
   });
 
   // Metrics refresh on their own clock; rendering runs at the frame rate.
-  const dt = options.interval / 1000;
+  // One refresh at a time. Collecting can outrun the interval — the tick-15 path
+  // alone allows journalctl five seconds — and every concurrent call mutates the
+  // same sample, the same previous-counter state, and the same tick counter that
+  // drives the staggered cadences, while spawning its own ps, ss, df and
+  // journalctl.
+  let refreshing = false;
+  let lastRefreshAt = Date.now();
   const poll = setInterval(() => {
-    if (state.paused) return;
-    void collector.refresh(dt).then(() => {
-      state.sample = collector.current();
-      state.sensorNote = collector.sensorNote ?? state.sensorNote;
-      app.invalidate();
-    });
+    if (state.paused || refreshing) return;
+    // Every rate is a counter delta divided by this, so it has to be the time
+    // that actually passed. A fixed interval overstated every rate by the skip
+    // factor whenever a refresh outran its tick — and `sh()` alone allows four
+    // seconds per command.
+    const now = Date.now();
+    const elapsed = Math.max(0.001, (now - lastRefreshAt) / 1000);
+    lastRefreshAt = now;
+    refreshing = true;
+    void collector
+      .refresh(elapsed)
+      .then(() => {
+        state.sample = collector.current();
+        state.sensorNote = collector.sensorNote ?? state.sensorNote;
+        app.invalidate();
+      })
+      .finally(() => {
+        refreshing = false;
+      });
   }, options.interval);
   poll.unref?.();
 

--- a/apps/demo/src/options.ts
+++ b/apps/demo/src/options.ts
@@ -1,0 +1,20 @@
+/**
+ * Option parsing that is worth testing on its own, kept out of main.ts because
+ * importing that module starts the dashboard.
+ */
+
+/**
+ * A refresh interval `setInterval` will honour.
+ *
+ * Node resets any delay outside [1, 2^31-1] — and NaN, and Infinity — to *one
+ * millisecond*, so clamping only the floor leaves the failure wide open at the
+ * top. `--interval 1e12` asks for one refresh every thirty-one years and gets a
+ * one-millisecond loop forking ps, ss and journalctl. `--interval Infinity`
+ * additionally makes the elapsed time infinite and every rate derived from it
+ * NaN.
+ */
+export function intervalMs(value: string | undefined): number {
+  const requested = Number(value);
+  if (!Number.isFinite(requested)) return 1000;
+  return Math.min(3_600_000, Math.max(100, Math.round(requested)));
+}

--- a/apps/demo/src/system/linux-telemetry.ts
+++ b/apps/demo/src/system/linux-telemetry.ts
@@ -155,6 +155,7 @@ export async function interfaces(dt: number, history: Map<string, Interface>): P
   if (!netdev) return [];
   const addresses = os.networkInterfaces();
   const out: Interface[] = [];
+  const seen = new Set<string>();
 
   for (const line of netdev.split("\n").slice(2)) {
     const match = /^\s*([\w.@-]+):\s*(.*)$/.exec(line);
@@ -172,6 +173,7 @@ export async function interfaces(dt: number, history: Map<string, Interface>): P
     const txRate = previous && txBytes >= previous[1] ? (txBytes - previous[1]) / dt : 0;
     previousInterfaces[name] = [rxBytes, txBytes];
 
+    seen.add(name);
     const address = (addresses[name] ?? []).find((a) => a.family === "IPv4");
     const existing = history.get(name);
     const entry: Interface = {
@@ -194,6 +196,16 @@ export async function interfaces(dt: number, history: Map<string, Interface>): P
     history.set(name, entry);
     out.push(entry);
   }
+  // Both maps are keyed by interface name and neither was ever pruned. On a
+  // container host the veth* names churn constantly, and each retained entry
+  // holds two 240-element history arrays — unbounded growth over an uptime.
+  for (const name of Object.keys(previousInterfaces)) {
+    if (!seen.has(name)) delete previousInterfaces[name];
+  }
+  for (const name of history.keys()) {
+    if (!seen.has(name)) history.delete(name);
+  }
+
   return out;
 }
 

--- a/apps/demo/test/options.test.ts
+++ b/apps/demo/test/options.test.ts
@@ -1,0 +1,23 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { intervalMs } from "../src/options.ts";
+
+test("the refresh interval is one setInterval will honour", () => {
+  // Node resets any delay outside [1, 2^31-1], and NaN and Infinity, to ONE
+  // millisecond. Clamping only the floor left the top wide open: `1e12` asks
+  // for a refresh every thirty-one years and got a 1ms loop forking ps, ss and
+  // journalctl, and `Infinity` additionally made every derived rate NaN.
+  const MAX_TIMEOUT = 2 ** 31 - 1;
+  for (const input of ["1e12", "Infinity", "-Infinity", "NaN", "abc", "-500", "0", "", undefined]) {
+    const ms = intervalMs(input);
+    assert.ok(Number.isFinite(ms), `${input} -> ${ms}`);
+    assert.ok(ms >= 100 && ms <= MAX_TIMEOUT, `${input} -> ${ms} is outside what setInterval honours`);
+  }
+  // Reasonable values pass through untouched.
+  assert.equal(intervalMs("1000"), 1000);
+  assert.equal(intervalMs("250"), 250);
+  assert.equal(intervalMs("60000"), 60000);
+  // And the clamps are where they say they are.
+  assert.equal(intervalMs("1"), 100);
+  assert.equal(intervalMs("99999999"), 3_600_000);
+});


### PR DESCRIPTION
Four ways the demo's collection loop misbehaves over a long uptime. All verified against a real Linux `/proc` in a container.

## Refreshes could run concurrently on one shared sample

`setInterval` fired `collector.refresh()` unconditionally and voided the promise. Collection can outrun the interval — the tick-15 path alone allows `journalctl` five seconds — and each concurrent call mutates the same sample, the same previous-counter state behind every rate, and the same tick counter driving the staggered cadences, while spawning its own `ps`, `ss`, `df` and `journalctl`.

One at a time now. Measured with a 40 ms interval against a 160 ms refresh: `started=6 maxConcurrent=1`, where the unguarded loop reached 4.

## The interval was clamped at one end only

`Math.max(100, Number(value) || 1000)` looked like it closed this, and didn't. Node resets any delay outside `[1, 2^31-1]` — **and NaN, and Infinity** — to *one millisecond*:

```
--interval 1e12      -> setInterval uses 1ms   (2,015 processes forked in 3s)
--interval Infinity  -> setInterval uses 1ms
--interval NaN       -> setInterval uses 1ms
```

`Infinity` also made the elapsed time infinite, and with it every derived number NaN: `cpu.total=NaN mem.used=NaN net.down=NaN`.

Bounded at both ends now, in `options.ts` so it can be tested without importing `main.ts` and starting the dashboard.

## Every rate was overstated whenever a refresh outran its tick

`dt` was the interval that was *asked* for, not the time that passed — while the new in-flight guard makes the real gap a multiple of it:

```
refresh cost | dt handed to collector | actual gap | rates overstated by
      300 ms |                   1 s  |    1003 ms |               x1.00
     1200 ms |                   1 s  |    2005 ms |               x2.00
     2500 ms |                   1 s  |    3004 ms |               x3.00
```

That reaches disk throughput, network up/down, per-interface rx/tx, context switches, interrupts and forks. CPU% is unaffected — it uses idle/total deltas with no `dt`. It's measured now: worst error **0.0%** against 100% before.

## Interface history grew for ever

`interfaceHistory` and the module-global `previousInterfaces` are keyed by interface name and were never pruned. On a container host the `veth*` names churn constantly and each retained entry holds two 240-element arrays.

Both are pruned to what `/proc/net/dev` still lists. Seeded with 5,000 departed interfaces against a real `/proc`, one refresh brought the map back to the 10 that exist. `lo` is skipped before either map is written, so pruning it is a no-op.

One cosmetic consequence worth naming: an interface that flaps loses its 240-sample sparkline and restarts. It isn't rendered while absent, so nothing displays inconsistently.

`bun run typecheck && bun test` pass — 132 tests on macOS and Linux aarch64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
