### PR TITLE
site: language cards claim no TTY is needed, but the demo refuses to start without one

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -260,8 +260,14 @@ export default async function Home() {
               </h3>
               <p className="mt-3 text-sm leading-relaxed text-white/60">{language.description}</p>
               <CommandBlock className="mt-4" command={language.demo} label={language.name} />
+              {/* These commands launch the interactive demo, which refuses to
+                  start without a terminal — "An interactive terminal is
+                  required." The headless claim belonged to the older
+                  `screenshot` examples this replaced. */}
               <p className="mt-2 text-xs text-white/40">
-                {language.needsCheckout ? "Renders a dashboard — no TTY needed." : "No install, no clone."}
+                {language.needsCheckout
+                  ? "Interactive — press q to quit, or add --snapshot for headless output."
+                  : "No install, no clone."}
               </p>
               <Link
                 href={language.href}


### PR DESCRIPTION
Every native-port card at [`#languages`](https://hqtui.com/#languages) says
**"Renders a dashboard — no TTY needed."** That was true when the card ran the
`screenshot` example (#38). #39 and #40 repointed the command at the interactive
ten-screen demo, which exits immediately outside a terminal — the caption was
left behind.

```console
$ (cd hqtui/ports/go && go run ./examples/dashboard) < /dev/null
An interactive terminal is required. Use --snapshot for headless output.
exit status 2
```

Reproduced on Go, Python and Zig. The check is shared, so Rust behaves the same.

Someone copying the command from the site into anything without a terminal — CI,
a piped shell, a container — gets an error that directly contradicts the line
under the copy button.

The caption now says what the command actually does, and points at the flag that
is headless. The docs already document `--snapshot` per port, so this only
brings the homepage into line with them.

## Test plan

- [x] Reproduced the failure on Go, Python and Zig with stdin closed
- [x] `next build` clean, 165 monorepo tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Ln29fxoXgFNrH8L8LAQ1u
