### PR TITLE
site: copyable demo commands per language, and the demo command moved to the hero

### DIFF
--- a/apps/web/app/docs/page.tsx
+++ b/apps/web/app/docs/page.tsx
@@ -1,11 +1,12 @@
 import Link from "next/link";
 import { Code } from "@/components/site/code";
+import { CommandBlock } from "@/components/site/command";
 import { SiteFooter, SiteNav } from "@/components/site/nav";
 import { Terminal } from "@/components/site/terminal";
 
 import { recordView } from "@/lib/db";
 import { Separator } from "@/components/ui/separator";
-import { LANGUAGES, PORTS } from "@/lib/languages";
+import { CLONE, LANGUAGES, PORTS } from "@/lib/languages";
 
 export const dynamic = "force-dynamic";
 
@@ -79,12 +80,12 @@ export default async function Docs() {
             Zig requires version 0.16. Each port&apos;s README covers its API, interactive examples
             and platform-specific terminal behavior.
           </P>
-          <Code className="mt-4" code="git clone https://github.com/profullstack/hqtui.git" />
+          <CommandBlock className="mt-4" command={CLONE} label="git clone" />
           <div className="mt-6 grid gap-6 xl:grid-cols-2">
             {PORTS.map((port) => (
               <section key={port.id} id={port.id} className="min-w-0 scroll-mt-20">
                 <h3 className="text-xl font-bold">{port.name}</h3>
-                <Code className="mt-3" code={`cd hqtui/ports/${port.id}\n${port.command}`} />
+                <CommandBlock className="mt-3" command={port.demo} label={port.name} />
                 <a href={`https://github.com/profullstack/hqtui/tree/main/ports/${port.id}`} className="mt-3 inline-block text-sm text-[#5fff87] underline underline-offset-4">{port.name} API, examples and setup</a>
               </section>
             ))}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -7,14 +7,15 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Code, InstallCommand } from "@/components/site/code";
+import { Code } from "@/components/site/code";
 import { SiteFooter, SiteNav } from "@/components/site/nav";
 import { Terminal } from "@/components/site/terminal";
 import { ThemeGallery, type ThemeCard } from "@/components/site/theme-gallery";
 
 import { recordView, themeVotes, totalViews } from "@/lib/db";
 import { themes } from "@profullstack/hqtui";
-import { LANGUAGES } from "@/lib/languages";
+import { CLONE, LANGUAGES } from "@/lib/languages";
+import { CommandBlock } from "@/components/site/command";
 
 export const dynamic = "force-dynamic";
 
@@ -46,6 +47,9 @@ const DASHBOARD = `app.render(({ ui }) => {
     });
   });
 });`;
+
+/** The reference dashboard, straight from npm. No clone, no build step. */
+const DEMO = "bunx @profullstack/hqtui-demo";
 
 const TESTING = `import { renderToScreen } from "@profullstack/hqtui";
 
@@ -160,9 +164,23 @@ export default async function Home() {
             <Link href="/blog/native-rust-go-python-zig" className="mt-5 inline-flex items-center gap-2 text-sm text-[#5fff87] underline underline-offset-4">
               New: native Rust, Go, Python and Zig ports <ArrowRight className="h-4 w-4 shrink-0" />
             </Link>
+            {/* The strongest thing this project can say is "run one command and
+                look at it", so that command leads — it used to sit in the last
+                section before the footer. */}
             <div className="mx-auto mt-7 flex max-w-md flex-col gap-3">
-              <InstallCommand command="bun add @profullstack/hqtui" />
-              <div className="flex justify-center gap-3">
+              <div className="text-left">
+                <p className="mb-1.5 text-center text-xs uppercase tracking-wide text-white/40">
+                  See it running, right now
+                </p>
+                <CommandBlock command={DEMO} label="demo" />
+              </div>
+              <div className="text-left">
+                <p className="mb-1.5 text-center text-xs uppercase tracking-wide text-white/40">
+                  Or add it to your project
+                </p>
+                <CommandBlock command="bun add @profullstack/hqtui" label="install" />
+              </div>
+              <div className="mt-1 flex justify-center gap-3">
                 <Button size="lg" render={<Link href="#languages" />}>
                   Choose your language <ArrowRight className="ml-1 h-4 w-4" />
                 </Button>
@@ -215,13 +233,43 @@ export default async function Home() {
           Each port includes the app loop, widgets, themes, input handling and a headless renderer.
           The four native ports need no JavaScript runtime and use only their standard libraries.
         </p>
-        <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-5">
+        <div className="mt-6 max-w-2xl">
+          <p className="text-sm text-white/50">
+            The four native ports are not on a package registry yet, so they run from a checkout.
+            Clone once, then pick a language below.
+          </p>
+          <CommandBlock className="mt-2" command={CLONE} label="git clone" />
+        </div>
+
+        {/* A card is no longer one big link: it now contains a copy button, and
+            a button nested inside an anchor is neither valid nor operable by
+            keyboard. The heading carries the link instead. */}
+        <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {LANGUAGES.map((language) => (
-            <Link key={language.id} href={language.href} className="rounded-xl border border-white/10 bg-white/[0.02] p-5 transition-colors hover:border-[#5fff87]/50 focus-visible:outline-2 focus-visible:outline-[#5fff87]">
-              <h3 className="font-mono text-lg font-bold text-[#5fff87]">{language.name}</h3>
+            <div
+              key={language.id}
+              className="flex flex-col rounded-xl border border-white/10 bg-white/[0.02] p-5 transition-colors hover:border-[#5fff87]/50"
+            >
+              <h3 className="font-mono text-lg font-bold">
+                <Link
+                  href={language.href}
+                  className="text-[#5fff87] hover:underline focus-visible:outline-2 focus-visible:outline-[#5fff87]"
+                >
+                  {language.name}
+                </Link>
+              </h3>
               <p className="mt-3 text-sm leading-relaxed text-white/60">{language.description}</p>
-              <span className="mt-5 inline-flex items-center gap-1 text-sm">Get started <ArrowRight className="h-4 w-4" /></span>
-            </Link>
+              <CommandBlock className="mt-4" command={language.demo} label={language.name} />
+              <p className="mt-2 text-xs text-white/40">
+                {language.needsCheckout ? "Renders a dashboard — no TTY needed." : "No install, no clone."}
+              </p>
+              <Link
+                href={language.href}
+                className="mt-4 inline-flex items-center gap-1 text-sm text-white/70 hover:text-white"
+              >
+                Get started <ArrowRight className="h-4 w-4" />
+              </Link>
+            </div>
           ))}
         </div>
         <p className="mt-5 text-sm text-white/60">
@@ -411,8 +459,8 @@ export default async function Home() {
                 benchmarks are reproducible.
               </p>
               <div className="mt-6 space-y-3">
-                <InstallCommand command="bunx @profullstack/hqtui-demo" />
-                <InstallCommand command="bunx @profullstack/hqtui-demo --sim" />
+                <CommandBlock command={DEMO} label="demo" />
+                <CommandBlock command={`${DEMO} --sim`} label="simulated demo" />
               </div>
               <p className="mt-4 text-sm text-white/50">
                 Ten screens: dashboard, sessions, network, traffic, services, components,

--- a/apps/web/components/site/code.tsx
+++ b/apps/web/components/site/code.tsx
@@ -75,12 +75,3 @@ export function Code({
     </div>
   );
 }
-
-export function InstallCommand({ command }: { command: string }) {
-  return (
-    <div className="flex items-center gap-3 rounded-lg border border-white/10 bg-[#0a0e14] px-4 py-3 font-mono text-sm">
-      <span className="select-none text-[#5fff87]">$</span>
-      <span className="text-[#c6d0db]">{command}</span>
-    </div>
-  );
-}

--- a/apps/web/components/site/command.tsx
+++ b/apps/web/components/site/command.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Check, Copy } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+type Status = "idle" | "copied" | "failed";
+
+/**
+ * Copy `text`, falling back to a throwaway textarea.
+ *
+ * The async Clipboard API needs a secure context and a permission that a
+ * browser can refuse, and both of those fail silently from the caller's point
+ * of view. The legacy path works everywhere a `<button>` click can reach it, so
+ * a refusal costs the visitor nothing.
+ */
+async function copyText(text: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard && window.isSecureContext) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // Fall through to the legacy path rather than reporting failure yet.
+  }
+
+  try {
+    const area = document.createElement("textarea");
+    area.value = text;
+    area.setAttribute("readonly", "");
+    // Off-screen and fixed: selecting a textarea in flow scrolls the page to it.
+    area.style.position = "fixed";
+    area.style.top = "-9999px";
+    document.body.appendChild(area);
+    area.select();
+    const ok = document.execCommand("copy");
+    document.body.removeChild(area);
+    return ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * A shell command with a copy button.
+ *
+ * `command` is what lands on the clipboard, verbatim — the `$` prompts are
+ * decoration and are never copied, because pasting one back into a shell is the
+ * classic way to make a copied command fail.
+ */
+export function CommandBlock({
+  command,
+  className,
+  label,
+}: {
+  command: string;
+  className?: string;
+  /** Overrides the button's accessible name when a page shows several blocks. */
+  label?: string;
+}) {
+  const [status, setStatus] = useState<Status>("idle");
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // A visitor can click again before the confirmation clears, and an unmount
+  // mid-timeout would otherwise set state on a dead component.
+  useEffect(() => {
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, []);
+
+  const onCopy = useCallback(async () => {
+    const ok = await copyText(command);
+    setStatus(ok ? "copied" : "failed");
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => setStatus("idle"), 2000);
+  }, [command]);
+
+  const lines = command.split("\n");
+
+  return (
+    <div
+      className={cn(
+        "group relative overflow-hidden rounded-lg border border-white/10 bg-[#0a0e14]",
+        className,
+      )}
+    >
+      <pre className="overflow-x-auto px-3 py-2.5 pr-11 font-mono text-[12px] leading-relaxed text-[#c6d0db]">
+        {lines.map((line, i) => (
+          <div key={i} className="whitespace-pre">
+            <span aria-hidden className="select-none text-[#5fff87]">
+              ${" "}
+            </span>
+            {line}
+          </div>
+        ))}
+      </pre>
+
+      <button
+        type="button"
+        onClick={onCopy}
+        aria-label={label ? `Copy ${label} command` : "Copy command"}
+        className={cn(
+          "absolute right-1.5 top-1.5 rounded-md border border-white/10 bg-white/[0.04] p-1.5",
+          "text-white/50 transition-colors hover:bg-white/10 hover:text-white",
+          "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#5fff87]",
+        )}
+      >
+        {status === "copied" ? (
+          <Check className="h-3.5 w-3.5 text-[#5fff87]" />
+        ) : (
+          <Copy className="h-3.5 w-3.5" />
+        )}
+      </button>
+
+      {/* Announced to screen readers; the icon swap is the visual equivalent. */}
+      <span aria-live="polite" className="sr-only">
+        {status === "copied" ? "Copied to clipboard" : null}
+        {status === "failed" ? "Copying failed — select the command and copy it" : null}
+      </span>
+    </div>
+  );
+}

--- a/apps/web/lib/languages.ts
+++ b/apps/web/lib/languages.ts
@@ -1,14 +1,67 @@
-export const LANGUAGES = [
-  { name: "TypeScript", id: "typescript", description: "The reference implementation. Runs on Bun, Node and Deno.", href: "/docs#install" },
-  { name: "Rust", id: "rust", description: "Native Rust with explicit ownership and interaction IDs.", href: "/docs#rust" },
-  { name: "Go", id: "go", description: "Native Go with callbacks that close over your application state.", href: "/docs#go" },
-  { name: "Python", id: "python", description: "Native Python with callbacks and compact array-backed cell storage.", href: "/docs#python" },
-  { name: "Zig", id: "zig", description: "Native Zig 0.16 with explicit context and arena-managed frames.", href: "/docs#zig" },
-] as const;
+export type Language = {
+  name: string;
+  id: string;
+  description: string;
+  href: string;
+  /**
+   * A runnable demo, exactly as it should be pasted. Every one of these renders
+   * the reference dashboard, and every one is checked by hand before it ships —
+   * a copy button makes a wrong command worse, not better.
+   */
+  demo: string;
+  /** Whether `demo` assumes {@link CLONE} has been run first. */
+  needsCheckout: boolean;
+};
 
-export const PORTS = [
-  { name: "Rust", id: "rust", command: "cargo run --example screenshot" },
-  { name: "Go", id: "go", command: "go run ./examples/screenshot" },
-  { name: "Python", id: "python", command: "python3 -m examples.screenshot" },
-  { name: "Zig", id: "zig", command: "zig build run-screenshot" },
-] as const;
+/** The four native ports run from a checkout; nothing is published yet. */
+export const CLONE = "git clone https://github.com/profullstack/hqtui";
+
+export const LANGUAGES: readonly Language[] = [
+  {
+    name: "TypeScript",
+    id: "typescript",
+    description: "The reference implementation. Runs on Bun, Node and Deno.",
+    href: "/docs#install",
+    demo: "bunx @profullstack/hqtui-demo",
+    needsCheckout: false,
+  },
+  {
+    name: "Rust",
+    id: "rust",
+    description: "Native Rust with explicit ownership and interaction IDs.",
+    href: "/docs#rust",
+    demo: "cd hqtui/ports/rust\ncargo run --example screenshot",
+    needsCheckout: true,
+  },
+  {
+    name: "Go",
+    id: "go",
+    description: "Native Go with callbacks that close over your application state.",
+    href: "/docs#go",
+    demo: "cd hqtui/ports/go\ngo run ./examples/screenshot",
+    needsCheckout: true,
+  },
+  {
+    name: "Python",
+    id: "python",
+    description: "Native Python with callbacks and compact array-backed cell storage.",
+    href: "/docs#python",
+    demo: "cd hqtui/ports/python\npython3 -m examples.screenshot",
+    needsCheckout: true,
+  },
+  {
+    name: "Zig",
+    id: "zig",
+    description: "Native Zig 0.16 with explicit context and arena-managed frames.",
+    href: "/docs#zig",
+    demo: "cd hqtui/ports/zig\nzig build run-screenshot",
+    needsCheckout: true,
+  },
+];
+
+/**
+ * The native ports, derived rather than listed again. The docs and the homepage
+ * showed the same commands from two arrays before this, which is one edit away
+ * from telling visitors two different things.
+ */
+export const PORTS: readonly Language[] = LANGUAGES.filter((language) => language.needsCheckout);


### PR DESCRIPTION
Two asks: demo commands per language at `#languages` with a clear copy button,
and `bunx @profullstack/hqtui-demo` moved up the funnel.

## The demo command leads the hero

It was in the last section before the footer. It now sits above the fold as the
primary call to action, with the install command under it as the secondary one.

```
SEE IT RUNNING, RIGHT NOW
$ bunx @profullstack/hqtui-demo          [copy]

OR ADD IT TO YOUR PROJECT
$ bun add @profullstack/hqtui            [copy]
```

The bottom CTA stays — it carries the `--sim` variant and the traffic
screenshot — and its commands are copyable now too.

## Every language card carries its own demo

The cards linked out to the docs for the commands. Each one now has the command
in place, so the section answers "how do I see this in my language" without a
navigation. The four native ports are not published, so the shared `git clone`
sits once above the grid rather than as three lines in every card.

| | Command |
|---|---|
| TypeScript | `bunx @profullstack/hqtui-demo` |
| Rust | `cd hqtui/ports/rust` → `cargo run --example screenshot` |
| Go | `cd hqtui/ports/go` → `go run ./examples/screenshot` |
| Python | `cd hqtui/ports/python` → `python3 -m examples.screenshot` |
| Zig | `cd hqtui/ports/zig` → `zig build run-screenshot` |

## The copy button

New `CommandBlock`, used by the hero, the language cards, the docs port sections
and the bottom CTA. It copies the command **verbatim** — the `$` prompts are
`aria-hidden` decoration and never reach the clipboard, which is the classic way
a copied command fails to paste. The async Clipboard API needs a secure context
and a permission a browser can refuse, so there is a textarea fallback; both
paths feed one state, and the icon swap has an `aria-live` counterpart.

This replaces `InstallCommand`, which had the same look and no copy button, and
is deleted rather than left behind as a decoy.

## Two things fixed on the way past

- **A button inside an anchor.** Each language card was one big `<Link>`; a copy
  button nested in it would be invalid and not keyboard-operable. The card is a
  `<div>` now, with the link on the heading.
- **Two sources for the same commands.** The homepage and the docs each listed
  them, one edit away from disagreeing. `LANGUAGES` is now the single source and
  `PORTS` is derived from it.

## Test plan

Verified in a browser, not just by building:

- [x] All 10 copy buttons resolve; intercepting `clipboard.writeText` shows each
      copies its exact command, with no `$` in any of them
- [x] Every command executed for real — the four ports from a fresh clone, and
      `bunx @profullstack/hqtui-demo --help` against the published 0.1.11
- [x] `next build` clean, 162 monorepo tests pass
- [x] Checked the rendered layout at desktop and tablet widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Ln29fxoXgFNrH8L8LAQ1u
