### PR TITLE
Docs: runnable native demos and mise examples at each language anchor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,21 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  python:
+    name: Python examples and terminal cleanup
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Test native Python library
+        working-directory: ports/python
+        run: python -m unittest discover -s tests -t .
+      - name: Smoke-test documented headless example
+        working-directory: ports/python
+        run: python -m examples.screenshot
+
   test:
     name: test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/apps/web/app/docs/page.tsx
+++ b/apps/web/app/docs/page.tsx
@@ -14,6 +14,7 @@ export const metadata = { title: "Docs" };
 
 const SECTIONS = [
   { id: "languages", label: "Choose a language" },
+  ...PORTS.map(({ id, name }) => ({ id, label: `${name} demos` })),
   { id: "install", label: "Install" },
   { id: "first-app", label: "Your first app" },
   { id: "layout", label: "Layout" },
@@ -76,16 +77,29 @@ export default async function Docs() {
           </div>
           <P>
             Rust, Go, Python and Zig are native ports with no JavaScript runtime requirement.
-            Start from the source checkout below; each command renders a dashboard without a TTY.
-            Zig requires version 0.16. Each port&apos;s README covers its API, interactive examples
-            and platform-specific terminal behavior.
+            Clone once, then run the examples below from the directory containing the checkout.
+            The interactive native dashboards use generated sample data to demonstrate graphs,
+            tables, mouse input and keyboard navigation; they are not the full ten-screen
+            TypeScript system monitor. Use a Linux or macOS terminal, arrow keys to navigate,
+            and q to quit. Headless examples also work without a TTY. Zig requires version 0.16.
           </P>
           <CommandBlock className="mt-4" command={CLONE} label="git clone" />
+          <P>
+            Already use <a href="https://mise.jdx.dev/" className="text-[#5fff87] underline underline-offset-4">mise</a>?
+            The alternatives below select pinned toolchains and install them if needed.
+            No global language install or mise configuration file is required. Choose either
+            the regular command or its mise alternative.
+          </P>
           <div className="mt-6 grid gap-6 xl:grid-cols-2">
             {PORTS.map((port) => (
               <section key={port.id} id={port.id} className="min-w-0 scroll-mt-20">
                 <h3 className="text-xl font-bold">{port.name}</h3>
-                <CommandBlock className="mt-3" command={port.demo} label={port.name} />
+                <p className="mt-3 text-sm text-white/60">Interactive dashboard</p>
+                <CommandBlock className="mt-2" command={port.interactiveDemo} label={`${port.name} demo`} />
+                <p className="mt-4 text-sm text-white/60">With mise</p>
+                <CommandBlock className="mt-2" command={port.miseDemo} label={`${port.name} · mise`} />
+                <p className="mt-4 text-sm text-white/60">Headless screenshot · no terminal required</p>
+                <CommandBlock className="mt-2" command={`(${port.demo.replace("\n", " && ")})`} label={`${port.name} screenshot`} />
                 <a href={`https://github.com/profullstack/hqtui/tree/main/ports/${port.id}`} className="mt-3 inline-block text-sm text-[#5fff87] underline underline-offset-4">{port.name} API, examples and setup</a>
               </section>
             ))}
@@ -96,6 +110,10 @@ export default async function Docs() {
           </P>
 
           <H2 id="install">Install TypeScript</H2>
+          <P>Try the full ten-screen demo with simulated data, without creating an app:</P>
+          <CommandBlock className="mt-3" command={LANGUAGES[0].interactiveDemo} label="TypeScript demo" />
+          <CommandBlock className="mt-3" command={LANGUAGES[0].miseDemo} label="TypeScript · mise" />
+          <P>Omit <code>--sim</code> to use real system metrics. To build your own app, install the library:</P>
           <Code className="mt-4" code={`bun add @profullstack/hqtui   # Bun is the default runtime
 npm  add @profullstack/hqtui   # Node 22.6+ works unchanged`} />
           <P>

--- a/apps/web/lib/languages.ts
+++ b/apps/web/lib/languages.ts
@@ -9,6 +9,10 @@ export type Language = {
    * a copy button makes a wrong command worse, not better.
    */
   demo: string;
+  /** Interactive example; native examples use generated sample data. */
+  interactiveDemo: string;
+  /** Same interactive example with a pinned mise-managed toolchain. */
+  miseDemo: string;
   /** Whether `demo` assumes {@link CLONE} has been run first. */
   needsCheckout: boolean;
 };
@@ -23,6 +27,8 @@ export const LANGUAGES: readonly Language[] = [
     description: "The reference implementation. Runs on Bun, Node and Deno.",
     href: "/docs#install",
     demo: "bunx @profullstack/hqtui-demo",
+    interactiveDemo: "bunx @profullstack/hqtui-demo --sim",
+    miseDemo: "mise exec bun@1.4.0 -- bunx @profullstack/hqtui-demo --sim",
     needsCheckout: false,
   },
   {
@@ -31,6 +37,8 @@ export const LANGUAGES: readonly Language[] = [
     description: "Native Rust with explicit ownership and interaction IDs.",
     href: "/docs#rust",
     demo: "cd hqtui/ports/rust\ncargo run --example screenshot",
+    interactiveDemo: "(cd hqtui/ports/rust && cargo run --example dashboard)",
+    miseDemo: "(cd hqtui/ports/rust && mise exec rust@1.97.1 -- cargo run --example dashboard)",
     needsCheckout: true,
   },
   {
@@ -39,6 +47,8 @@ export const LANGUAGES: readonly Language[] = [
     description: "Native Go with callbacks that close over your application state.",
     href: "/docs#go",
     demo: "cd hqtui/ports/go\ngo run ./examples/screenshot",
+    interactiveDemo: "(cd hqtui/ports/go && go run ./examples/dashboard)",
+    miseDemo: "(cd hqtui/ports/go && mise exec go@1.26.0 -- go run ./examples/dashboard)",
     needsCheckout: true,
   },
   {
@@ -47,6 +57,8 @@ export const LANGUAGES: readonly Language[] = [
     description: "Native Python with callbacks and compact array-backed cell storage.",
     href: "/docs#python",
     demo: "cd hqtui/ports/python\npython3 -m examples.screenshot",
+    interactiveDemo: "(cd hqtui/ports/python && python3 -m examples.dashboard)",
+    miseDemo: "(cd hqtui/ports/python && mise exec python@3.12.13 -- python -m examples.dashboard)",
     needsCheckout: true,
   },
   {
@@ -55,6 +67,8 @@ export const LANGUAGES: readonly Language[] = [
     description: "Native Zig 0.16 with explicit context and arena-managed frames.",
     href: "/docs#zig",
     demo: "cd hqtui/ports/zig\nzig build run-screenshot",
+    interactiveDemo: "(cd hqtui/ports/zig && zig build run-dashboard)",
+    miseDemo: "(cd hqtui/ports/zig && mise exec zig@0.16.0 -- zig build run-dashboard)",
     needsCheckout: true,
   },
 ];

--- a/apps/web/test/languages.test.ts
+++ b/apps/web/test/languages.test.ts
@@ -1,0 +1,41 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { LANGUAGES, PORTS } from "../lib/languages.ts";
+
+const root = resolve(import.meta.dirname, "../../..");
+
+test("every supported language has interactive and pinned mise demo commands", () => {
+  assert.deepEqual(LANGUAGES.map(({ id }) => id), ["typescript", "rust", "go", "python", "zig"]);
+  for (const language of LANGUAGES) {
+    assert.ok(language.interactiveDemo.length > 0, language.id);
+    assert.match(language.miseDemo, /mise exec \w+@\d+\.\d+\.\d+ -- /);
+    assert.ok(!language.interactiveDemo.includes("screenshot"));
+  }
+});
+
+test("native demo commands point to dashboard and screenshot examples in the checkout", () => {
+  const files: Record<string, string[]> = {
+    rust: ["examples/dashboard.rs", "examples/screenshot.rs"],
+    go: ["examples/dashboard/main.go", "examples/screenshot/main.go"],
+    python: ["examples/dashboard.py", "examples/screenshot.py"],
+    zig: ["examples/dashboard.zig", "examples/screenshot.zig"],
+  };
+  for (const port of PORTS) {
+    assert.ok(port.interactiveDemo.startsWith(`(cd hqtui/ports/${port.id} && `));
+    assert.ok(port.interactiveDemo.endsWith(")"), "subshell preserves the user's directory");
+    assert.match(port.interactiveDemo, /dashboard/);
+    assert.match(port.demo, /screenshot/);
+    for (const file of files[port.id]) assert.ok(existsSync(resolve(root, "ports", port.id, file)), file);
+  }
+});
+
+test("docs show demos and mise alternatives at the existing native language anchors", () => {
+  const page = readFileSync(resolve(root, "apps/web/app/docs/page.tsx"), "utf8");
+  assert.ok(page.includes("id={port.id}"));
+  assert.ok(page.includes("command={port.interactiveDemo}"));
+  assert.ok(page.includes("command={port.miseDemo}"));
+  assert.ok(page.includes("Headless screenshot"));
+  assert.ok(page.includes("generated sample data"));
+});

--- a/ports/python/hqtui/app.py
+++ b/ports/python/hqtui/app.py
@@ -100,6 +100,7 @@ class App:
 
         self._render_fn: Callable[[RenderArgs], None] = lambda args: None
         self._running = False
+        self._terminal_active = False
         self._dirty = True
         self._force_repaint = True
         self._started_at = 0.0
@@ -196,8 +197,9 @@ class App:
             return
         self._running = True
         self._started_at = time.monotonic()
-        self.terminal.enter()
+        self._terminal_active = True
         try:
+            self.terminal.enter()
             interval = max(0.008, 1 / self._target_fps())
             self.frame()
             while self._running:
@@ -220,10 +222,11 @@ class App:
 
     def stop(self) -> None:
         """Stop the loop and restore the terminal."""
-        if not self._running:
+        if not self._running and not self._terminal_active:
             return
         self._running = False
         self.terminal.restore()
+        self._terminal_active = False
         self._emit("exit")
 
     def quit(self) -> None:

--- a/ports/python/tests/test_app_cleanup.py
+++ b/ports/python/tests/test_app_cleanup.py
@@ -1,0 +1,24 @@
+"""A stopped loop must still restore the terminal it entered."""
+import unittest
+from unittest.mock import MagicMock
+
+from hqtui import App
+
+
+class AppCleanupTests(unittest.TestCase):
+    def test_quit_restores_terminal_once(self):
+        app = App()
+        app.terminal = MagicMock()
+        app.frame = lambda: app.quit()
+        app.start()
+        app.stop()
+        app.terminal.enter.assert_called_once()
+        app.terminal.restore.assert_called_once()
+
+    def test_partial_enter_failure_restores_terminal(self):
+        app = App()
+        app.terminal = MagicMock()
+        app.terminal.enter.side_effect = RuntimeError("partial enter")
+        with self.assertRaisesRegex(RuntimeError, "partial enter"):
+            app.start()
+        app.terminal.restore.assert_called_once()

--- a/ports/zig/build.zig
+++ b/ports/zig/build.zig
@@ -19,7 +19,8 @@ pub fn build(b: *std.Build) void {
     const tests = b.addTest(.{ .root_module = hqtui });
     tests.root_module.addOptions("build_options", options);
     const run_tests = b.addRunArtifact(tests);
-    b.step("test", "Run the conformance suite").dependOn(&run_tests.step);
+    const test_step = b.step("test", "Run the conformance suite and dashboard regression tests");
+    test_step.dependOn(&run_tests.step);
 
     // Examples are separate executables, so `zig build run-screenshot` works
     // without a TTY while `run-dashboard` takes one over.
@@ -34,6 +35,11 @@ pub fn build(b: *std.Build) void {
             }),
         });
         b.installArtifact(exe);
+        if (std.mem.eql(u8, name, "dashboard")) {
+            const dashboard_tests = b.addTest(.{ .root_module = exe.root_module });
+            const run_dashboard_tests = b.addRunArtifact(dashboard_tests);
+            test_step.dependOn(&run_dashboard_tests.step);
+        }
         const run = b.addRunArtifact(exe);
         run.step.dependOn(b.getInstallStep());
         if (b.args) |args| run.addArgs(args);

--- a/ports/zig/examples/dashboard.zig
+++ b/ports/zig/examples/dashboard.zig
@@ -73,13 +73,17 @@ const State = struct {
             .rows = &.{.{ .fr = 1 }},
             .layout = .{ .gap = 1 },
         }, GridBody.with(self, cells));
+        // Drawing happens after view returns; a runtime array literal would
+        // leave the status bar pointing into this function's expired stack.
+        const right = try ui.ctx.allocator.alloc(hqtui.widgets.StatusItem, 1);
+        right[0] = .{ .label = self.size };
         try ui.statusBar(.{
             .items = &.{
                 .{ .key = "q", .label = "quit" },
                 .{ .key = "↑↓", .label = "select" },
                 .{ .key = "←→", .label = "tab" },
             },
-            .right = &.{.{ .label = self.size }},
+            .right = right,
         });
     }
 
@@ -142,6 +146,15 @@ const State = struct {
         }, "procs");
     }
 };
+
+test "dashboard retains dynamic status items until the frame is drawn" {
+    var state: State = .{ .size = "100x30" };
+    state.tick();
+    var screen = try hqtui.renderToScreen(std.testing.allocator, 100, 30, "dark", Body.with(&state, State.view));
+    defer screen.deinit();
+    try std.testing.expect(screen.contains("100x30"));
+    try std.testing.expect(screen.contains("Processes"));
+}
 
 pub fn main(init: std.process.Init) !void {
     var app = try hqtui.App.init(init.gpa, .{


### PR DESCRIPTION
Adds copyable interactive dashboard, pinned mise, and headless commands to Rust/Go/Python/Zig docs, plus TypeScript demo commands and language sidebar links. Clearly distinguishes current native sample dashboards from the still-in-progress full reference demo ports. Preserves existing homepage and logo artwork. Fixes Python terminal restoration on quit and a Zig dashboard status-item lifetime crash discovered while testing the advertised commands; includes regression tests. Verification: 165 Bun tests, production Next build, 15 Python tests, 17 Zig tests, all four native headless commands, and all five interactive mise commands launched in a PTY and exited with q, restoring original terminal settings. Rendered docs checked for all language anchors and 15 copy buttons.