### PR TITLE
Show all five HQTUI languages on the website and announce the native ports

### DIFF
--- a/apps/web/app/docs/page.tsx
+++ b/apps/web/app/docs/page.tsx
@@ -5,12 +5,14 @@ import { Terminal } from "@/components/site/terminal";
 
 import { recordView } from "@/lib/db";
 import { Separator } from "@/components/ui/separator";
+import { LANGUAGES, PORTS } from "@/lib/languages";
 
 export const dynamic = "force-dynamic";
 
 export const metadata = { title: "Docs" };
 
 const SECTIONS = [
+  { id: "languages", label: "Choose a language" },
   { id: "install", label: "Install" },
   { id: "first-app", label: "Your first app" },
   { id: "layout", label: "Layout" },
@@ -60,13 +62,39 @@ export default async function Docs() {
         <main className="min-w-0 flex-1">
           <h1 className="text-4xl font-bold tracking-tight">Documentation</h1>
           <P>
-            HQTUI is a rendering library for building terminal applications in TypeScript. It
-            owns the terminal directly — ANSI sequences, a typed-array framebuffer, differential
-            rendering, Braille graphics and truecolor — with no ncurses, no browser DOM, no
-            React, and no native addon.
+            HQTUI builds terminal applications in TypeScript, Rust, Go, Python and Zig.
+            All five implementations provide differential rendering, Braille graphics,
+            truecolor, widgets and headless testing.
           </P>
 
-          <H2 id="install">Install</H2>
+          <H2 id="languages">Choose a language</H2>
+          <div className="mt-4 flex flex-wrap gap-3">
+            {LANGUAGES.map((language) => (
+              <Link key={language.id} href={language.href} className="rounded-lg border border-white/15 px-4 py-2 text-[#5fff87] hover:bg-white/5">{language.name}</Link>
+            ))}
+          </div>
+          <P>
+            Rust, Go, Python and Zig are native ports with no JavaScript runtime requirement.
+            Start from the source checkout below; each command renders a dashboard without a TTY.
+            Zig requires version 0.16. Each port&apos;s README covers its API, interactive examples
+            and platform-specific terminal behavior.
+          </P>
+          <Code className="mt-4" code="git clone https://github.com/profullstack/hqtui.git" />
+          <div className="mt-6 grid gap-6 xl:grid-cols-2">
+            {PORTS.map((port) => (
+              <section key={port.id} id={port.id} className="min-w-0 scroll-mt-20">
+                <h3 className="text-xl font-bold">{port.name}</h3>
+                <Code className="mt-3" code={`cd hqtui/ports/${port.id}\n${port.command}`} />
+                <a href={`https://github.com/profullstack/hqtui/tree/main/ports/${port.id}`} className="mt-3 inline-block text-sm text-[#5fff87] underline underline-offset-4">{port.name} API, examples and setup</a>
+              </section>
+            ))}
+          </div>
+          <P>
+            <Link href="/blog/native-rust-go-python-zig" className="text-[#5fff87] underline underline-offset-4">Read how the ports share a conformance corpus</Link>.
+            The API guide below describes the TypeScript reference implementation.
+          </P>
+
+          <H2 id="install">Install TypeScript</H2>
           <Code className="mt-4" code={`bun add @profullstack/hqtui   # Bun is the default runtime
 npm  add @profullstack/hqtui   # Node 22.6+ works unchanged`} />
           <P>

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -7,24 +7,25 @@ const sans = Geist({ variable: "--font-sans", subsets: ["latin"] });
 const mono = Geist_Mono({ variable: "--font-mono", subsets: ["latin"] });
 
 const description =
-  "High Quality Terminal UI for TypeScript. btop-grade terminal dashboards with a one-import API, dark by default, zero runtime dependencies.";
+  "High Quality Terminal UI for TypeScript, Rust, Go, Python and Zig. Native implementations, dark themes, Braille graphics and zero runtime dependencies.";
+const title = "HQTUI — Terminal UI for TypeScript, Rust, Go, Python and Zig";
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://hqtui.com"),
   title: {
-    default: "HQTUI — High Quality Terminal UI for TypeScript",
+    default: title,
     template: "%s — HQTUI",
   },
   description,
   keywords: [
     "tui", "terminal ui", "typescript", "bun", "node", "btop", "dashboard",
-    "ansi", "braille", "truecolor", "framebuffer", "cli",
+    "ansi", "braille", "truecolor", "framebuffer", "cli", "rust", "go", "python", "zig",
   ],
   authors: [{ name: "Profullstack, Inc.", url: "https://profullstack.com" }],
   openGraph: {
     type: "website",
     url: "https://hqtui.com",
-    title: "HQTUI — High Quality Terminal UI for TypeScript",
+    title,
     description,
     siteName: "HQTUI",
     images: [
@@ -34,7 +35,7 @@ export const metadata: Metadata = {
   appleWebApp: { title: "HQTUI", statusBarStyle: "black-translucent" },
   twitter: {
     card: "summary_large_image",
-    title: "HQTUI — High Quality Terminal UI for TypeScript",
+    title,
     description,
     images: ["/shots/dashboard.png"],
   },

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -136,7 +136,7 @@ export default async function Home() {
               High Quality Terminal UI for TypeScript, Rust, Go, Python and Zig
             </p>
             <Badge variant="secondary" className="mb-5 font-mono text-xs">
-              5 languages · MIT · zero runtime dependencies
+              v0.1.11 · 5 languages · MIT
             </Badge>
             <p className="text-balance text-3xl font-bold tracking-tight sm:text-5xl">
               Terminal dashboards that

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,4 +1,3 @@
-import Image from "next/image";
 import Link from "next/link";
 import { ArrowRight, Boxes, Cpu, Gauge, Keyboard, Palette, TerminalSquare, TestTube2, Zap } from "lucide-react";
 
@@ -14,6 +13,7 @@ import { ThemeGallery, type ThemeCard } from "@/components/site/theme-gallery";
 
 import { recordView, themeVotes, totalViews } from "@/lib/db";
 import { themes } from "@profullstack/hqtui";
+import { LANGUAGES } from "@/lib/languages";
 
 export const dynamic = "force-dynamic";
 
@@ -65,7 +65,7 @@ const FEATURES = [
   {
     icon: Cpu,
     title: "Zero dependencies",
-    body: "The library imports nothing. No ncurses, no native addon, no browser DOM, no React. It makes no network requests and spawns no subprocesses, ever.",
+    body: "The TypeScript library has zero runtime dependencies. The Rust, Go, Python and Zig ports use only their standard libraries. No ncurses, browser DOM or React.",
   },
   {
     icon: TerminalSquare,
@@ -131,18 +131,13 @@ export default async function Home() {
         <div className="dot-grid absolute inset-0 opacity-40" aria-hidden />
         <div className="relative mx-auto max-w-7xl px-4 pb-16 pt-16 sm:px-6 sm:pt-24">
           <div className="mx-auto max-w-3xl text-center">
-            <Image
-              src="/logo.png"
-              alt="HQTUI — High Quality Terminal UI for TypeScript"
-              width={2172}
-              height={724}
-              priority
-              className="mx-auto mb-6 w-[22rem] max-w-full sm:w-[30rem]"
-            />
+            <h1 className="mb-3 font-mono text-7xl font-bold tracking-tight text-[#5fff87] sm:text-8xl">HQTUI</h1>
+            <p className="mb-6 text-balance text-lg text-white/70">
+              High Quality Terminal UI for TypeScript, Rust, Go, Python and Zig
+            </p>
             <Badge variant="secondary" className="mb-5 font-mono text-xs">
-              v0.1.11 · MIT · zero runtime dependencies
+              5 languages · MIT · zero runtime dependencies
             </Badge>
-            <h1 className="sr-only">HQTUI — High Quality Terminal UI for TypeScript</h1>
             <p className="text-balance text-3xl font-bold tracking-tight sm:text-5xl">
               Terminal dashboards that
               <span className="block bg-gradient-to-r from-[#5fff87] via-[#56d4dd] to-[#58a6ff] bg-clip-text text-transparent">
@@ -153,11 +148,14 @@ export default async function Home() {
               btop-grade dashboards with a one-import API. Own the terminal directly, render
               only what changed, and make beautiful graphics a first-class primitive.
             </p>
+            <Link href="/blog/native-rust-go-python-zig" className="mt-5 inline-flex items-center gap-2 text-sm text-[#5fff87] underline underline-offset-4">
+              New: native Rust, Go, Python and Zig ports <ArrowRight className="h-4 w-4 shrink-0" />
+            </Link>
             <div className="mx-auto mt-7 flex max-w-md flex-col gap-3">
               <InstallCommand command="bun add @profullstack/hqtui" />
               <div className="flex justify-center gap-3">
-                <Button size="lg" render={<Link href="/docs" />}>
-                  Get started <ArrowRight className="ml-1 h-4 w-4" />
+                <Button size="lg" render={<Link href="#languages" />}>
+                  Choose your language <ArrowRight className="ml-1 h-4 w-4" />
                 </Button>
                 <Button
                   size="lg"
@@ -187,7 +185,7 @@ export default async function Home() {
 
           <div className="mt-10 grid grid-cols-2 gap-4 text-center sm:grid-cols-4">
             {[
-              ["0.29 ms", "10% changed frame"],
+              ["0.29 ms", "TypeScript: 10% changed frame"],
               ["0", "runtime dependencies"],
               ["30+", "widgets"],
               ["9", "built-in themes"],
@@ -201,11 +199,33 @@ export default async function Home() {
         </div>
       </section>
 
+      <section id="languages" className="mx-auto max-w-7xl scroll-mt-14 px-4 pt-20 sm:px-6">
+        <h2 className="text-3xl font-bold tracking-tight">One terminal UI, five languages</h2>
+        <p className="mt-3 max-w-3xl text-white/60">
+          Build in TypeScript or use a native Rust, Go, Python or Zig implementation.
+          Each port includes the app loop, widgets, themes, input handling and a headless renderer.
+          The four native ports need no JavaScript runtime and use only their standard libraries.
+        </p>
+        <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-5">
+          {LANGUAGES.map((language) => (
+            <Link key={language.id} href={language.href} className="rounded-xl border border-white/10 bg-white/[0.02] p-5 transition-colors hover:border-[#5fff87]/50 focus-visible:outline-2 focus-visible:outline-[#5fff87]">
+              <h3 className="font-mono text-lg font-bold text-[#5fff87]">{language.name}</h3>
+              <p className="mt-3 text-sm leading-relaxed text-white/60">{language.description}</p>
+              <span className="mt-5 inline-flex items-center gap-1 text-sm">Get started <ArrowRight className="h-4 w-4" /></span>
+            </Link>
+          ))}
+        </div>
+        <p className="mt-5 text-sm text-white/60">
+          Shared conformance fixtures check cells, colors and escape bytes across implementations.{' '}
+          <Link href="/blog/native-rust-go-python-zig" className="text-[#5fff87] underline underline-offset-4">Read the launch article</Link>.
+        </p>
+      </section>
+
       {/* Quick start */}
       <section className="mx-auto max-w-7xl px-4 py-20 sm:px-6">
         <div className="grid items-center gap-10 lg:grid-cols-2">
           <div>
-            <h2 className="text-3xl font-bold tracking-tight">Ten lines to a real TUI</h2>
+            <h2 className="text-3xl font-bold tracking-tight">Start with TypeScript</h2>
             <p className="mt-3 text-white/60">
               <code className="rounded bg-white/5 px-1.5 py-0.5 font-mono text-sm">createApp()</code> already
               gives you a dark theme, truecolor with automatic fallback, mouse tracking, the

--- a/apps/web/components/site/nav.tsx
+++ b/apps/web/components/site/nav.tsx
@@ -12,6 +12,7 @@ function GithubMark() {
 }
 
 const LINKS = [
+  { href: "/#languages", label: "Languages" },
   { href: "/#features", label: "Features" },
   { href: "/showcase", label: "Showcase" },
   { href: "/docs", label: "Docs" },
@@ -37,7 +38,7 @@ export function SiteNav() {
             className="h-8 w-8"
           />
         </Link>
-        <div className="hidden items-center gap-5 text-sm text-white/60 md:flex">
+        <div className="hidden items-center gap-5 text-sm text-white/60 lg:flex">
           {LINKS.map((link) => (
             <Link key={link.href} href={link.href} className="transition-colors hover:text-white">
               {link.label}
@@ -51,6 +52,7 @@ export function SiteNav() {
           </a>
         </div>
         <div className="ml-auto flex items-center gap-2">
+          <Link href="/#languages" className="text-sm text-white/70 hover:text-white lg:hidden">Languages</Link>
           <Button
             variant="ghost"
             size="sm"
@@ -90,6 +92,7 @@ export function SiteFooter({ views }: { views?: number }) {
           <span>MIT</span>
         </div>
         <div className="flex flex-wrap gap-4 sm:ml-auto">
+          <Link className="hover:text-white" href="/#languages">Languages</Link>
           <a className="hover:text-white" href="https://bbs.hqtui.com">Discussions</a>
           <a className="hover:text-white" href="https://github.com/profullstack/hqtui">GitHub</a>
           <a className="hover:text-white" href="https://www.npmjs.com/package/@profullstack/hqtui">npm</a>

--- a/apps/web/content/blog/native-rust-go-python-zig.md
+++ b/apps/web/content/blog/native-rust-go-python-zig.md
@@ -1,0 +1,38 @@
+---
+title: HQTUI now speaks Rust, Go, Python and Zig
+date: 2026-09-06
+description: Four native implementations join TypeScript, with standard-library-only runtimes and shared fixtures that check rendering cell for cell.
+author: Profullstack
+---
+
+HQTUI now has native implementations in **Rust, Go, Python and Zig**, alongside the TypeScript reference. [PR #35](https://github.com/profullstack/hqtui/pull/35) merged all four ports on September 6. Each includes a terminal layer, app loop, builder API, widgets, themes, input handling and a headless renderer for testing.
+
+The ports run in their own languages. They require no Node runtime, and their runtime dependencies are limited to each language's standard library.
+
+## Pick your language
+
+- [TypeScript](/docs#install): the reference implementation, running on Bun, Node and Deno.
+- [Rust](/docs#rust): explicit ownership, with interaction IDs that let your app handle control events.
+- [Go](/docs#go): callbacks that close over application state, with pointers for optional values.
+- [Python](/docs#python): callbacks and compact arrays for the framebuffer's cell planes.
+- [Zig](/docs#zig): explicit context pointers and two frame/event arenas. Requires Zig 0.16.
+
+The [language setup guide](/docs#languages) has commands to run a dashboard from each port's source directory. Each also includes a minimal hello example and an interactive dashboard. The existing TypeScript package remains available as `@profullstack/hqtui` on npm.
+
+## The same screen, checked across languages
+
+The [shared conformance corpus](https://github.com/profullstack/hqtui/tree/main/ports/conformance) records expected output from the TypeScript implementation. Each port replays those fixtures and checks cells, colors and escape bytes.
+
+The corpus covers thirteen groups, including Unicode widths, layout, framebuffer writes, diff encoding, themes, borders, Braille rasterization and input parsing. It includes 53 widget scenes and 10 complete screen layouts. Testing the complete layout catches errors that an individually sized widget cannot reveal.
+
+All four ports include a screenshot example that renders the same dashboard, apart from its port label, without requiring an interactive terminal.
+
+## What carries over, and what differs
+
+The rendering model carries across languages: describe the screen, compute layout, draw into a framebuffer and emit the changes. Your application still owns its state.
+
+Interaction and terminal handling follow each language's facilities. Rust and Zig report interactions through IDs; Go and Python offer callbacks. Platform support and terminal setup differ by port. For example, Rust uses the system `stty` command to manage terminal modes. The individual READMEs document these details and show the idiomatic API.
+
+The [port roadmap](https://github.com/profullstack/hqtui/blob/main/ports/TARGETS.md) identifies C as the next candidate. C is planned; the implementations available now are TypeScript, Rust, Go, Python and Zig.
+
+[Choose your language](/docs#languages), explore the [source](https://github.com/profullstack/hqtui/tree/main/ports), or discuss what you are building on the [HQTUI board](https://bbs.hqtui.com/).

--- a/apps/web/lib/languages.ts
+++ b/apps/web/lib/languages.ts
@@ -1,0 +1,14 @@
+export const LANGUAGES = [
+  { name: "TypeScript", id: "typescript", description: "The reference implementation. Runs on Bun, Node and Deno.", href: "/docs#install" },
+  { name: "Rust", id: "rust", description: "Native Rust with explicit ownership and interaction IDs.", href: "/docs#rust" },
+  { name: "Go", id: "go", description: "Native Go with callbacks that close over your application state.", href: "/docs#go" },
+  { name: "Python", id: "python", description: "Native Python with callbacks and compact array-backed cell storage.", href: "/docs#python" },
+  { name: "Zig", id: "zig", description: "Native Zig 0.16 with explicit context and arena-managed frames.", href: "/docs#zig" },
+] as const;
+
+export const PORTS = [
+  { name: "Rust", id: "rust", command: "cargo run --example screenshot" },
+  { name: "Go", id: "go", command: "go run ./examples/screenshot" },
+  { name: "Python", id: "python", command: "python3 -m examples.screenshot" },
+  { name: "Zig", id: "zig", command: "zig build run-screenshot" },
+] as const;


### PR DESCRIPTION
PR #35 added native Rust, Go, Python and Zig implementations, but hqtui.com still described a TypeScript-only library. The homepage now presents all five languages with setup links, and the docs include verified source-checkout commands for each native port. Search and social metadata use the same language list.

Adds a launch article to the existing blog and RSS feed, describing the shared conformance corpus and linking to port APIs. The existing TypeScript guide stays clearly labeled, and the homepage's TypeScript benchmark is identified as such.

Validation: production Next.js build and TypeScript check passed; all 162 repository tests passed; homepage, docs, blog, article and RSS returned 200 with the language content; all four native dashboard commands ran successfully. Browser screenshots could not run because this host's Chromium lacks libatk-1.0.so.0.
