### PR TITLE
Link the board from the nav, the footer and the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ btop-grade dashboards with a one-import API, dark by default, zero runtime depen
 <p align="center">
   <a href="https://hqtui.com">hqtui.com</a> ·
   <a href="https://www.npmjs.com/package/@profullstack/hqtui">npm</a> ·
-  <a href="https://hqtui.com/docs">docs</a>
+  <a href="https://hqtui.com/docs">docs</a> ·
+  <a href="https://bbs.hqtui.com/">forum</a>
 </p>
 
 ![HQTUI dashboard](./assets/screens/dashboard.png)
@@ -193,6 +194,15 @@ apps/web         hqtui.com
 examples/        small, focused programs
 docs/            the original PRD
 ```
+
+## Community
+
+Questions, showcases and bug reports have a home at
+**[bbs.hqtui.com](https://bbs.hqtui.com/)** — a board running
+[tsbb](https://github.com/profullstack/tsbb), themed to match this project. It
+serves no client-side JavaScript, and `tsbb-tui` reads and posts to it from a
+terminal, which felt like the right place for a terminal UI library to hold its
+conversations.
 
 ## Runtimes
 

--- a/apps/web/components/site/nav.tsx
+++ b/apps/web/components/site/nav.tsx
@@ -42,6 +42,12 @@ export function SiteNav() {
               {link.label}
             </Link>
           ))}
+          {/* A plain anchor, not next/link: the board is a separate origin on
+              its own subdomain, so there is no route for the router to
+              prefetch and nothing it could do with one. */}
+          <a href="https://bbs.hqtui.com" className="transition-colors hover:text-white">
+            BBS
+          </a>
         </div>
         <div className="ml-auto flex items-center gap-2">
           <Button
@@ -83,6 +89,7 @@ export function SiteFooter({ views }: { views?: number }) {
           <span>MIT</span>
         </div>
         <div className="flex flex-wrap gap-4 sm:ml-auto">
+          <a className="hover:text-white" href="https://bbs.hqtui.com">BBS</a>
           <a className="hover:text-white" href="https://github.com/profullstack/hqtui">GitHub</a>
           <a className="hover:text-white" href="https://www.npmjs.com/package/@profullstack/hqtui">npm</a>
           <Link className="hover:text-white" href="/docs">Docs</Link>


### PR DESCRIPTION
[bbs.hqtui.com](https://bbs.hqtui.com/) is live — a [tsbb](https://github.com/profullstack/tsbb) board on the new `terminal` skin, wearing this project's wordmark and `#5fff87` accent. Nothing pointed at it.

- **Nav**: a `BBS` entry beside Features / Showcase / Docs / Themes / Performance.
- **Footer**: `BBS`, first in the link row.
- **README**: `forum` in the header link row, and a short Community section.

The nav entry is a plain `<a>` rather than `next/link`: the board is a separate origin on its own subdomain, so there is no route for the router to prefetch and nothing it could do with one.

`next build` passes (the workspace package has to be built first in a fresh worktree, or `@profullstack/hqtui` will not resolve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQRBzkLAusnFQHWMjgBLDZ