### PR TITLE
Build the library before typechecking what depends on it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ jobs:
         with:
           bun-version: latest
       - run: bun install --frozen-lockfile
+      # `typecheck` builds the library itself, because apps/demo and examples
+      # resolve `@profullstack/hqtui` through its published `types`, which point
+      # into dist. Running it before Build in a clean checkout — as CI does —
+      # left them with no types to find.
       - name: Typecheck
         run: bun run typecheck
       - name: Test

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "bench": "bun apps/benchmark/src/main.ts",
     "test": "bun test packages/hqtui/test apps/demo/test",
     "test:node": "node --test packages/hqtui/test/*.test.ts apps/demo/test/*.test.ts",
-    "typecheck": "bun run typecheck:lib && bun run typecheck:demo && bun run typecheck:examples",
+    "typecheck": "bun run typecheck:lib && bun run build && bun run typecheck:demo && bun run typecheck:examples",
     "typecheck:lib": "cd packages/hqtui && bun run typecheck",
     "typecheck:demo": "cd apps/demo && bun x tsc -p tsconfig.check.json",
     "typecheck:examples": "cd examples && bun x tsc -p tsconfig.json"


### PR DESCRIPTION
**CI on `main` is currently failing, and has been since #10 — which is mine.** This fixes it.

## What broke

#10 extended `typecheck` to cover `apps/demo` and `examples`. Both import `@profullstack/hqtui` by package name, which resolves through the library's `types` field into `dist` — so typechecking them requires the library to have been built.

`ci.yml` runs Typecheck *before* Build. In a clean checkout there is nothing to resolve:

```
src/state.ts(1,28): error TS2307: Cannot find module '@profullstack/hqtui'
... 17 such errors across apps/demo and examples
```

Reproduced exactly, in a fresh shallow clone with `bun install --frozen-lockfile` and no `dist`.

## Why it wasn't caught

Two reasons, both worth stating:

1. It passed locally only because a `dist` from an earlier build was always lying around. The script had a hidden dependency on build state I never ran without.
2. Workflows on fork PRs were still awaiting maintainer approval when #10 was reviewed, so CI never actually ran on it.

## The fix

`typecheck` now builds the library between checking it and checking its consumers:

```
typecheck:lib  ->  build  ->  typecheck:demo  ->  typecheck:examples
```

That makes the script correct whatever order a caller runs things in, rather than depending on CI's step ordering — which is what made this invisible in the first place.

## Verified

Clean shallow clone, `dist` absent:

```
bun run typecheck   PASSES   (previously 17 unresolved-module errors)
bun test            131 pass, 0 fail
bun run build       ok
```

## Please merge this first

My other open PRs (#20–#25) are all red for this same pre-existing reason, not for anything in their own diffs. Once this lands I'll rebase them and they should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
