### PR TITLE
Fix Rust live sensors and update-and-run demos for all five languages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4.3.0
+      - name: Verify update-and-run launcher isolation and fresh revisions
+        run: python apps/demo/scripts/test-updater.py
       - run: mise run test:rust
       - run: mise run test:go
       - run: mise run test:python

--- a/apps/demo/README.md
+++ b/apps/demo/README.md
@@ -15,11 +15,38 @@ reproducible.
 
 ## Run it
 
-```bash
-bunx @profullstack/hqtui-demo          # your real machine
-bunx @profullstack/hqtui-demo --sim    # deterministic simulation
+To automatically fetch **latest main**, build it and run it on every invocation:
 
-npx @profullstack/hqtui-demo           # Node 22.6+ works too
+```sh
+# Vanilla — uses your installed toolchain (Bun for TypeScript)
+curl -fsSL https://hqtui.com/demo.sh | sh -s -- --system typescript
+curl -fsSL https://hqtui.com/demo.sh | sh -s -- --system rust
+
+# Mise — installs/uses the selected pinned toolchain
+curl -fsSL https://hqtui.com/demo.sh | sh -s -- --mise typescript
+curl -fsSL https://hqtui.com/demo.sh | sh -s -- --mise rust
+```
+
+Replace the language with `go`, `python` or `zig` for the other native demos.
+Append `--sim` directly; native headless previews use `--snapshot`. Git and curl
+are required. Review the [launcher](https://hqtui.com/demo.sh) before executing it.
+
+The launcher prints the exact commit, fetches before every run, caches sources
+and optimized builds under `$XDG_CACHE_HOME/hqtui-demo` (default
+`~/.cache/hqtui-demo`), and never modifies your own checkout. A failed update
+does not silently run an old copy. Set `HQTUI_DEMO_CACHE` to a dedicated absolute
+directory to choose another cache. Old revisions are retained so running demos
+are not disrupted. `--check` before the language prints the fetched commit without
+building or entering a terminal. First builds are slower; unchanged revisions
+reuse completed builds. C/C++ demos are not available yet.
+
+For the latest **published npm release** instead of latest source:
+
+```bash
+bunx @profullstack/hqtui-demo@latest          # your real machine
+bunx @profullstack/hqtui-demo@latest --sim    # deterministic simulation
+
+npx --yes @profullstack/hqtui-demo@latest     # Node 22.6+ works too
 ```
 
 ## Options

--- a/apps/demo/scripts/test-updater.py
+++ b/apps/demo/scripts/test-updater.py
@@ -1,0 +1,185 @@
+"""Hermetic update-and-run integration tests against real local Git revisions.
+
+Git's per-process URL rewrite maps the fixed official URL to a temporary fixture.
+No network, remote writes, installed packages, or caller checkouts are modified.
+"""
+import json
+import os
+from pathlib import Path
+import pty
+import select
+import signal
+import subprocess
+import tempfile
+import time
+import unittest
+
+ROOT = Path(__file__).resolve().parents[3]
+LAUNCHER = ROOT / "apps/web/public/demo.sh"
+
+class Updater(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory(prefix="hqtui-updater-test-")
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.repo = self.root / "upstream"
+        self.repo.mkdir()
+        self.git("init", "-b", "main")
+        self.git("config", "user.name", "Updater Test")
+        self.git("config", "user.email", "test@example.invalid")
+        self.bin = self.root / "bin"
+        self.bin.mkdir()
+        self.env = {**os.environ, "HQTUI_DEMO_CACHE": str(self.root / "cache"),
+                    "GIT_CONFIG_COUNT": "1", "GIT_CONFIG_KEY_0": f"url.{self.repo}.insteadOf",
+                    "GIT_CONFIG_VALUE_0": "https://github.com/profullstack/hqtui.git",
+                    "PATH": str(self.bin) + os.pathsep + os.environ["PATH"],
+                    "UPDATER_TEST_LOG": str(self.root / "tools.jsonl")}
+        self.first = self.commit("first")
+
+    def git(self, *args):
+        return subprocess.check_output(["git", *args], cwd=self.repo, stderr=subprocess.DEVNULL, text=True).strip()
+
+    def commit(self, label):
+        (self.repo / "mise.toml").write_text('[tools]\nbun = "1.4.0"\npython = "3.12.13"\nrust = "1.97.1"\ngo = "1.26.0"\nzig = "0.16.0"\n')
+        (self.repo / ".gitignore").write_text('__pycache__/\n')
+        path = self.repo / "ports/python/examples"
+        path.mkdir(parents=True, exist_ok=True)
+        (path / "__init__.py").write_text("")
+        (path / "dashboard.py").write_text(
+            'import json, os, sys\n'
+            f'print(json.dumps({{"revision": {label!r}, "args": sys.argv[1:], "cwd": os.getcwd(), "tty": os.isatty(0)}}), flush=True)\n'
+            'if "--wait" in sys.argv: input()\n')
+        for language in ("rust", "go", "zig"):
+            (self.repo / "ports" / language).mkdir(exist_ok=True)
+            (self.repo / "ports" / language / "source").write_text(label)
+        self.git("add", ".")
+        self.git("commit", "-m", label)
+        return self.git("rev-parse", "HEAD")
+
+    def run_demo(self, *args, env=None, timeout=20):
+        return subprocess.run(["sh", str(LAUNCHER), *args], cwd=ROOT,
+                              env=env or self.env, capture_output=True, text=True, timeout=timeout)
+
+    def test_latest_revision_updates_without_touching_caller(self):
+        before = subprocess.check_output(["git", "status", "--porcelain"], cwd=ROOT)
+        one = self.run_demo("--system", "python", "--snapshot", "literal argument", "$(not-a-command)")
+        self.assertEqual(one.returncode, 0, one.stderr)
+        self.assertEqual(json.loads(one.stdout)["revision"], "first")
+        self.assertEqual(json.loads(one.stdout)["args"][-2:], ["literal argument", "$(not-a-command)"])
+        second = self.commit("second")
+        two = self.run_demo("--system", "python", "--snapshot")
+        self.assertEqual(two.returncode, 0, two.stderr)
+        self.assertEqual(json.loads(two.stdout)["revision"], "second")
+        self.assertIn(second, two.stderr)
+        self.assertIn(second, json.loads(two.stdout)["cwd"])
+        self.assertNotEqual(self.first, second)
+        self.assertEqual(before, subprocess.check_output(["git", "status", "--porcelain"], cwd=ROOT))
+
+    def test_fetch_failure_never_launches_cached_source(self):
+        self.assertEqual(self.run_demo("--system", "python", "--snapshot").returncode, 0)
+        broken = {**self.env, "GIT_CONFIG_KEY_0": f"url.{self.root / 'missing'}.insteadOf"}
+        result = self.run_demo("--system", "python", "--snapshot", env=broken)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("no cached demo was launched", result.stderr)
+        self.assertEqual(result.stdout, "")
+
+    def test_modified_cache_is_preserved_and_rejected(self):
+        result = self.run_demo("--system", "python", "--snapshot")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        path = self.root / "cache/v1/revisions" / self.first / "ports/python/examples/dashboard.py"
+        path.write_text("# local edit\n")
+        result = self.run_demo("--system", "python", "--snapshot")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Cached source was modified", result.stderr)
+        self.assertEqual(path.read_text(), "# local edit\n")
+
+    def test_check_only_reports_fetched_commit(self):
+        result = self.run_demo("--system", "--check", "rust")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), self.first)
+        self.assertFalse((self.root / "cache/v1/revisions").exists())
+
+    def test_invalid_language_and_missing_terminal_fail_before_fetch(self):
+        for args in (("--system", "cpp"), ("--system", "python")):
+            result = self.run_demo(*args)
+            self.assertNotEqual(result.returncode, 0)
+        self.assertFalse((self.root / "cache").exists())
+
+    def stub_compilers(self):
+        code = '''#!/usr/bin/env python3
+import json, os, pathlib, sys
+tool=pathlib.Path(sys.argv[0]).name
+args=sys.argv[1:]
+with open(os.environ["UPDATER_TEST_LOG"],"a") as log: log.write(json.dumps([tool,*args])+"\\n")
+if tool=="mise":
+    assert args[0:2]==["--no-config","exec"]
+    assert args[3]=="--"
+    os.execvp(args[4],args[4:])
+elif tool=="cargo":
+    assert args==["build","--release","--example","dashboard"]
+    output=pathlib.Path(os.environ["CARGO_TARGET_DIR"])/"release/examples/dashboard"
+elif tool=="go":
+    assert args[0:2]==["build","-o"] and args[3]=="./examples/dashboard"
+    output=pathlib.Path(args[2])
+elif tool=="zig":
+    assert args[0:3]==["build","-Doptimize=ReleaseFast","--prefix"]
+    output=pathlib.Path(args[3])/"bin/hqtui-demo-zig"
+else: raise AssertionError(tool)
+label=pathlib.Path("source").read_text()
+output.parent.mkdir(parents=True,exist_ok=True)
+output.write_text("#!/usr/bin/env python3\\nimport json,sys\\nprint(json.dumps(dict(revision="+repr(label)+",args=sys.argv[1:])))\\n")
+output.chmod(0o700)
+'''
+        for name in ("mise", "cargo", "go", "zig"):
+            path = self.bin / name
+            path.write_text(code)
+            path.chmod(0o700)
+
+    def test_vanilla_and_mise_build_latest_and_reuse_only_same_revision(self):
+        self.stub_compilers()
+        for manager in ("--system", "--mise"):
+            for language in ("rust", "go", "zig"):
+                result = self.run_demo(manager, language, "--snapshot", "argument with spaces")
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(json.loads(result.stdout)["revision"], "first")
+                self.assertEqual(json.loads(result.stdout)["args"][-1], "argument with spaces")
+        log = [json.loads(line) for line in (self.root / "tools.jsonl").read_text().splitlines()]
+        self.assertEqual(sum(row[0] in ("cargo", "go", "zig") for row in log), 6)
+        for language in ("rust", "go", "zig"):
+            self.assertEqual(self.run_demo("--mise", language, "--snapshot").returncode, 0)
+        self.commit("second")
+        for language in ("rust", "go", "zig"):
+            result = self.run_demo("--mise", language, "--snapshot")
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(json.loads(result.stdout)["revision"], "second")
+        log = [json.loads(line) for line in (self.root / "tools.jsonl").read_text().splitlines()]
+        self.assertEqual(sum(row[0] in ("cargo", "go", "zig") for row in log), 9)
+
+    @unittest.skipUnless(os.name == "posix", "requires a controlling PTY")
+    def test_pipe_launcher_reattaches_keyboard_and_releases_build_lock(self):
+        pid, master = pty.fork()
+        if pid == 0:
+            # Like curl | sh: the script arrives on a pipe, not stdin's TTY.
+            os.execvpe("sh", ["sh", "-c", 'cat "$1" | sh -s -- --system python --wait', "test", str(LAUNCHER)], self.env)
+        output = b""
+        done = False
+        deadline = time.monotonic() + 15
+        try:
+            while time.monotonic() < deadline:
+                if select.select([master], [], [], .1)[0]:
+                    try: output += os.read(master, 65536)
+                    except OSError: break
+                if b'"tty": true' in output:
+                    self.assertFalse((self.root / "cache/v1/update.lock").exists())
+                    os.write(master, b"q\n")
+                    done = True
+                    break
+            self.assertTrue(done, output.decode(errors="replace"))
+        finally:
+            if not done:
+                os.killpg(pid, signal.SIGTERM)
+            os.waitpid(pid, 0)
+            os.close(master)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/web/app/docs/page.tsx
+++ b/apps/web/app/docs/page.tsx
@@ -77,7 +77,8 @@ export default async function Docs() {
           </div>
           <P>
             Rust, Go, Python and Zig are native ports with no JavaScript runtime requirement.
-            Clone once, then run the examples below from the directory containing the checkout.
+            Both the vanilla and mise commands below fetch latest main before running.
+            They work from any directory and never switch branches, reset, or pull in your checkout.
             All four dashboard commands now launch ten-screen native demos. Live metrics
             currently require Linux; use --sim for generated sample data on other platforms.
             Rust screen bodies pass 120 cell-by-cell TypeScript comparisons, but live-data
@@ -85,17 +86,18 @@ export default async function Docs() {
             need layout-parity work. Use 1–9 / 0 or Tab to change screens and q to quit.
             Headless screenshots work without a TTY. Zig requires version 0.16.
           </P>
-          <CommandBlock className="mt-4" command={CLONE} label="git clone" />
-          <P>Already cloned? Update main before running these commands; older checkouts launch the small examples.</P>
-          <CommandBlock className="mt-4" command="(cd hqtui && git switch main && git pull --ff-only)" label="Update checkout" />
           <P>
-            Already use <a href="https://mise.jdx.dev/" className="text-[#5fff87] underline underline-offset-4">mise</a>?
-            The alternatives below select pinned toolchains and install them if needed.
-            Trust this checkout&apos;s mise.toml when prompted. Choose either the regular
-            command or its mise alternative. From the repository root you can also run
-            mise trust, mise install, then mise run demo:rust -- --sim (or demo:go,
-            demo:python, demo:zig, demo:typescript). For direct commands below, append
-            --sim to the demo arguments; Cargo and Zig require a -- separator first.
+            Vanilla commands require Git, curl and the language&apos;s installed toolchain
+            (Bun for TypeScript). The <a href="https://mise.jdx.dev/" className="text-[#5fff87] underline underline-offset-4">mise</a>
+            alternatives install/use only the selected pinned toolchain without loading project
+            hooks. The launcher prints the full Git revision, reuses completed builds for that
+            revision, and fails rather than silently launching stale code if fetching fails.
+            First builds take longer. Append --sim or --snapshot directly; no extra Cargo/Zig separator is needed.
+          </P>
+          <P>
+            These commands execute our <a href="/demo.sh" className="text-[#5fff87] underline underline-offset-4">launcher script</a>;
+            review it first if needed. Sources/builds live under $XDG_CACHE_HOME/hqtui-demo
+            (or ~/.cache/hqtui-demo), not your project. Native interactive runs need Linux/macOS terminals.
           </P>
           <div className="mt-6 grid gap-6 xl:grid-cols-2">
             {PORTS.map((port) => (
@@ -111,6 +113,9 @@ export default async function Docs() {
               </section>
             ))}
           </div>
+          <P>For development only, you can still clone the monorepo and use its local commands; those do not auto-update:</P>
+          <CommandBlock className="mt-4" command={CLONE} label="Developer checkout (optional)" />
+          <P>In an updated checkout, mise run demo:rust also updates before running (likewise demo:go, demo:python, demo:zig and demo:typescript). Use demo-local:rust and the other demo-local tasks to work on your local edits without updating.</P>
           <P>
             <Link href="/blog/native-rust-go-python-zig" className="text-[#5fff87] underline underline-offset-4">Read how the ports share a conformance corpus</Link>.
             The API guide below describes the TypeScript reference implementation.

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -14,7 +14,7 @@ import { ThemeGallery, type ThemeCard } from "@/components/site/theme-gallery";
 
 import { recordView, themeVotes, totalViews } from "@/lib/db";
 import { themes } from "@profullstack/hqtui";
-import { CLONE, LANGUAGES } from "@/lib/languages";
+import { LANGUAGES } from "@/lib/languages";
 import { CommandBlock } from "@/components/site/command";
 
 export const dynamic = "force-dynamic";
@@ -48,8 +48,8 @@ const DASHBOARD = `app.render(({ ui }) => {
   });
 });`;
 
-/** The reference dashboard, straight from npm. No clone, no build step. */
-const DEMO = "bunx @profullstack/hqtui-demo";
+/** Fetch current main into a private cache, build, then run. */
+const DEMO = LANGUAGES[0].demo;
 
 const TESTING = `import { renderToScreen } from "@profullstack/hqtui";
 
@@ -235,10 +235,10 @@ export default async function Home() {
         </p>
         <div className="mt-6 max-w-2xl">
           <p className="text-sm text-white/50">
-            The four native ports are not on a package registry yet, so they run from a checkout.
-            Clone once, then pick a language below.
+            Every command checks latest main, builds in a private cache, and runs it.
+            No manual clone or pull. Vanilla uses your installed toolchain; mise uses
+            the pinned toolchain. Git and curl are required; the first build takes longer.
           </p>
-          <CommandBlock className="mt-2" command={CLONE} label="git clone" />
         </div>
 
         {/* A card is no longer one big link: it now contains a copy button, and
@@ -260,14 +260,15 @@ export default async function Home() {
               </h3>
               <p className="mt-3 text-sm leading-relaxed text-white/60">{language.description}</p>
               <CommandBlock className="mt-4" command={language.demo} label={language.name} />
+              <CommandBlock className="mt-3" command={language.miseDemo} label={`${language.name} · mise`} />
               {/* These commands launch the interactive demo, which refuses to
                   start without a terminal — "An interactive terminal is
                   required." The headless claim belonged to the older
                   `screenshot` examples this replaced. */}
               <p className="mt-2 text-xs text-white/40">
-                {language.needsCheckout
+                {language.native
                   ? "Interactive — press q to quit, or add --snapshot for headless output."
-                  : "No install, no clone."}
+                  : "Latest source, built with Bun. Interactive — press q to quit."}
               </p>
               <Link
                 href={language.href}

--- a/apps/web/lib/languages.ts
+++ b/apps/web/lib/languages.ts
@@ -8,14 +8,18 @@ export type Language = {
   /** Interactive ten-screen demo. Native demos default to live Linux metrics. */
   interactiveDemo: string;
   snapshotDemo?: string;
-  /** Same interactive example with a pinned mise-managed toolchain. */
+  /** Same latest-source demo with a pinned mise-managed toolchain. */
   miseDemo: string;
-  /** Whether `demo` assumes {@link CLONE} has been run first. */
-  needsCheckout: boolean;
+  native: boolean;
 };
 
-/** The four native ports run from a checkout; nothing is published yet. */
+/** Optional developer checkout; public demo commands do not require it. */
 export const CLONE = "git clone https://github.com/profullstack/hqtui";
+export const LAUNCHER = "https://hqtui.com/demo.sh";
+export function latestDemo(language: string, mise = false): string {
+  if (!["typescript", "rust", "go", "python", "zig"].includes(language)) throw new Error("Unsupported demo language");
+  return `curl -fsSL ${LAUNCHER} | sh -s -- --${mise ? "mise" : "system"} ${language}`;
+}
 
 export const LANGUAGES: readonly Language[] = [
   {
@@ -23,54 +27,54 @@ export const LANGUAGES: readonly Language[] = [
     id: "typescript",
     description: "The reference implementation. Runs on Bun, Node and Deno.",
     href: "/docs#install",
-    demo: "bunx @profullstack/hqtui-demo",
-    interactiveDemo: "bunx @profullstack/hqtui-demo --sim",
-    miseDemo: "mise exec bun@1.4.0 -- bunx @profullstack/hqtui-demo --sim",
-    needsCheckout: false,
+    demo: latestDemo("typescript"),
+    interactiveDemo: `${latestDemo("typescript")} --sim`,
+    miseDemo: `${latestDemo("typescript", true)} --sim`,
+    native: false,
   },
   {
     name: "Rust",
     id: "rust",
     description: "Native Rust with explicit ownership and interaction IDs.",
     href: "/docs#rust",
-    demo: "(cd hqtui/ports/rust && cargo run --example dashboard)",
-    snapshotDemo: "(cd hqtui/ports/rust && cargo run --example dashboard -- --snapshot)",
-    interactiveDemo: "(cd hqtui/ports/rust && cargo run --example dashboard)",
-    miseDemo: "(cd hqtui/ports/rust && mise exec rust@1.97.1 -- cargo run --example dashboard)",
-    needsCheckout: true,
+    demo: latestDemo("rust"),
+    snapshotDemo: `${latestDemo("rust")} --snapshot`,
+    interactiveDemo: latestDemo("rust"),
+    miseDemo: latestDemo("rust", true),
+    native: true,
   },
   {
     name: "Go",
     id: "go",
     description: "Native Go with callbacks that close over your application state.",
     href: "/docs#go",
-    demo: "(cd hqtui/ports/go && go run ./examples/dashboard)",
-    snapshotDemo: "(cd hqtui/ports/go && go run ./examples/dashboard --snapshot)",
-    interactiveDemo: "(cd hqtui/ports/go && go run ./examples/dashboard)",
-    miseDemo: "(cd hqtui/ports/go && mise exec go@1.26.0 -- go run ./examples/dashboard)",
-    needsCheckout: true,
+    demo: latestDemo("go"),
+    snapshotDemo: `${latestDemo("go")} --snapshot`,
+    interactiveDemo: latestDemo("go"),
+    miseDemo: latestDemo("go", true),
+    native: true,
   },
   {
     name: "Python",
     id: "python",
     description: "Native Python with callbacks and compact array-backed cell storage.",
     href: "/docs#python",
-    demo: "(cd hqtui/ports/python && python3 -m examples.dashboard)",
-    snapshotDemo: "(cd hqtui/ports/python && python3 -m examples.dashboard --snapshot)",
-    interactiveDemo: "(cd hqtui/ports/python && python3 -m examples.dashboard)",
-    miseDemo: "(cd hqtui/ports/python && mise exec python@3.12.13 -- python -m examples.dashboard)",
-    needsCheckout: true,
+    demo: latestDemo("python"),
+    snapshotDemo: `${latestDemo("python")} --snapshot`,
+    interactiveDemo: latestDemo("python"),
+    miseDemo: latestDemo("python", true),
+    native: true,
   },
   {
     name: "Zig",
     id: "zig",
     description: "Native Zig 0.16 with explicit context and arena-managed frames.",
     href: "/docs#zig",
-    demo: "(cd hqtui/ports/zig && zig build run-dashboard)",
-    snapshotDemo: "(cd hqtui/ports/zig && zig build run-dashboard -- --snapshot)",
-    interactiveDemo: "(cd hqtui/ports/zig && zig build run-dashboard)",
-    miseDemo: "(cd hqtui/ports/zig && mise exec zig@0.16.0 -- zig build run-dashboard)",
-    needsCheckout: true,
+    demo: latestDemo("zig"),
+    snapshotDemo: `${latestDemo("zig")} --snapshot`,
+    interactiveDemo: latestDemo("zig"),
+    miseDemo: latestDemo("zig", true),
+    native: true,
   },
 ];
 
@@ -79,4 +83,4 @@ export const LANGUAGES: readonly Language[] = [
  * showed the same commands from two arrays before this, which is one edit away
  * from telling visitors two different things.
  */
-export const PORTS: readonly Language[] = LANGUAGES.filter((language) => language.needsCheckout);
+export const PORTS: readonly Language[] = LANGUAGES.filter((language) => language.native);

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -49,6 +49,13 @@ const nextConfig: NextConfig = {
   async headers() {
     return [
       {
+        source: "/demo.sh",
+        headers: [
+          { key: "Cache-Control", value: "no-store" },
+          { key: "Content-Type", value: "text/plain; charset=utf-8" },
+        ],
+      },
+      {
         source: "/:path*",
         headers: [
           { key: "X-Content-Type-Options", value: "nosniff" },

--- a/apps/web/public/demo.sh
+++ b/apps/web/public/demo.sh
@@ -1,0 +1,205 @@
+#!/bin/sh
+# HQTUI update-and-run launcher. Run only after reviewing/trusting this script.
+# Source and builds live in a private cache, never in the caller's checkout.
+# A complete function definition must arrive before the final invocation runs.
+main() (
+    set -eu
+    umask 077
+    fail() { printf 'hqtui-demo: %s\n' "$*" >&2; exit 1; }
+    note() { printf 'hqtui-demo: %s\n' "$*" >&2; }
+    usage() {
+        printf '%s\n' 'Usage: demo.sh [--mise|--system] [--check] LANGUAGE [demo arguments...]' \
+          'Languages: typescript (ts), rust, go, python, zig' \
+          'Every invocation fetches latest main. --check prints the revision without building.' \
+          'Defaults to mise when installed, otherwise uses your installed compiler/runtime.' \
+          'Examples: demo.sh rust --sim; demo.sh --mise rust --snapshot'
+    }
+    manager=auto
+    check=0
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --mise) manager=mise; shift ;;
+            --system) manager=system; shift ;;
+            --check) check=1; shift ;;
+            --help|-h) usage; exit 0 ;;
+            --) shift; break ;;
+            *) break ;;
+        esac
+    done
+    [ "$#" -gt 0 ] || { usage >&2; exit 2; }
+    language=$1; shift
+    case "$language" in
+        ts|typescript) language=typescript; tool=bun ;;
+        rust|go|python|zig) tool=$language ;;
+        *) fail "Unsupported language '$language'. C/C++ demos are not ready; use typescript, rust, go, python or zig." ;;
+    esac
+    # When invoked through curl | sh, the pipe is not the demo's keyboard.
+    # Connect only interactive runs to the controlling terminal; preserve pipes
+    # for headless output. Do this before any update/build work.
+    headless=$check
+    for argument in "$@"; do
+        case "$argument" in --snapshot|--help|-h|--version|-V) headless=1 ;; esac
+    done
+    if [ "$headless" -eq 0 ]; then
+        [ -t 1 ] || fail 'Interactive demo needs a terminal on stdout. Use --snapshot for native headless output.'
+        if [ ! -t 0 ]; then
+            ( : </dev/tty ) 2>/dev/null || fail 'No controlling terminal. Run this command in a terminal, or use --snapshot.'
+            exec </dev/tty
+        fi
+    fi
+    command -v git >/dev/null 2>&1 || fail 'Git is required. Install Git, then run the same command again.'
+    if [ "$manager" = auto ]; then
+        if command -v mise >/dev/null 2>&1; then manager=mise; else manager=system; fi
+    fi
+    if [ "$manager" = mise ]; then
+        command -v mise >/dev/null 2>&1 || fail 'mise was requested but is not installed. Install mise or omit --mise.'
+    fi
+    if [ "$manager" = system ] && [ "$check" -eq 0 ]; then
+        case "$language" in rust) driver=cargo ;; typescript) driver=bun ;; python) driver=python3 ;; *) driver=$language ;; esac
+        driver_path=$(command -v "$driver") || fail "$driver is not installed. Install it, or use --mise."
+        # Resolve a mise shim BEFORE entering the fetched checkout. Vanilla must
+        # not accidentally load or ask to trust the downloaded mise.toml. Keep the
+        # resolved bin directory first for nested build commands (Bun, rustc).
+        case "$driver_path" in
+            */mise/shims/*|"${MISE_DATA_DIR:-/nonexistent}"/shims/*)
+                driver_path=$(mise which "$driver") || fail "Cannot resolve installed $driver; try --mise."
+                ;;
+        esac
+        case "$driver_path" in /*) ;; *) fail "Expected an executable path for $driver." ;; esac
+        PATH=$(dirname "$driver_path"):$PATH
+        export PATH
+    fi
+    base=${XDG_CACHE_HOME:-${HOME:?HOME must be set}/.cache}
+    cache=${HQTUI_DEMO_CACHE:-$base/hqtui-demo}/v1
+    case "$cache" in /*) ;; *) fail 'The cache location must be an absolute path.' ;; esac
+    [ ! -L "$cache" ] || fail "Cache is a symlink: $cache"
+    mkdir -p "$cache"
+    lock=$cache/update.lock
+    locked=0
+    cleanup() {
+        if [ "$locked" -eq 1 ]; then
+            # Only remove the two lock entries created by this process.
+            rm -f "$lock/pid"
+            rmdir "$lock" || :
+        fi
+    }
+    trap cleanup EXIT
+    trap 'exit 130' INT
+    trap 'exit 143' TERM
+    trap 'exit 129' HUP
+    waited=0
+    while ! mkdir "$lock" 2>/dev/null; do
+        # Do not guess whether another process or a crashed invocation owns it.
+        # This also avoids PID-reuse and partially-created-lock races.
+        [ "$waited" -ne 0 ] || note "Waiting for another updater ($lock)."
+        [ "$waited" -lt 120 ] || fail "Updater lock is still present: $lock. Check for another build; if none is running, remove only this lock directory and retry."
+        sleep 1
+        waited=$((waited + 1))
+    done
+    locked=1
+    printf '%s\n' "$$" > "$lock/pid"
+    repository=https://github.com/profullstack/hqtui.git
+    mirror=$cache/repository.git
+    [ ! -L "$mirror" ] || fail 'Refusing a symlinked repository cache.'
+    export GIT_TERMINAL_PROMPT=0
+    git_safe() { git -c core.hooksPath=/dev/null "$@"; }
+    if [ ! -e "$mirror" ]; then
+        git_safe init --bare --quiet "$mirror"
+        git_safe --git-dir="$mirror" remote add origin "$repository"
+    fi
+    [ "$(git_safe --git-dir="$mirror" rev-parse --is-bare-repository)" = true ] || fail 'Cache is not a bare repository.'
+    [ "$(git_safe --git-dir="$mirror" config --get remote.origin.url)" = "$repository" ] || fail 'Cache remote is not the official HQTUI repository.'
+    note 'Checking latest main…'
+    # Never fall back to an old revision when offline or when fetch fails.
+    git_safe --git-dir="$mirror" fetch --quiet --depth=1 origin '+refs/heads/main:refs/remotes/origin/main' \
+        || fail 'Update failed; no cached demo was launched. Check the connection and retry.'
+    revision=$(git_safe --git-dir="$mirror" rev-parse --verify 'refs/remotes/origin/main^{commit}')
+    case "$revision" in ''|*[!0-9a-f]*) fail 'Invalid Git revision.' ;; esac
+    note "$language · main $revision"
+    if [ "$check" -eq 1 ]; then printf '%s\n' "$revision"; exit 0; fi
+    sources=$cache/revisions
+    [ ! -L "$sources" ] || fail 'Refusing symlinked source cache.'
+    mkdir -p "$sources"
+    source=$sources/$revision
+    [ ! -L "$source" ] || fail 'Refusing symlinked source revision.'
+    if [ ! -e "$source" ]; then
+        git_safe --git-dir="$mirror" worktree add --quiet --detach "$source" "$revision"
+    fi
+    [ "$(git_safe -C "$source" rev-parse HEAD)" = "$revision" ] || fail 'Cached checkout has a different revision.'
+    [ -z "$(git_safe -C "$source" status --porcelain --untracked-files=normal)" ] \
+        || fail "Cached source was modified: $source. It has been left untouched; choose a new HQTUI_DEMO_CACHE location."
+    # Read only the selected version string, not mise hooks or environment code.
+    version=$(awk -v key="$tool" '$1 == key && $2 == "=" {gsub(/"/, "", $3); print $3; exit}' "$source/mise.toml")
+    case "$version" in ''|*[!0-9.]*) fail "Invalid pinned $tool version in mise.toml." ;; esac
+    run_tool() {
+        if [ "$manager" = mise ]; then
+            mise --no-config exec "$tool@$version" -- "$@"
+        else
+            "$@"
+        fi
+    }
+    launch() {
+        cleanup; locked=0
+        trap - EXIT INT TERM HUP
+        if [ "$manager" = mise ]; then
+            exec mise --no-config exec "$tool@$version" -- "$@"
+        else
+            exec "$@"
+        fi
+    }
+    platform=$(uname -sm | tr ' /' '--')
+    case "$platform" in ''|*[!a-zA-Z0-9_.-]*) fail 'Unsupported platform identifier.' ;; esac
+    bins=$cache/bin/$platform/$manager-$tool-$version/$revision
+    mkdir -p "$bins" "$cache/build"
+    case "$language" in
+        rust)
+            cd "$source/ports/rust"
+            if [ ! -f "$bins/rust.ready" ] || [ ! -x "$bins/rust" ]; then
+                note 'Building optimized Rust demo (first run of this revision)…'
+                CARGO_TARGET_DIR=$cache/build/rust; export CARGO_TARGET_DIR
+                run_tool cargo build --release --example dashboard
+                cp "$CARGO_TARGET_DIR/release/examples/dashboard" "$bins/rust.pending"
+                mv "$bins/rust.pending" "$bins/rust"
+                printf '%s\n' "$revision" > "$bins/rust.ready"
+            fi
+            launch "$bins/rust" "$@"
+            ;;
+        go)
+            cd "$source/ports/go"
+            if [ ! -f "$bins/go.ready" ] || [ ! -x "$bins/go" ]; then
+                note 'Building Go demo (first run of this revision)…'
+                run_tool go build -o "$bins/go" ./examples/dashboard
+                printf '%s\n' "$revision" > "$bins/go.ready"
+            fi
+            launch "$bins/go" "$@"
+            ;;
+        python)
+            cd "$source/ports/python"
+            python=python3
+            [ "$manager" != mise ] || python=python
+            launch "$python" -B -m examples.dashboard "$@"
+            ;;
+        zig)
+            cd "$source/ports/zig"
+            if [ ! -f "$bins/zig.ready" ] || [ ! -x "$bins/zig/bin/hqtui-demo-zig" ]; then
+                note 'Building optimized Zig demo (first run of this revision)…'
+                run_tool zig build -Doptimize=ReleaseFast --prefix "$bins/zig"
+                printf '%s\n' "$revision" > "$bins/zig.ready"
+            fi
+            launch "$bins/zig/bin/hqtui-demo-zig" "$@"
+            ;;
+        typescript)
+            cd "$source"
+            if [ ! -f "$bins/typescript.ready" ] || [ ! -f apps/demo/dist/main.js ]; then
+                note 'Building current TypeScript demo (first run of this revision)…'
+                run_tool bun install --frozen-lockfile --ignore-scripts
+                # Keep nested tsc/build scripts on Bun too, even with Node
+                # version-manager shims in PATH and an untrusted mise.toml.
+                run_tool bun run --bun build
+                printf '%s\n' "$revision" > "$bins/typescript.ready"
+            fi
+            launch bun apps/demo/dist/main.js "$@"
+            ;;
+    esac
+)
+main "$@"

--- a/apps/web/test/languages.test.ts
+++ b/apps/web/test/languages.test.ts
@@ -2,20 +2,21 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { LANGUAGES, PORTS } from "../lib/languages.ts";
+import { LANGUAGES, PORTS, LAUNCHER, latestDemo } from "../lib/languages.ts";
 
 const root = resolve(import.meta.dirname, "../../..");
 
-test("every supported language has interactive and pinned mise demo commands", () => {
+test("every supported language has latest-source vanilla and mise demo commands", () => {
   assert.deepEqual(LANGUAGES.map(({ id }) => id), ["typescript", "rust", "go", "python", "zig"]);
   for (const language of LANGUAGES) {
     assert.ok(language.interactiveDemo.length > 0, language.id);
-    assert.match(language.miseDemo, /mise exec \w+@\d+\.\d+\.\d+ -- /);
+    assert.ok(language.interactiveDemo.startsWith(`curl -fsSL ${LAUNCHER} | sh -s -- --system ${language.id}`));
+    assert.ok(language.miseDemo.startsWith(`curl -fsSL ${LAUNCHER} | sh -s -- --mise ${language.id}`));
     assert.ok(!language.interactiveDemo.includes("screenshot"));
   }
 });
 
-test("native demo commands point to dashboard and screenshot examples in the checkout", () => {
+test("native updater commands retain full-dashboard source entrypoints", () => {
   const files: Record<string, string[]> = {
     rust: ["examples/dashboard.rs", "examples/screenshot.rs"],
     go: ["examples/dashboard/main.go", "examples/screenshot/main.go"],
@@ -23,13 +24,18 @@ test("native demo commands point to dashboard and screenshot examples in the che
     zig: ["examples/dashboard.zig", "examples/screenshot.zig"],
   };
   for (const port of PORTS) {
-    assert.ok(port.interactiveDemo.startsWith(`(cd hqtui/ports/${port.id} && `));
-    assert.ok(port.interactiveDemo.endsWith(")"), "subshell preserves the user's directory");
-    assert.match(port.interactiveDemo, /dashboard/);
     assert.equal(port.demo, port.interactiveDemo);
-    assert.match(port.snapshotDemo!, /dashboard.*--snapshot/);
+    assert.equal(port.snapshotDemo, `${port.demo} --snapshot`);
     for (const file of files[port.id]) assert.ok(existsSync(resolve(root, "ports", port.id, file)), file);
   }
+});
+
+test("the homepage also exposes both vanilla and mise commands", () => {
+  const page = readFileSync(resolve(root, "apps/web/app/page.tsx"), "utf8");
+  assert.ok(page.includes("command={language.demo}"));
+  assert.ok(page.includes("command={language.miseDemo}"));
+  assert.throws(() => latestDemo("cpp"), /Unsupported/);
+  assert.ok(existsSync(resolve(root, "apps/web/public/demo.sh")));
 });
 
 test("docs show demos and mise alternatives at the existing native language anchors", () => {

--- a/mise.toml
+++ b/mise.toml
@@ -9,24 +9,44 @@ zig = "0.16.0"
 
 [tasks."demo:typescript"]
 description = "TypeScript reference demo (Bun)"
-run = "bun apps/demo/src/main.ts"
+run = "sh apps/web/public/demo.sh --mise typescript"
 
 [tasks."demo:python"]
 description = "Native Python reference demo"
-dir = "{{config_root}}/ports/python"
-run = "python -m examples.dashboard"
+run = "sh apps/web/public/demo.sh --mise python"
 
 [tasks."demo:go"]
 description = "Native Go reference demo"
-dir = "{{config_root}}/ports/go"
-run = "go run ./examples/dashboard"
+run = "sh apps/web/public/demo.sh --mise go"
 
 [tasks."demo:rust"]
 description = "Native Rust reference demo"
-run = "cargo run --manifest-path ports/rust/Cargo.toml --example dashboard --"
+run = "sh apps/web/public/demo.sh --mise rust"
 
 [tasks."demo:zig"]
 description = "Native Zig reference demo"
+run = "sh apps/web/public/demo.sh --mise zig"
+
+[tasks."demo-local:typescript"]
+description = "Run this checkout's TypeScript demo without updating"
+run = "bun apps/demo/src/main.ts"
+
+[tasks."demo-local:rust"]
+description = "Run this checkout's Rust demo without updating"
+run = "cargo run --manifest-path ports/rust/Cargo.toml --example dashboard --"
+
+[tasks."demo-local:go"]
+description = "Run this checkout's Go demo without updating"
+dir = "{{config_root}}/ports/go"
+run = "go run ./examples/dashboard"
+
+[tasks."demo-local:python"]
+description = "Run this checkout's Python demo without updating"
+dir = "{{config_root}}/ports/python"
+run = "python -m examples.dashboard"
+
+[tasks."demo-local:zig"]
+description = "Run this checkout's Zig demo without updating"
 dir = "{{config_root}}/ports/zig"
 run = "zig build run-dashboard --"
 

--- a/ports/go/README.md
+++ b/ports/go/README.md
@@ -1,5 +1,20 @@
 # hqtui — Go
 
+Fetch latest main and run the full demo (from any directory):
+
+```sh
+# Vanilla: installed toolchain
+curl -fsSL https://hqtui.com/demo.sh | sh -s -- --system go
+# Mise: pinned toolchain
+curl -fsSL https://hqtui.com/demo.sh | sh -s -- --mise go
+```
+
+Both update a private cache before running, print the exact commit, and leave
+your checkout alone. Append `--sim` or `--snapshot` directly. Review the
+[launcher](https://hqtui.com/demo.sh) before executing it. In an updated checkout,
+`mise run demo:go` also updates; `mise run demo-local:go` and the
+direct example commands below run local source without updating.
+
 High Quality Terminal UI for Go. btop-grade dashboards with a one-import API,
 dark by default, **standard library only** — no `golang.org/x/...`, nothing in
 `go.sum`.

--- a/ports/python/README.md
+++ b/ports/python/README.md
@@ -1,5 +1,20 @@
 # hqtui — Python
 
+Fetch latest main and run the full demo (from any directory):
+
+```sh
+# Vanilla: installed toolchain
+curl -fsSL https://hqtui.com/demo.sh | sh -s -- --system python
+# Mise: pinned toolchain
+curl -fsSL https://hqtui.com/demo.sh | sh -s -- --mise python
+```
+
+Both update a private cache before running, print the exact commit, and leave
+your checkout alone. Append `--sim` or `--snapshot` directly. Review the
+[launcher](https://hqtui.com/demo.sh) before executing it. In an updated checkout,
+`mise run demo:python` also updates; `mise run demo-local:python` and the
+direct example commands below run local source without updating.
+
 High Quality Terminal UI for Python. btop-grade dashboards with a one-import
 API, dark by default, **standard library only** — nothing in `dependencies`,
 nothing to pin.

--- a/ports/rust/README.md
+++ b/ports/rust/README.md
@@ -1,5 +1,20 @@
 # hqtui — Rust
 
+Fetch latest main and run the full demo (from any directory):
+
+```sh
+# Vanilla: installed toolchain
+curl -fsSL https://hqtui.com/demo.sh | sh -s -- --system rust
+# Mise: pinned toolchain
+curl -fsSL https://hqtui.com/demo.sh | sh -s -- --mise rust
+```
+
+Both update a private cache before running, print the exact commit, and leave
+your checkout alone. Append `--sim` or `--snapshot` directly. Review the
+[launcher](https://hqtui.com/demo.sh) before executing it. In an updated checkout,
+`mise run demo:rust` also updates; `mise run demo-local:rust` and the
+direct example commands below run local source without updating.
+
 High Quality Terminal UI for Rust. btop-grade dashboards with a one-import API,
 dark by default, **zero runtime dependencies**. The full dashboard example
 uses `serde_json` for telemetry and its TypeScript comparison fixtures.
@@ -8,7 +23,7 @@ This is a native port of [the TypeScript reference
 implementation](https://hqtui.com), not a binding. There is no Node in the
 picture at runtime or at build time.
 
-Not on crates.io yet — it ships in the monorepo. To run it now:
+Not on crates.io yet — it ships in the monorepo. To develop from local source:
 
 ```bash
 git clone https://github.com/profullstack/hqtui

--- a/ports/rust/demo/src/collect.rs
+++ b/ports/rust/demo/src/collect.rs
@@ -233,7 +233,6 @@ impl Collector {
         self.processes(dt);
         self.network(dt);
         self.disks(dt);
-        self.sensors();
         if self
             .slow
             .map(|t| now.duration_since(t).as_secs() >= 5)
@@ -242,6 +241,7 @@ impl Collector {
             self.slow = Some(now);
             self.slow_collect()
         }
+        self.sensors();
         self.missing.extend(self.slow_missing.clone());
     }
     fn processes(&mut self, dt: f64) {
@@ -443,37 +443,31 @@ impl Collector {
         self.sample["disks"] = json!(disks)
     }
     fn sensors(&mut self) {
-        let mut temps = vec![];
-        if let Ok(dirs) = std::fs::read_dir("/sys/class/hwmon") {
-            for dir in dirs.flatten() {
-                if let Ok(entries) = std::fs::read_dir(dir.path()) {
-                    for entry in entries.flatten() {
-                        let name = entry.file_name().to_string_lossy().into_owned();
-                        if !name.starts_with("temp") || !name.ends_with("_input") {
-                            continue;
-                        }
-                        let raw = read(entry.path());
-                        if raw.trim().is_empty() {
-                            continue;
-                        }
-                        let value = number(raw.trim()) / 1000.;
-                        if !(-50. ..=200.).contains(&value) {
-                            continue;
-                        }
-                        let label = read(
-                            entry
-                                .path()
-                                .with_file_name(name.replace("_input", "_label")),
-                        );
-                        temps.push(json!({"label":if label.trim().is_empty(){&name}else{label.trim()},"value":value,"max":100}));
-                    }
-                }
-            }
+        let readings = crate::sensors::collect(
+            Path::new("/"),
+            &read("/proc/cpuinfo"),
+            &self.sample["telemetry"]["gpus"],
+            || command(&["sensors", "-j"]),
+        );
+        if readings.temperatures.is_empty() {
+            self.missing.push("temperatures".into());
         }
-        self.sample["temperatures"] = json!(temps)
+        if readings.hardware_count == 0 {
+            self.missing.push("fans/voltage/power".into());
+        }
+        self.sample["temperatures"] = json!(readings.temperatures);
+        self.sample["sensors"] = json!(readings.sensors);
+        self.sample["telemetry"]["power"] = readings.power;
     }
     fn slow_collect(&mut self) {
         let mut missing = vec![];
+        self.sample["telemetry"]["gpus"] = crate::sensors::parse_gpus(&command(&[
+            "nvidia-smi", "--query-gpu=name,utilization.gpu,memory.used,memory.total,temperature.gpu,power.draw",
+            "--format=csv,noheader,nounits",
+        ]).unwrap_or_default());
+        if array(&self.sample["telemetry"]["gpus"]).is_empty() {
+            missing.push("GPU telemetry".into());
+        }
         let mut run = |label: &str, args: &[&str]| {
             command(args).unwrap_or_else(|| {
                 missing.push(label.to_owned());
@@ -554,7 +548,6 @@ impl Collector {
                 "login history",
                 "SSH authentication log",
                 "HTTP access log",
-                "GPU/power",
             ]
             .map(str::to_owned),
         );

--- a/ports/rust/demo/src/main.rs
+++ b/ports/rust/demo/src/main.rs
@@ -1,4 +1,5 @@
 mod collect;
+mod sensors;
 mod components;
 mod dashboard;
 mod model;

--- a/ports/rust/demo/src/sensors.rs
+++ b/ports/rust/demo/src/sensors.rs
@@ -1,0 +1,445 @@
+//! Read-only Linux sensor sources, matching the TypeScript collector's routes.
+//! The root is explicit for fixture tests; production uses `/`.
+use crate::collect::read;
+use serde_json::{json, Value};
+use std::path::{Path, PathBuf};
+
+fn path(root: &Path, absolute: &str) -> PathBuf {
+    root.join(absolute.trim_start_matches('/'))
+}
+fn entries(dir: &Path) -> Vec<String> {
+    let mut names: Vec<_> = std::fs::read_dir(dir)
+        .into_iter()
+        .flatten()
+        .take(4096)
+        .filter_map(Result::ok)
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .collect();
+    names.sort();
+    names
+}
+fn finite(raw: &str) -> Option<f64> {
+    raw.trim().parse::<f64>().ok().filter(|n| n.is_finite())
+}
+fn positive(raw: &str) -> Option<f64> {
+    finite(raw).filter(|n| *n > 0.)
+}
+fn input(name: &str, prefix: &str, suffix: &str) -> bool {
+    name.strip_prefix(prefix)
+        .and_then(|s| s.strip_suffix(suffix))
+        .is_some_and(|n| !n.is_empty() && n.bytes().all(|c| c.is_ascii_digit()))
+}
+fn label(dir: &Path, name: &str, chip: &str, fallback: &str) -> String {
+    let named = read(
+        dir.join(
+            name.replace("_input", "_label")
+                .replace("_average", "_label"),
+        ),
+    );
+    if !named.trim().is_empty() {
+        named.trim().into()
+    } else if !chip.is_empty() {
+        format!("{chip} {fallback}")
+    } else {
+        fallback.into()
+    }
+}
+
+pub struct Readings {
+    pub temperatures: Vec<Value>,
+    pub sensors: Vec<Value>,
+    pub hardware_count: usize,
+    pub power: Value,
+}
+pub fn collect(
+    root: &Path,
+    cpuinfo: &str,
+    gpus: &Value,
+    lm_sensors: impl FnOnce() -> Option<String>,
+) -> Readings {
+    let mut temperatures = vec![];
+    let mut hardware = vec![];
+    let base = path(root, "/sys/class/hwmon");
+    for name in entries(&base).into_iter().take(128) {
+        let dir = base.join(&name);
+        let chip = read(dir.join("name"));
+        let old_chip = read(dir.join("device/name"));
+        let chip = if !chip.trim().is_empty() {
+            chip.trim()
+        } else if !old_chip.trim().is_empty() {
+            old_chip.trim()
+        } else {
+            &name
+        };
+        for dir in [dir.clone(), dir.join("device")] {
+            for name in entries(&dir) {
+                if input(&name, "temp", "_input") && temperatures.len() < 12 {
+                    let Some(value) = positive(&read(dir.join(&name)))
+                        .map(|n| n / 1000.)
+                        .filter(|n| *n <= 150.)
+                    else {
+                        continue;
+                    };
+                    let max = positive(&read(dir.join(name.replace("_input", "_crit"))))
+                        .map(|n| n / 1000.)
+                        .unwrap_or(100.);
+                    temperatures.push(json!({"label":label(&dir,&name,chip,name.trim_end_matches("_input")),"value":value,"max":max}));
+                } else if hardware.len() < 14 {
+                    let kind = if input(&name, "fan", "_input") {
+                        "fan"
+                    } else if input(&name, "in", "_input") {
+                        "voltage"
+                    } else if input(&name, "power", "_input") || input(&name, "power", "_average") {
+                        "power"
+                    } else if input(&name, "curr", "_input") {
+                        "current"
+                    } else {
+                        continue;
+                    };
+                    let Some(value) = positive(&read(dir.join(&name))) else {
+                        continue;
+                    };
+                    let fallback = name.trim_end_matches("_input").trim_end_matches("_average");
+                    let fallback = if kind == "fan" {
+                        fallback.replacen("fan", "Fan ", 1)
+                    } else {
+                        fallback.into()
+                    };
+                    let value = match kind {
+                        "fan" => format!("{:.0} RPM", (value + 0.5).floor()),
+                        "voltage" => format!("{:.2} V", value / 1000.),
+                        "power" => format!("{:.1} W", value / 1e6),
+                        _ => format!("{:.2} A", value / 1000.),
+                    };
+                    hardware.push(json!({"label":label(&dir,&name,chip,&fallback),"value":value}));
+                }
+            }
+        }
+    }
+    if temperatures.is_empty() {
+        let base = path(root, "/sys/class/thermal");
+        for zone in entries(&base)
+            .into_iter()
+            .filter(|n| n.starts_with("thermal_zone"))
+            .take(128)
+        {
+            let dir = base.join(&zone);
+            let Some(value) = positive(&read(dir.join("temp")))
+                .map(|n| n / 1000.)
+                .filter(|n| *n <= 150.)
+            else {
+                continue;
+            };
+            let name = read(dir.join("type"));
+            temperatures.push(json!({"label":if name.trim().is_empty(){&zone}else{name.trim()},"value":value,"max":100}));
+            if temperatures.len() == 12 {
+                break;
+            }
+        }
+    }
+    if temperatures.is_empty() {
+        if let Some(raw) = lm_sensors() {
+            temperatures = parse_lm_sensors(&raw);
+        }
+    }
+    let hardware_count = hardware.len();
+    let power = power(root);
+    if !power.is_null() {
+        hardware.push(json!({"label":"Battery","value":format!("{}% ({})",power["battery"].as_f64().unwrap_or_default(),power["timeRemaining"].as_str().unwrap_or("unknown"))}));
+        if let Some(watts) = power["powerDraw"].as_f64().filter(|w| *w > 0.) {
+            hardware.push(json!({"label":"Battery draw","value":format!("{watts:.1} W")}));
+        }
+    }
+    for gpu in gpus.as_array().into_iter().flatten().take(16) {
+        let Some(name) = gpu["name"].as_str() else {
+            continue;
+        };
+        let utilization = gpu["utilization"]
+            .as_f64()
+            .map(|n| format!("{:.0}%", (n * 100. + 0.5).floor()))
+            .unwrap_or("unavailable".into());
+        let temperature = gpu["temperature"]
+            .as_f64()
+            .map(|n| format!("{n}°C"))
+            .unwrap_or("temperature unavailable".into());
+        hardware.push(json!({"label":name,"value":format!("{utilization} · {temperature}")}));
+    }
+    let base = path(root, "/sys/devices/system/cpu");
+    let mut cpus: Vec<_> = entries(&base)
+        .into_iter()
+        .filter_map(|name| {
+            let index = name.strip_prefix("cpu")?.parse::<u32>().ok()?;
+            Some((index, name))
+        })
+        .collect();
+    cpus.sort_by_key(|(index, _)| *index);
+    let mut clocks = vec![];
+    for (_, cpu) in cpus.into_iter().take(4) {
+        if let Some(khz) = positive(&read(base.join(&cpu).join("cpufreq/scaling_cur_freq"))) {
+            clocks
+                .push(json!({"label":format!("{cpu} clock"),"value":format!("{:.2} GHz",khz/1e6)}));
+        }
+    }
+    if clocks.is_empty() {
+        for mhz in cpuinfo
+            .lines()
+            .filter_map(|line| {
+                let (key, value) = line.split_once(':')?;
+                (key.trim() == "cpu MHz").then(|| positive(value)).flatten()
+            })
+            .take(4)
+        {
+            clocks.push(json!({"label":format!("cpu{} clock",clocks.len()),"value":format!("{:.2} GHz",mhz/1000.)}));
+        }
+    }
+    hardware.extend(clocks);
+    hardware.truncate(14);
+    Readings {
+        temperatures,
+        sensors: hardware,
+        hardware_count,
+        power,
+    }
+}
+
+pub fn parse_lm_sensors(raw: &str) -> Vec<Value> {
+    let Ok(Value::Object(chips)) = serde_json::from_str::<Value>(raw) else {
+        return vec![];
+    };
+    let mut out = vec![];
+    for (chip, features) in chips {
+        let Some(features) = features.as_object() else {
+            continue;
+        };
+        for (feature, values) in features {
+            let Some(values) = values.as_object() else {
+                continue;
+            };
+            for (key, value) in values {
+                if !input(key, "temp", "_input") {
+                    continue;
+                }
+                let Some(value) = value
+                    .as_f64()
+                    .filter(|v| v.is_finite() && *v > 0. && *v <= 150.)
+                else {
+                    continue;
+                };
+                out.push(json!({"label":format!("{} {feature}",chip.split('-').next().unwrap_or(&chip)),"value":value,"max":100}));
+                if out.len() == 12 {
+                    return out;
+                }
+                break;
+            }
+        }
+    }
+    out
+}
+pub fn parse_gpus(raw: &str) -> Value {
+    let mut out = vec![];
+    for line in raw.lines().take(16) {
+        let fields: Vec<_> = line.split(',').map(str::trim).collect();
+        if fields.len() != 6 || fields[0].is_empty() {
+            continue;
+        }
+        out.push(json!({"name":fields[0],"utilization":finite(fields[1]).map(|n|n/100.),
+            "memoryUsed":finite(fields[2]).map(|n|n*1048576.),"memoryTotal":finite(fields[3]).map(|n|n*1048576.),
+            "temperature":finite(fields[4]),"power":finite(fields[5])}));
+    }
+    json!(out)
+}
+fn power(root: &Path) -> Value {
+    let base = path(root, "/sys/class/power_supply");
+    let names = entries(&base);
+    let ac = names.iter().any(|name| {
+        read(base.join(name).join("type")).trim() == "Mains"
+            && read(base.join(name).join("online")).trim() == "1"
+    });
+    for name in names.into_iter().take(128) {
+        let dir = base.join(name);
+        if read(dir.join("type")).trim() != "Battery" {
+            continue;
+        }
+        let Some(capacity) =
+            finite(&read(dir.join("capacity"))).filter(|n| (0. ..=100.).contains(n))
+        else {
+            continue;
+        };
+        let status = read(dir.join("status"));
+        let watts = finite(&read(dir.join("power_now")))
+            .map(|n| n / 1e6)
+            .or_else(|| {
+                Some(
+                    finite(&read(dir.join("current_now")))?
+                        * finite(&read(dir.join("voltage_now")))?
+                        / 1e12,
+                )
+            });
+        return json!({"battery":capacity,"charging":status.trim()=="Charging","timeRemaining":status.trim(),"powerDraw":watts,"acConnected":ac});
+    }
+    Value::Null
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    struct Fixture(PathBuf);
+    impl Fixture {
+        fn new() -> Self {
+            static SEQUENCE: AtomicUsize = AtomicUsize::new(0);
+            let root = std::env::temp_dir().join(format!(
+                "hqtui-sensors-{}-{}-{}",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_nanos(),
+                SEQUENCE.fetch_add(1, Ordering::Relaxed)
+            ));
+            std::fs::create_dir(&root).unwrap();
+            Self(root)
+        }
+        fn put(&self, name: &str, value: &str) {
+            let file = self.0.join(name);
+            std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+            std::fs::write(file, value).unwrap();
+        }
+        fn read(&self, cpu: &str) -> Readings {
+            collect(&self.0, cpu, &json!([]), || None)
+        }
+    }
+    impl Drop for Fixture {
+        fn drop(&mut self) {
+            std::fs::remove_dir_all(&self.0).unwrap();
+        }
+    }
+    fn sensor(readings: &Readings, label: &str) -> Option<String> {
+        readings
+            .sensors
+            .iter()
+            .find(|s| s["label"] == label)
+            .and_then(|s| s["value"].as_str().map(str::to_owned))
+    }
+    #[test]
+    fn hwmon_sources_and_changed_readings() {
+        let f = Fixture::new();
+        for (name, value) in [
+            ("hwmon0/name", "coretemp"),
+            ("hwmon0/temp1_input", "52000"),
+            ("hwmon0/temp1_label", "Package id 0"),
+            ("hwmon0/temp1_crit", "100000"),
+            ("hwmon0/temp2_input", "49000"),
+            ("hwmon0/temp3_input", "900000"),
+            ("hwmon0/temp4_input", "0"),
+            ("hwmon1/name", "nct6775"),
+            ("hwmon1/fan1_input", "2140"),
+            ("hwmon1/fan1_label", "CPU Fan"),
+            ("hwmon1/fan2_input", "0"),
+            ("hwmon1/in0_input", "1104"),
+            ("hwmon1/in0_label", "Vcore"),
+            ("hwmon1/power1_average", "14300000"),
+            ("hwmon1/curr1_input", "2500"),
+            ("hwmon2/device/temp1_input", "41000"),
+        ] {
+            f.put(&format!("sys/class/hwmon/{name}"), value);
+        }
+        f.put(
+            "sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq",
+            "2900000",
+        );
+        f.put(
+            "sys/devices/system/cpu/cpu1/cpufreq/scaling_cur_freq",
+            "3100000",
+        );
+        let first = f.read("cpu MHz : 9000");
+        assert_eq!(
+            first
+                .temperatures
+                .iter()
+                .map(|t| t["value"].as_f64().unwrap())
+                .collect::<Vec<_>>(),
+            vec![52., 49., 41.]
+        );
+        assert_eq!(first.hardware_count, 4);
+        for (label, value) in [
+            ("CPU Fan", "2140 RPM"),
+            ("Vcore", "1.10 V"),
+            ("nct6775 power1", "14.3 W"),
+            ("nct6775 curr1", "2.50 A"),
+            ("cpu0 clock", "2.90 GHz"),
+            ("cpu1 clock", "3.10 GHz"),
+        ] {
+            assert_eq!(sensor(&first, label).as_deref(), Some(value));
+        }
+        f.put("sys/class/hwmon/hwmon1/fan1_input", "2500");
+        f.put("sys/class/hwmon/hwmon0/temp1_input", "57000");
+        f.put(
+            "sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq",
+            "3300000",
+        );
+        let next = f.read("");
+        assert_eq!(next.temperatures[0]["value"], 57.);
+        assert_eq!(sensor(&next, "CPU Fan").as_deref(), Some("2500 RPM"));
+        assert_eq!(sensor(&next, "cpu0 clock").as_deref(), Some("3.30 GHz"));
+    }
+    #[test]
+    fn vm_cpuinfo_fallback_refreshes_without_inventing_hardware() {
+        let f = Fixture::new();
+        let first = f.read("cpu MHz : 2494.134\ncpu MHz : 2494.134\ncpu MHz : NaN");
+        assert!(first.temperatures.is_empty());
+        assert!(first.power.is_null());
+        assert_eq!(first.hardware_count, 0);
+        assert_eq!(first.sensors.len(), 2);
+        assert_eq!(sensor(&first, "cpu0 clock").as_deref(), Some("2.49 GHz"));
+        assert_eq!(
+            sensor(&f.read("cpu MHz : 3200"), "cpu0 clock").as_deref(),
+            Some("3.20 GHz")
+        );
+        assert!(f.read("").sensors.is_empty());
+    }
+    #[test]
+    fn temperature_fallbacks_and_bad_input() {
+        let f = Fixture::new();
+        let raw = r#"{"coretemp-isa-0000":{"Package id 0":{"temp1_input":53},"bad":{"temp2_input":900}}}"#;
+        let result = collect(&f.0, "", &json!([]), || Some(raw.into()));
+        assert_eq!(result.temperatures.len(), 1);
+        assert_eq!(result.temperatures[0]["value"], 53.);
+        f.put("sys/class/thermal/thermal_zone0/temp", "44000");
+        f.put("sys/class/thermal/thermal_zone0/type", "x86_pkg_temp");
+        let result = collect(&f.0, "", &json!([]), || panic!("thermal source should win"));
+        assert_eq!(result.temperatures[0]["value"], 44.);
+        assert!(parse_lm_sensors("broken").is_empty());
+    }
+    #[test]
+    fn battery_gpu_and_missing_numeric_values() {
+        let f = Fixture::new();
+        for (name, value) in [
+            ("BAT0/type", "Battery"),
+            ("BAT0/capacity", "87"),
+            ("BAT0/status", "Discharging"),
+            ("BAT0/current_now", "2000000"),
+            ("BAT0/voltage_now", "12000000"),
+            ("AC/type", "Mains"),
+            ("AC/online", "1"),
+        ] {
+            f.put(&format!("sys/class/power_supply/{name}"), value);
+        }
+        let gpus = parse_gpus("RTX, 25, 100, 1000, 55, 30\nOther, N/A, N/A, N/A, N/A, N/A\nbroken");
+        assert_eq!(gpus[0]["utilization"], 0.25);
+        assert_eq!(gpus[0]["memoryUsed"], 104857600.);
+        assert!(gpus[1]["temperature"].is_null());
+        let result = collect(&f.0, "", &gpus, || None);
+        assert_eq!(result.power["powerDraw"], 24.);
+        assert_eq!(result.power["acConnected"], true);
+        assert_eq!(
+            sensor(&result, "Battery").as_deref(),
+            Some("87% (Discharging)")
+        );
+        assert_eq!(sensor(&result, "RTX").as_deref(), Some("25% · 55°C"));
+        assert_eq!(
+            sensor(&result, "Other").as_deref(),
+            Some("unavailable · temperature unavailable")
+        );
+    }
+}

--- a/ports/rust/demo/src/tests.rs
+++ b/ports/rust/demo/src/tests.rs
@@ -171,6 +171,30 @@ fn real_is_never_seeded() {
     assert_eq!(s.sample["telemetry"]["sessions"], json!([]));
 }
 #[test]
+fn real_collector_wires_available_sensors_into_dashboard() {
+    if !cfg!(target_os = "linux") {
+        return;
+    }
+    let mut collector = collect::Collector::new();
+    collector.refresh();
+    let mut state = State::new(true, 42);
+    state.sample = collector.sample;
+    let frame = render_to_screen(200, 60, "dark", |ui| dashboard::render(ui, &state));
+    for sensor in model::array(&state.sample["sensors"]).iter().take(4) {
+        assert!(frame.contains(sensor["label"].as_str().unwrap()));
+        assert!(frame.contains(sensor["value"].as_str().unwrap()));
+    }
+    if collect::read("/proc/cpuinfo")
+        .lines()
+        .any(|l| l.starts_with("cpu MHz"))
+    {
+        assert!(
+            !model::array(&state.sample["sensors"]).is_empty(),
+            "CPU clocks are available but Sensors is empty"
+        );
+    }
+}
+#[test]
 fn counter_resets() {
     assert_eq!(collect::rate(100., Some(50.), 2.), 25.);
     assert_eq!(collect::rate(10., Some(50.), 1.), 0.);

--- a/ports/zig/README.md
+++ b/ports/zig/README.md
@@ -1,5 +1,20 @@
 # hqtui — Zig
 
+Fetch latest main and run the full demo (from any directory):
+
+```sh
+# Vanilla: installed toolchain
+curl -fsSL https://hqtui.com/demo.sh | sh -s -- --system zig
+# Mise: pinned toolchain
+curl -fsSL https://hqtui.com/demo.sh | sh -s -- --mise zig
+```
+
+Both update a private cache before running, print the exact commit, and leave
+your checkout alone. Append `--sim` or `--snapshot` directly. Review the
+[launcher](https://hqtui.com/demo.sh) before executing it. In an updated checkout,
+`mise run demo:zig` also updates; `mise run demo-local:zig` and the
+direct example commands below run local source without updating.
+
 High Quality Terminal UI for Zig. btop-grade dashboards with a one-import API,
 dark by default, **standard library only** — no package dependencies, nothing in
 `build.zig.zon` to fetch.


### PR DESCRIPTION
Rust previously never populated the Sensors array. Add native hwmon readings, thermal/lm-sensors fallbacks, CPU clocks (including VM cpuinfo fallback), battery and NVIDIA telemetry. Test changing values, absent hardware, and real collector-to-dashboard wiring; retain 120 TypeScript screen-body comparisons.

Add a reviewed public launcher that fetches main every invocation, prints the exact SHA, caches release builds, preserves caller checkouts, and fails closed on update errors. Show vanilla and mise variants for TypeScript, Rust, Go, Python and Zig on homepage/docs. Keep local-development mise tasks separately. Never change logo or hero assets.

Validation: Rust example and standalone tests, hermetic updater integration tests (including changed Git revisions, stale fetch refusal, preserved edits and PTY keyboard input), shellcheck, web tests and production site build. Live launcher builds and terminal cleanup checks exercised against GitHub. Full live-data parity and Go/Python/Zig layout parity remain explicitly documented as unfinished.