### PR TITLE
0.1.11: build the demo with the types it publishes with

### DIFF
--- a/apps/benchmark/package.json
+++ b/apps/benchmark/package.json
@@ -7,6 +7,6 @@
     "start": "bun src/main.ts"
   },
   "dependencies": {
-    "@profullstack/hqtui": "^0.1.10"
+    "@profullstack/hqtui": "^0.1.11"
   }
 }

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@profullstack/hqtui-demo",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "The HQTUI reference dashboard: a btop-grade terminal system monitor. Runs on real system metrics or a deterministic simulation.",
   "license": "MIT",
   "type": "module",
@@ -27,7 +27,7 @@
     "audit:scroll": "bun scripts/scrollaudit.ts"
   },
   "dependencies": {
-    "@profullstack/hqtui": "^0.1.10"
+    "@profullstack/hqtui": "^0.1.11"
   },
   "publishConfig": {
     "access": "public"

--- a/apps/demo/src/main.ts
+++ b/apps/demo/src/main.ts
@@ -51,7 +51,7 @@ function parseArgs(argv: string[]): Options {
       case "-h":
       case "--help": printHelp(); process.exit(0);
       case "-v":
-      case "--version": console.log("hqtui-demo 0.1.10"); process.exit(0);
+      case "--version": console.log("hqtui-demo 0.1.11"); process.exit(0);
     }
   }
   return options;

--- a/apps/demo/tsconfig.check.json
+++ b/apps/demo/tsconfig.check.json
@@ -2,8 +2,10 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": true,
-    "rootDir": ".",
-    "types": ["node"]
+    "rootDir": "."
   },
-  "include": ["src/**/*.ts", "test/**/*.ts"]
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts"
+  ]
 }

--- a/apps/demo/tsconfig.json
+++ b/apps/demo/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["ES2023"],
+    "lib": [
+      "ES2023"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "strict": true,
@@ -13,7 +15,12 @@
     "outDir": "dist",
     "rootDir": "src",
     "sourceMap": true,
-    "declaration": false
+    "declaration": false,
+    "types": [
+      "node"
+    ]
   },
-  "include": ["src/**/*.ts"]
+  "include": [
+    "src/**/*.ts"
+  ]
 }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -140,7 +140,7 @@ export default async function Home() {
               className="mx-auto mb-6 w-[22rem] max-w-full sm:w-[30rem]"
             />
             <Badge variant="secondary" className="mb-5 font-mono text-xs">
-              v0.1.10 · MIT · zero runtime dependencies
+              v0.1.11 · MIT · zero runtime dependencies
             </Badge>
             <h1 className="sr-only">HQTUI — High Quality Terminal UI for TypeScript</h1>
             <p className="text-balance text-3xl font-bold tracking-tight sm:text-5xl">

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@base-ui/react": "1.7.0",
-    "@profullstack/hqtui": "^0.1.10",
+    "@profullstack/hqtui": "^0.1.11",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "lucide-react": "1.37.0",

--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
     },
     "apps/demo": {
       "name": "@profullstack/hqtui-demo",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "bin": {
         "hqtui-demo": "./src/main.ts",
       },
@@ -34,7 +34,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@base-ui/react": "1.7.0",
-        "@profullstack/hqtui": "^0.1.10",
+        "@profullstack/hqtui": "^0.1.11",
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
         "lucide-react": "1.37.0",
@@ -58,12 +58,12 @@
       "name": "@profullstack/hqtui-examples",
       "version": "0.1.0",
       "dependencies": {
-        "@profullstack/hqtui": "^0.1.10",
+        "@profullstack/hqtui": "^0.1.11",
       },
     },
     "packages/hqtui": {
       "name": "@profullstack/hqtui",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "bin": {
         "hqtui": "./bin/hqtui.mjs",
       },

--- a/examples/package.json
+++ b/examples/package.json
@@ -4,6 +4,6 @@
   "version": "0.1.0",
   "type": "module",
   "dependencies": {
-    "@profullstack/hqtui": "^0.1.10"
+    "@profullstack/hqtui": "^0.1.11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node": ">=22.6"
   },
   "scripts": {
-    "build": "cd packages/hqtui && bun run build",
+    "build": "cd packages/hqtui && bun run build && cd ../../apps/demo && bun run build",
     "demo": "bun apps/demo/src/main.ts",
     "bench": "bun apps/benchmark/src/main.ts",
     "test": "bun test packages/hqtui/test apps/demo/test apps/web/test",

--- a/packages/hqtui/package.json
+++ b/packages/hqtui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@profullstack/hqtui",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "High Quality Terminal UI for TypeScript. btop-grade dashboards with a one-import API, dark by default, zero runtime dependencies.",
   "license": "MIT",
   "type": "module",

--- a/packages/hqtui/src/cli.ts
+++ b/packages/hqtui/src/cli.ts
@@ -13,7 +13,7 @@ import { detectCapabilities } from "./capabilities.ts";
 import { themeList, themes } from "./theme.ts";
 import { BrailleCanvas } from "./graphics/braille.ts";
 
-const VERSION = "0.1.10";
+const VERSION = "0.1.11";
 
 function help(): void {
   console.log(`hqtui ${VERSION} — High Quality Terminal UI for TypeScript


### PR DESCRIPTION
The v0.1.10 release published `@profullstack/hqtui` and then failed on the demo. Its `prepublishOnly` compiles `apps/demo` with `tsconfig.json`, which never named its types, so TypeScript 7 built it with no Node globals and stopped on the first `process`:

```
src/main.ts(52,35): error TS2591: Cannot find name 'process'.
src/main.ts(123,16): error TS2304: Cannot find name 'setInterval'.
```

CI never saw this. It typechecks the demo through `tsconfig.check.json`, which does name the types, and nothing built the demo, so CI was green on a package that cannot be built.

## What changes

- `"types": ["node"]` moves into `apps/demo/tsconfig.json`, where the build reads it. The check config inherits it instead of carrying its own copy.
- The root `build` script builds the demo after the library, so CI's Build step and the publish workflow's pre-check both run the exact compile that publishing runs.
- Every package moves to 0.1.11. The publish workflow refuses to republish a version, and it requires the two packages to agree, so this is a new version rather than a retry.

## Verified

The failure reproduces on main with `cd apps/demo && bun x tsc -p tsconfig.json`. With this branch:

| step | result |
| --- | --- |
| `bun run typecheck` | clean |
| `bun run build` (library, then demo) | clean |
| `node apps/demo/bin/hqtui-demo.mjs --version` | prints `hqtui-demo 0.1.11` |
| `bun test` and `node --test` | 162 pass each |
| `bun install --frozen-lockfile` | no changes |

`v0.1.11` gets tagged on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5n3MdiHjRVDiqJXMSgQ9j
