### PR TITLE
0.1.10: one refresh at a time, a bounded interval, and pruned interface history

### DIFF
--- a/apps/benchmark/package.json
+++ b/apps/benchmark/package.json
@@ -7,6 +7,6 @@
     "start": "bun src/main.ts"
   },
   "dependencies": {
-    "@profullstack/hqtui": "^0.1.9"
+    "@profullstack/hqtui": "^0.1.10"
   }
 }

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@profullstack/hqtui-demo",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "The HQTUI reference dashboard: a btop-grade terminal system monitor. Runs on real system metrics or a deterministic simulation.",
   "license": "MIT",
   "type": "module",
@@ -27,7 +27,7 @@
     "audit:scroll": "bun scripts/scrollaudit.ts"
   },
   "dependencies": {
-    "@profullstack/hqtui": "^0.1.9"
+    "@profullstack/hqtui": "^0.1.10"
   },
   "publishConfig": {
     "access": "public"

--- a/apps/demo/src/main.ts
+++ b/apps/demo/src/main.ts
@@ -51,7 +51,7 @@ function parseArgs(argv: string[]): Options {
       case "-h":
       case "--help": printHelp(); process.exit(0);
       case "-v":
-      case "--version": console.log("hqtui-demo 0.1.9"); process.exit(0);
+      case "--version": console.log("hqtui-demo 0.1.10"); process.exit(0);
     }
   }
   return options;

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -140,7 +140,7 @@ export default async function Home() {
               className="mx-auto mb-6 w-[22rem] max-w-full sm:w-[30rem]"
             />
             <Badge variant="secondary" className="mb-5 font-mono text-xs">
-              v0.1.9 · MIT · zero runtime dependencies
+              v0.1.10 · MIT · zero runtime dependencies
             </Badge>
             <h1 className="sr-only">HQTUI — High Quality Terminal UI for TypeScript</h1>
             <p className="text-balance text-3xl font-bold tracking-tight sm:text-5xl">

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@base-ui/react": "1.7.0",
-    "@profullstack/hqtui": "^0.1.9",
+    "@profullstack/hqtui": "^0.1.10",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "lucide-react": "1.37.0",

--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
     },
     "apps/demo": {
       "name": "@profullstack/hqtui-demo",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "bin": {
         "hqtui-demo": "./src/main.ts",
       },
@@ -34,7 +34,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@base-ui/react": "1.7.0",
-        "@profullstack/hqtui": "^0.1.9",
+        "@profullstack/hqtui": "^0.1.10",
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
         "lucide-react": "1.37.0",
@@ -58,12 +58,12 @@
       "name": "@profullstack/hqtui-examples",
       "version": "0.1.0",
       "dependencies": {
-        "@profullstack/hqtui": "^0.1.9",
+        "@profullstack/hqtui": "^0.1.10",
       },
     },
     "packages/hqtui": {
       "name": "@profullstack/hqtui",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "bin": {
         "hqtui": "./bin/hqtui.mjs",
       },

--- a/examples/package.json
+++ b/examples/package.json
@@ -4,6 +4,6 @@
   "version": "0.1.0",
   "type": "module",
   "dependencies": {
-    "@profullstack/hqtui": "^0.1.9"
+    "@profullstack/hqtui": "^0.1.10"
   }
 }

--- a/packages/hqtui/package.json
+++ b/packages/hqtui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@profullstack/hqtui",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "High Quality Terminal UI for TypeScript. btop-grade dashboards with a one-import API, dark by default, zero runtime dependencies.",
   "license": "MIT",
   "type": "module",

--- a/packages/hqtui/src/cli.ts
+++ b/packages/hqtui/src/cli.ts
@@ -13,7 +13,7 @@ import { detectCapabilities } from "./capabilities.ts";
 import { themeList, themes } from "./theme.ts";
 import { BrailleCanvas } from "./graphics/braille.ts";
 
-const VERSION = "0.1.9";
+const VERSION = "0.1.10";
 
 function help(): void {
   console.log(`hqtui ${VERSION} — High Quality Terminal UI for TypeScript


### PR DESCRIPTION
Bumps every package to 0.1.10 so #30 (the rebase of #25 by @anjaustin) reaches npm. That change stops demo refreshes stacking, bounds `--interval` at both ends, measures rates against the time that actually passed, and prunes departed interfaces from the two per-interface maps.

Every hand-written version string moves together, as `version.test.ts` requires: the library's `package.json` and `cli.ts`, the demo's `package.json` and `--version` output, the site badge, and the `@profullstack/hqtui` ranges in the demo, site, benchmark and examples packages. The lockfile's two workspace ranges are updated by hand because `bun install` leaves a workspace-resolved range untouched when the resolution does not change.

Locally: `bun run typecheck` clean, 162 tests pass under both bun and node, `bun install --frozen-lockfile` reports no changes.

Once this merges, `v0.1.10` gets tagged on the merge commit and the release fires `publish.yml`, which now has the `NPM_TOKEN` secret it needs. This is the first release cut through that workflow; 0.1.9 was published by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5n3MdiHjRVDiqJXMSgQ9j
