### PR TITLE
Fix live sensor, Traffic and Sessions data in all native dashboards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
       - run: mise run test:python
       - run: mise run test:zig
       - run: python apps/demo/scripts/check-native-commands.py
+      - run: python apps/demo/scripts/check-native-data.py
 
   python:
     name: Python examples and terminal cleanup

--- a/apps/demo/scripts/check-native-data.py
+++ b/apps/demo/scripts/check-native-data.py
@@ -1,0 +1,59 @@
+"""Exercise every full native CLI's real collector -> sample -> rendered tabs.
+
+Only this test process sees fixture utilities in a temporary PATH. No installed
+commands, real logs, services or network endpoints are modified.
+"""
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[3]
+COMMANDS = {
+    'rust': ['mise', 'exec', 'rust@1.97.1', '--', 'cargo', 'run', '--example', 'dashboard', '--'],
+    'go': ['mise', 'exec', 'go@1.26.0', '--', 'go', 'run', './examples/dashboard'],
+    'python': ['mise', 'exec', 'python@3.12.13', '--', 'python', '-m', 'examples.dashboard'],
+    'zig': ['mise', 'exec', 'zig@0.16.0', '--', 'zig', 'build', 'run-dashboard', '--'],
+}
+
+
+def main():
+    fixture = json.loads((ROOT / 'ports/conformance/fixtures/demo-traffic.json').read_text())
+    utility = '''#!/usr/bin/env python3
+import json, os, sys
+fixture=json.loads(os.environ['HQTUI_TEST_TRAFFIC'])
+name=os.path.basename(sys.argv[0])
+if name=='who': print(fixture['who'])
+elif name=='last': print(fixture['last'])
+elif name=='lastb': print(fixture['lastb'])
+elif name=='ss':
+    for c in fixture['connections']:
+        print(c['proto'],c['state'],'0 0',c['local'],c['remote'])
+elif name=='journalctl':
+    if '-u' in sys.argv: print(fixture['ssh'])
+elif name=='nvidia-smi': print('Test GPU, 25, 100, 1000, 55, 30')
+'''
+    with tempfile.TemporaryDirectory(prefix='hqtui-native-data-') as directory:
+        for name in ('who', 'last', 'lastb', 'ss', 'journalctl', 'nvidia-smi'):
+            path = Path(directory) / name
+            path.write_text(utility)
+            path.chmod(0o700)
+        env = {**os.environ, 'PATH': directory + os.pathsep + os.environ['PATH'],
+               'HQTUI_TEST_TRAFFIC': json.dumps(fixture)}
+        for language, command in COMMANDS.items():
+            for screen, expected in [('dashboard', ['Sensors', 'Test GPU', '25%']),
+                                     ('traffic', ['HTTPS', 'DNS', 'SSH', 'accepted', 'alice']),
+                                     ('sessions', ['alice', 'eve', 'still', 'failed'])]:
+                result = subprocess.run([*command, '--real', '--snapshot', '--screen', screen,
+                                         '--width', '240', '--height', '80'], cwd=ROOT / 'ports' / language,
+                                        env=env, capture_output=True, text=True, timeout=120)
+                assert result.returncode == 0, (language, result.stderr)
+                for label in expected:
+                    assert label.lower() in result.stdout.lower(), (language, screen, f'missing {label}')
+                assert 'simulated' not in result.stdout.lower(), (language, screen)
+                print(f'{language} {screen}: fixture utilities reached the real collector and rendered rows', flush=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/apps/demo/test/native-telemetry-reference.test.ts
+++ b/apps/demo/test/native-telemetry-reference.test.ts
@@ -1,0 +1,12 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { breakdown } from "../src/system/linux-traffic.ts";
+
+test("native Traffic fixture matches the TypeScript port-based reference", () => {
+  const fixture = JSON.parse(readFileSync(new URL("../../../ports/conformance/fixtures/demo-traffic.json", import.meta.url), "utf8"));
+  const result = breakdown(fixture.connections.filter((c: { state: string }) => c.state !== "LISTEN"), fixture.listeners);
+  assert.equal(result.inbound, 1);
+  assert.equal(result.outbound, 2);
+  assert.deepEqual(Object.fromEntries(result.protocols.map(p => [p.protocol,p.total])), {SSH: 1, HTTPS: 1, DNS: 1});
+});

--- a/apps/web/app/docs/page.tsx
+++ b/apps/web/app/docs/page.tsx
@@ -87,6 +87,15 @@ export default async function Docs() {
             Headless screenshots work without a TTY. Zig requires version 0.16.
           </P>
           <P>
+            Linux sensor panels now collect available hwmon temperatures, fans, voltage,
+            current and power, plus CPU clocks (including the /proc/cpuinfo fallback for VMs),
+            battery and NVIDIA readings. Traffic and Sessions read socket breakdowns,
+            login/failed-login history, SSH events and readable HTTP access logs.
+            Protocol/direction labels are port-based estimates; HTTP request rates are estimated
+            from log growth. No active sessions or unreadable logs can legitimately leave a
+            panel empty. These demos do not request elevated privileges or invent real-mode data.
+          </P>
+          <P>
             Vanilla commands require Git, curl and the language&apos;s installed toolchain
             (Bun for TypeScript). The <a href="https://mise.jdx.dev/" className="text-[#5fff87] underline underline-offset-4">mise</a>
             alternatives install/use only the selected pinned toolchain without loading project

--- a/ports/conformance/fixtures/demo-sensors.json
+++ b/ports/conformance/fixtures/demo-sensors.json
@@ -1,0 +1,51 @@
+[
+  {
+    "name": "hwmon and legacy device paths",
+    "files": {
+      "sys/class/hwmon/hwmon0/name": "coretemp",
+      "sys/class/hwmon/hwmon0/temp1_input": "52000",
+      "sys/class/hwmon/hwmon0/temp1_label": "Package id 0",
+      "sys/class/hwmon/hwmon0/temp2_input": "900000",
+      "sys/class/hwmon/hwmon0/temp3_input": "NaN",
+      "sys/class/hwmon/hwmon1/name": "nct6775",
+      "sys/class/hwmon/hwmon1/fan1_input": "2140",
+      "sys/class/hwmon/hwmon1/fan1_label": "CPU Fan",
+      "sys/class/hwmon/hwmon1/fan2_input": "0",
+      "sys/class/hwmon/hwmon1/in0_input": "1104",
+      "sys/class/hwmon/hwmon1/in0_label": "Vcore",
+      "sys/class/hwmon/hwmon1/power1_average": "14300000",
+      "sys/class/hwmon/hwmon1/curr1_input": "2500",
+      "sys/class/hwmon/hwmon2/name": "legacy",
+      "sys/class/hwmon/hwmon2/device/temp1_input": "41000",
+      "sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq": "2900000"
+    },
+    "cpuinfo": "cpu MHz : 9000",
+    "temperatures": [52, 41],
+    "sensors": {"CPU Fan": "2140 RPM", "Vcore": "1.10 V", "nct6775 power1": "14.3 W", "nct6775 curr1": "2.50 A", "cpu0 clock": "2.90 GHz"},
+    "changes": {"sys/class/hwmon/hwmon1/fan1_input": "2500", "sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq": "3300000"},
+    "nextSensors": {"CPU Fan": "2500 RPM", "cpu0 clock": "3.30 GHz"}
+  },
+  {
+    "name": "VM clock fallback without fake hardware",
+    "files": {}, "cpuinfo": "cpu MHz : 2494.134\ncpu MHz : 2494.134\ncpu MHz : NaN",
+    "temperatures": [], "sensors": {"cpu0 clock": "2.49 GHz", "cpu1 clock": "2.49 GHz"},
+    "nextCpuinfo": "cpu MHz : 3200", "nextSensors": {"cpu0 clock": "3.20 GHz"}
+  },
+  {
+    "name": "thermal zone fallback",
+    "files": {"sys/class/thermal/thermal_zone0/temp": "44000", "sys/class/thermal/thermal_zone0/type": "x86_pkg_temp"},
+    "cpuinfo": "", "temperatures": [44], "sensors": {}
+  },
+  {
+    "name": "lm-sensors fallback",
+    "files": {}, "cpuinfo": "",
+    "lm": "{\"coretemp-isa-0000\":{\"Package id 0\":{\"temp1_input\":53},\"bad\":{\"temp2_input\":900}}}",
+    "temperatures": [53], "sensors": {}
+  },
+  {
+    "name": "battery and GPU, unknown values stay unavailable",
+    "files": {"sys/class/power_supply/BAT0/type": "Battery", "sys/class/power_supply/BAT0/capacity": "87", "sys/class/power_supply/BAT0/status": "Discharging", "sys/class/power_supply/BAT0/current_now": "2000000", "sys/class/power_supply/BAT0/voltage_now": "12000000", "sys/class/power_supply/AC/type": "Mains", "sys/class/power_supply/AC/online": "1"},
+    "cpuinfo": "", "gpus": "RTX, 25, 100, 1000, 55, 30\nOther, N/A, N/A, N/A, N/A, N/A",
+    "temperatures": [], "sensors": {"Battery": "87% (Discharging)", "Battery draw": "24.0 W", "RTX": "25% · 55°C", "Other": "unavailable · temperature unavailable"}
+  }
+]

--- a/ports/conformance/fixtures/demo-traffic.json
+++ b/ports/conformance/fixtures/demo-traffic.json
@@ -1,0 +1,14 @@
+{
+  "who": "alice pts/0 2026-09-06 10:00 . 123 (203.0.113.4)\n",
+  "last": "alice pts/0 203.0.113.4 Sun Sep 6 10:00 still logged in\nreboot system boot 6.8 Sun Sep 6 09:00\nwtmp begins Sun Sep 6 09:00\n",
+  "lastb": "eve ssh:notty 203.0.113.8 Sun Sep 6 09:00 - 09:00 (00:00)\nbtmp begins Sun Sep 6 08:00\n",
+  "ssh": "2026-09-06T10:01:02+00:00 host sshd[1]: Accepted publickey for alice from 203.0.113.4 port 60000 ssh2\nSep 6 10:02:03 host sshd[2]: Failed password for invalid user eve from 203.0.113.8 port 60001 ssh2\nSep 6 10:03:04 host sshd[1]: Disconnected from authenticating user alice 203.0.113.4 port 60000\nSep 6 10:04:05 unrelated[1]: Accepted password for fake from nowhere\n",
+  "connections": [
+    {"proto":"tcp","state":"ESTAB","local":"10.0.0.1:22","remote":"203.0.113.4:60000"},
+    {"proto":"tcp","state":"ESTAB","local":"[::1]:50000","remote":"[2001:db8::1]:443"},
+    {"proto":"udp","state":"UNCONN","local":"10.0.0.1:50001","remote":"192.0.2.53:53"},
+    {"proto":"tcp","state":"LISTEN","local":"0.0.0.0:22","remote":"0.0.0.0:*"}
+  ],
+  "listeners": [{"port":"22","proto":"tcp","address":"0.0.0.0"}],
+  "http": "192.0.2.1 - - [06/Sep/2026:10:01:00 +0000] \"GET /health HTTP/1.1\" 200 12\n192.0.2.2 - - [06/Sep/2026:10:01:01 +0000] \"GET /missing?token=secret HTTP/1.1\" 404 4\n192.0.2.1 - - [06/Sep/2026:10:01:02 +0000] \"GET /chat HTTP/1.1\" 101 -\nmalformed line\n"
+}

--- a/ports/go/internal/demo/collect.go
+++ b/ports/go/internal/demo/collect.go
@@ -56,6 +56,7 @@ func counterRate(now, previous, dt float64, known bool) float64 {
 }
 
 type collector struct {
+	http                 httpCollector
 	sample               object
 	previous             map[string]float64
 	cpu                  map[string][2]float64
@@ -183,11 +184,11 @@ func (c *collector) refresh() {
 	c.processes(dt)
 	c.network(dt)
 	c.disks(dt)
-	c.sensors()
 	if c.slow.IsZero() || now.Sub(c.slow) >= 5*time.Second {
 		c.slow = now
 		c.slowCollect()
 	}
+	c.sensors()
 	c.missing = append(c.missing, c.slowMissing...)
 }
 func (c *collector) processes(dt float64) {
@@ -257,6 +258,24 @@ func (c *collector) processes(dt float64) {
 	}
 	c.procs = current
 	c.sample["processes"] = rows
+	states := object{"total": float64(len(rows)), "running": 0., "sleeping": 0., "stopped": 0., "zombie": 0.}
+	for _, v := range rows {
+		key := ""
+		switch str(obj(v)["state"]) {
+		case "R":
+			key = "running"
+		case "S", "D":
+			key = "sleeping"
+		case "T", "t":
+			key = "stopped"
+		case "Z":
+			key = "zombie"
+		}
+		if key != "" {
+			states[key] = num(states[key]) + 1
+		}
+	}
+	obj(c.sample["telemetry"])["states"] = states
 	sys := obj(c.sample["system"])
 	sys["processCount"] = len(rows)
 	sys["threadCount"] = threads
@@ -326,7 +345,9 @@ func (c *collector) network(dt float64) {
 	net := obj(tele["net"])
 	for key := range net {
 		source := ""
-		if strings.HasPrefix(key, "tcp") || strings.HasPrefix(key, "udp") {
+		if key == "tcpEstablished" {
+			source = "TcpCurrEstab"
+		} else if strings.HasPrefix(key, "tcp") || strings.HasPrefix(key, "udp") {
 			source = strings.ToUpper(key[:1]) + key[1:]
 		} else if strings.HasPrefix(key, "icmp") {
 			source = "Icmp" + key[4:]
@@ -372,28 +393,26 @@ func (c *collector) disks(dt float64) {
 	c.sample["disks"] = disks
 }
 func (c *collector) sensors() {
-	temps := []any{}
-	paths, _ := filepath.Glob("/sys/class/hwmon/hwmon*/temp*_input")
-	for _, path := range paths {
-		raw := strings.TrimSpace(readFile(path))
-		if raw == "" {
-			continue
-		}
-		v := number(raw) / 1000
-		if v < -50 || v > 200 {
-			continue
-		}
-		label := strings.TrimSpace(readFile(strings.Replace(path, "_input", "_label", 1)))
-		if label == "" {
-			label = filepath.Base(path)
-		}
-		temps = append(temps, object{"label": label, "value": v, "max": 100.})
+	t := obj(c.sample["telemetry"])
+	r := collectSensors("/sys", readFile("/proc/cpuinfo"), arr(t["gpus"]), func() string { raw, _ := command("sensors", "-j"); return raw })
+	c.sample["temperatures"] = r.temperatures
+	c.sample["sensors"] = r.sensors
+	t["power"] = r.power
+	if len(r.temperatures) == 0 {
+		c.missing = append(c.missing, "temperatures")
 	}
-	c.sample["temperatures"] = temps
+	if r.hardwareCount == 0 {
+		c.missing = append(c.missing, "fans/voltage/power")
+	}
 }
 func (c *collector) slowCollect() {
 	t := obj(c.sample["telemetry"])
 	missing := []string{}
+	gpuRaw, _ := command("nvidia-smi", "--query-gpu=name,utilization.gpu,memory.used,memory.total,temperature.gpu,power.draw", "--format=csv,noheader,nounits")
+	t["gpus"] = parseGPUs(gpuRaw)
+	if len(arr(t["gpus"])) == 0 {
+		missing = append(missing, "GPU telemetry")
+	}
 	run := func(label string, args ...string) string {
 		out, ok := command(args...)
 		if !ok {
@@ -401,13 +420,7 @@ func (c *collector) slowCollect() {
 		}
 		return out
 	}
-	sessions := []any{}
-	for _, line := range strings.Split(run("sessions", "who"), "\n") {
-		f := strings.Fields(line)
-		if len(f) >= 4 {
-			sessions = append(sessions, object{"user": f[0], "tty": f[1], "loginAt": strings.Join(f[2:4], " "), "from": strings.Join(f[4:], " "), "idle": "—", "what": "—"})
-		}
-	}
+	sessions := trafficSessions(run("sessions", "who", "-u"))
 	t["sessions"] = sessions
 	push(t, "sessionHistory", float64(len(sessions)))
 	services := []any{}
@@ -429,7 +442,7 @@ func (c *collector) slowCollect() {
 		}
 		process := strings.Join(f[6:], " ")
 		connections = append(connections, object{"proto": f[0], "state": f[1], "local": f[4], "remote": f[5], "process": process})
-		if f[1] == "LISTEN" || f[1] == "UNCONN" {
+		if f[1] == "LISTEN" {
 			cut := strings.LastIndex(f[4], ":")
 			if cut >= 0 {
 				listeners = append(listeners, object{"proto": f[0], "address": f[4][:cut], "port": f[4][cut+1:], "process": process})
@@ -473,5 +486,6 @@ func (c *collector) slowCollect() {
 		}
 	}
 	t["filesystems"] = filesystems
-	c.slowMissing = append(missing, "connection direction/application protocols", "login history", "SSH authentication log", "HTTP access log", "GPU/power")
+	c.trafficCollect(&missing)
+	c.slowMissing = missing
 }

--- a/ports/go/internal/demo/sensors.go
+++ b/ports/go/internal/demo/sensors.go
@@ -1,0 +1,271 @@
+package demo
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+var sensorInput = regexp.MustCompile(`^(temp|fan|in|power|curr)([0-9]+)_(input|average)$`)
+var cpuDirectory = regexp.MustCompile(`^cpu([0-9]+)$`)
+
+func sensorNumber(raw string) (float64, bool) {
+	v, err := strconv.ParseFloat(strings.TrimSpace(raw), 64)
+	return v, err == nil && !math.IsNaN(v) && !math.IsInf(v, 0)
+}
+func sensorPositive(raw string) (float64, bool) { v, ok := sensorNumber(raw); return v, ok && v > 0 }
+func sensorEntries(path string) []string {
+	dir, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer dir.Close()
+	names, _ := dir.Readdirnames(4096)
+	sort.Strings(names)
+	return names
+}
+
+type sensorReadings struct {
+	temperatures, sensors []any
+	power                 any
+	hardwareCount         int
+}
+
+func collectSensors(sysroot, cpuinfo string, gpus []any, lm func() string) sensorReadings {
+	out := sensorReadings{temperatures: []any{}, sensors: []any{}}
+	read := func(path string) string { return strings.TrimSpace(readFile(path)) }
+	base := filepath.Join(sysroot, "class/hwmon")
+	for i, folder := range sensorEntries(base) {
+		if i >= 128 {
+			break
+		}
+		dir := filepath.Join(base, folder)
+		chip := read(filepath.Join(dir, "name"))
+		if chip == "" {
+			chip = read(filepath.Join(dir, "device/name"))
+		}
+		if chip == "" {
+			chip = folder
+		}
+		for _, dir := range []string{dir, filepath.Join(dir, "device")} {
+			for _, name := range sensorEntries(dir) {
+				match := sensorInput.FindStringSubmatch(name)
+				if match == nil {
+					continue
+				}
+				kind, index, suffix := match[1], match[2], match[3]
+				if suffix == "average" && kind != "power" {
+					continue
+				}
+				value, ok := sensorPositive(read(filepath.Join(dir, name)))
+				if !ok {
+					continue
+				}
+				label := read(filepath.Join(dir, kind+index+"_label"))
+				if label == "" {
+					fallback := kind + index
+					if kind == "fan" {
+						fallback = "Fan " + index
+					}
+					label = chip + " " + fallback
+				}
+				if kind == "temp" {
+					if value > 150000 || len(out.temperatures) >= 12 {
+						continue
+					}
+					maximum, ok := sensorPositive(read(filepath.Join(dir, kind+index+"_crit")))
+					if !ok {
+						maximum = 100000
+					}
+					out.temperatures = append(out.temperatures, object{"label": label, "value": value / 1000, "max": maximum / 1000})
+				} else if len(out.sensors) < 14 {
+					text := ""
+					switch kind {
+					case "fan":
+						text = fmt.Sprintf("%.0f RPM", math.Floor(value+.5))
+					case "in":
+						text = fmt.Sprintf("%.2f V", value/1000)
+					case "power":
+						text = fmt.Sprintf("%.1f W", value/1e6)
+					case "curr":
+						text = fmt.Sprintf("%.2f A", value/1000)
+					}
+					out.sensors = append(out.sensors, object{"label": label, "value": text})
+				}
+			}
+		}
+	}
+	if len(out.temperatures) == 0 {
+		base := filepath.Join(sysroot, "class/thermal")
+		for i, name := range sensorEntries(base) {
+			if i >= 128 {
+				break
+			}
+			if !strings.HasPrefix(name, "thermal_zone") {
+				continue
+			}
+			dir := filepath.Join(base, name)
+			value, ok := sensorPositive(read(filepath.Join(dir, "temp")))
+			if !ok || value > 150000 {
+				continue
+			}
+			label := read(filepath.Join(dir, "type"))
+			if label == "" {
+				label = name
+			}
+			out.temperatures = append(out.temperatures, object{"label": label, "value": value / 1000, "max": 100.})
+			if len(out.temperatures) == 12 {
+				break
+			}
+		}
+	}
+	if len(out.temperatures) == 0 {
+		var chips object
+		if json.Unmarshal([]byte(lm()), &chips) == nil {
+			for _, chip := range sortedKeys(chips) {
+				for _, feature := range sortedKeys(obj(chips[chip])) {
+					values := obj(obj(chips[chip])[feature])
+					for _, key := range sortedKeys(values) {
+						match := sensorInput.FindStringSubmatch(key)
+						value, ok := values[key].(float64)
+						if match != nil && match[1] == "temp" && match[3] == "input" && ok && value > 0 && value <= 150 {
+							if len(out.temperatures) < 12 {
+								out.temperatures = append(out.temperatures, object{"label": strings.Split(chip, "-")[0] + " " + feature, "value": value, "max": 100.})
+							}
+							break
+						}
+					}
+				}
+			}
+		}
+	}
+	out.hardwareCount = len(out.sensors)
+	out.power = sensorBattery(sysroot)
+	if power, ok := out.power.(object); ok {
+		out.sensors = append(out.sensors, object{"label": "Battery", "value": fmt.Sprintf("%g%% (%s)", num(power["battery"]), str(power["timeRemaining"]))})
+		if watts := num(power["powerDraw"]); watts > 0 {
+			out.sensors = append(out.sensors, object{"label": "Battery draw", "value": fmt.Sprintf("%.1f W", watts)})
+		}
+	}
+	for i, v := range gpus {
+		if i >= 16 {
+			break
+		}
+		gpu := obj(v)
+		usage, temp := "unavailable", "temperature unavailable"
+		if gpu["utilization"] != nil {
+			usage = fmt.Sprintf("%.0f%%", math.Floor(num(gpu["utilization"])*100+.5))
+		}
+		if gpu["temperature"] != nil {
+			temp = fmt.Sprintf("%g°C", num(gpu["temperature"]))
+		}
+		out.sensors = append(out.sensors, object{"label": gpu["name"], "value": usage + " · " + temp})
+	}
+	clocks := []any{}
+	base = filepath.Join(sysroot, "devices/system/cpu")
+	cpus := []string{}
+	for _, name := range sensorEntries(base) {
+		if cpuDirectory.MatchString(name) {
+			cpus = append(cpus, name)
+		}
+	}
+	sort.Slice(cpus, func(i, j int) bool {
+		a, _ := strconv.Atoi(cpus[i][3:])
+		b, _ := strconv.Atoi(cpus[j][3:])
+		return a < b
+	})
+	for i, cpu := range cpus {
+		if i >= 4 {
+			break
+		}
+		if value, ok := sensorPositive(read(filepath.Join(base, cpu, "cpufreq/scaling_cur_freq"))); ok {
+			clocks = append(clocks, object{"label": cpu + " clock", "value": fmt.Sprintf("%.2f GHz", value/1e6)})
+		}
+	}
+	if len(clocks) == 0 {
+		for _, line := range strings.Split(cpuinfo, "\n") {
+			key, raw, ok := strings.Cut(line, ":")
+			if !ok || strings.TrimSpace(key) != "cpu MHz" {
+				continue
+			}
+			if value, ok := sensorPositive(raw); ok {
+				clocks = append(clocks, object{"label": fmt.Sprintf("cpu%d clock", len(clocks)), "value": fmt.Sprintf("%.2f GHz", value/1000)})
+				if len(clocks) == 4 {
+					break
+				}
+			}
+		}
+	}
+	out.sensors = append(out.sensors, clocks...)
+	out.sensors = out.sensors[:min(14, len(out.sensors))]
+	return out
+}
+func sortedKeys(o object) []string {
+	keys := make([]string, 0, len(o))
+	for k := range o {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+func sensorBattery(sysroot string) any {
+	base := filepath.Join(sysroot, "class/power_supply")
+	names := sensorEntries(base)
+	names = names[:min(128, len(names))]
+	read := func(name, key string) string { return strings.TrimSpace(readFile(filepath.Join(base, name, key))) }
+	ac := false
+	for _, name := range names {
+		if read(name, "type") == "Mains" && read(name, "online") == "1" {
+			ac = true
+		}
+	}
+	for _, name := range names {
+		if read(name, "type") != "Battery" {
+			continue
+		}
+		capacity, ok := sensorNumber(read(name, "capacity"))
+		if !ok || capacity < 0 || capacity > 100 {
+			continue
+		}
+		var watts any
+		if value, ok := sensorNumber(read(name, "power_now")); ok {
+			watts = value / 1e6
+		} else {
+			amps, a := sensorNumber(read(name, "current_now"))
+			volts, v := sensorNumber(read(name, "voltage_now"))
+			if a && v {
+				watts = amps * volts / 1e12
+			}
+		}
+		status := read(name, "status")
+		return object{"battery": capacity, "charging": status == "Charging", "timeRemaining": status, "powerDraw": watts, "acConnected": ac}
+	}
+	return nil
+}
+func parseGPUs(raw string) []any {
+	out := []any{}
+	for i, line := range strings.Split(raw, "\n") {
+		if i >= 16 {
+			break
+		}
+		f := strings.Split(line, ",")
+		if len(f) != 6 || strings.TrimSpace(f[0]) == "" {
+			continue
+		}
+		row := object{"name": strings.TrimSpace(f[0])}
+		for i, key := range []string{"utilization", "memoryUsed", "memoryTotal", "temperature", "power"} {
+			row[key] = nil
+			if value, ok := sensorNumber(f[i+1]); ok && value >= 0 {
+				row[key] = value * []float64{.01, 1048576, 1048576, 1, 1}[i]
+			}
+		}
+		out = append(out, row)
+	}
+	return out
+}

--- a/ports/go/internal/demo/sensors_test.go
+++ b/ports/go/internal/demo/sensors_test.go
@@ -1,0 +1,84 @@
+package demo
+
+import (
+	"encoding/json"
+	ui "github.com/profullstack/hqtui/ports/go"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestSharedSensorsRefreshAndRender(t *testing.T) {
+	var cases []struct {
+		Name                 string
+		Files, Changes       map[string]string
+		CPUInfo              string  `json:"cpuinfo"`
+		NextCPUInfo          *string `json:"nextCpuinfo"`
+		GPUs, LM             string
+		Temperatures         []float64
+		Sensors, NextSensors map[string]string
+	}
+	raw, err := os.ReadFile("../../../conformance/fixtures/demo-sensors.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = json.Unmarshal(raw, &cases); err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			root := t.TempDir()
+			write := func(files map[string]string) {
+				for name, value := range files {
+					path := filepath.Join(root, name)
+					if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+						t.Fatal(err)
+					}
+					if err := os.WriteFile(path, []byte(value), 0600); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+			write(c.Files)
+			read := func(cpu string) sensorReadings {
+				return collectSensors(filepath.Join(root, "sys"), cpu, parseGPUs(c.GPUs), func() string { return c.LM })
+			}
+			first := read(c.CPUInfo)
+			temps := []float64{}
+			values := map[string]string{}
+			for _, v := range first.temperatures {
+				temps = append(temps, num(obj(v)["value"]))
+			}
+			for _, v := range first.sensors {
+				values[str(obj(v)["label"])] = str(obj(v)["value"])
+			}
+			if !reflect.DeepEqual(temps, c.Temperatures) || !reflect.DeepEqual(values, c.Sensors) {
+				t.Fatalf("temperatures=%v sensors=%v", temps, values)
+			}
+			s := newState(true, 42)
+			s.sample["temperatures"] = first.temperatures
+			s.sample["sensors"] = first.sensors
+			frame := ui.RenderToScreen(220, 70, "dark", s.render)
+			for label, value := range values {
+				if !frame.Contains(label) || !frame.Contains(value) {
+					t.Fatalf("sensor not rendered: %s=%s", label, value)
+				}
+			}
+			write(c.Changes)
+			cpu := c.CPUInfo
+			if c.NextCPUInfo != nil {
+				cpu = *c.NextCPUInfo
+			}
+			values = map[string]string{}
+			for _, v := range read(cpu).sensors {
+				values[str(obj(v)["label"])] = str(obj(v)["value"])
+			}
+			for label, value := range c.NextSensors {
+				if values[label] != value {
+					t.Fatalf("stale %s: %s", label, values[label])
+				}
+			}
+		})
+	}
+}

--- a/ports/go/internal/demo/traffic.go
+++ b/ports/go/internal/demo/traffic.go
@@ -1,0 +1,334 @@
+package demo
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Same port-based estimates as TypeScript. No packet capture or active probes.
+const protocolPorts = "20=FTP 21=FTP 22=SSH 23=Telnet 25=SMTP 53=DNS 67=DHCP 68=DHCP 80=HTTP 110=POP3 111=RPC 123=NTP 143=IMAP 161=SNMP 389=LDAP 443=HTTPS 445=SMB 465=SMTPS 514=Syslog 587=SMTP 631=IPP 636=LDAPS 993=IMAPS 995=POP3S 1194=OpenVPN 1433=MSSQL 1521=Oracle 2049=NFS 2379=etcd 3000=HTTP-dev 3306=MySQL 3389=RDP 4000=HTTP-dev 5000=HTTP-dev 5432=Postgres 5672=AMQP 5900=VNC 6379=Redis 8000=HTTP-alt 8080=HTTP-alt 8443=HTTPS-alt 9000=HTTP-alt 9090=Prometheus 9200=Elasticsearch 11211=Memcached 27017=MongoDB 41641=Tailscale 51820=WireGuard"
+
+func classifyPort(port string) string {
+	for _, pair := range strings.Fields(protocolPorts) {
+		key, value, _ := strings.Cut(pair, "=")
+		if key == port {
+			return value
+		}
+	}
+	if n, _ := strconv.Atoi(port); n >= 32768 {
+		return "ephemeral"
+	}
+	return "port " + port
+}
+func splitEndpoint(endpoint string) (string, string) {
+	cut := strings.LastIndex(endpoint, ":")
+	if cut < 0 {
+		return endpoint, ""
+	}
+	return endpoint[:cut], endpoint[cut+1:]
+}
+func socketBreakdown(connections, listeners []any) object {
+	listening := map[string]bool{}
+	for _, v := range listeners {
+		listening[str(obj(v)["port"])] = true
+	}
+	buckets, remotes := map[string]object{}, map[string]object{}
+	order, hosts := []string{}, []string{}
+	protocolsByHost := map[string][]string{}
+	in, out := 0., 0.
+	for _, v := range connections {
+		c := obj(v)
+		if str(c["state"]) == "LISTEN" || (str(c["state"]) != "ESTAB" && !strings.HasPrefix(str(c["proto"]), "udp")) {
+			continue
+		}
+		_, lp := splitEndpoint(str(c["local"]))
+		host, rp := splitEndpoint(str(c["remote"]))
+		incoming := listening[lp]
+		port := rp
+		if incoming {
+			port = lp
+		}
+		protocol := classifyPort(port)
+		if buckets[protocol] == nil {
+			buckets[protocol] = object{"protocol": protocol, "inbound": 0., "outbound": 0., "total": 0.}
+			order = append(order, protocol)
+		}
+		b := buckets[protocol]
+		key := "outbound"
+		if incoming {
+			key = "inbound"
+			in++
+		} else {
+			out++
+		}
+		b[key] = num(b[key]) + 1
+		b["total"] = num(b["total"]) + 1
+		if host != "" && host != "*" && host != "0.0.0.0" {
+			if remotes[host] == nil {
+				remotes[host] = object{"host": host, "connections": 0.}
+				hosts = append(hosts, host)
+			}
+			r := remotes[host]
+			r["connections"] = num(r["connections"]) + 1
+			seen := false
+			for _, p := range protocolsByHost[host] {
+				if p == protocol {
+					seen = true
+				}
+			}
+			if !seen {
+				protocolsByHost[host] = append(protocolsByHost[host], protocol)
+			}
+		}
+	}
+	sort.SliceStable(order, func(i, j int) bool { return num(buckets[order[i]]["total"]) > num(buckets[order[j]]["total"]) })
+	sort.SliceStable(hosts, func(i, j int) bool {
+		return num(remotes[hosts[i]]["connections"]) > num(remotes[hosts[j]]["connections"])
+	})
+	bs, rs := []any{}, []any{}
+	for _, p := range order {
+		bs = append(bs, buckets[p])
+	}
+	for _, host := range hosts[:min(12, len(hosts))] {
+		ps := protocolsByHost[host]
+		remotes[host]["protocols"] = strings.Join(ps[:min(3, len(ps))], ", ")
+		rs = append(rs, remotes[host])
+	}
+	return object{"protocols": bs, "remotes": rs, "inboundConnections": in, "outboundConnections": out}
+}
+
+var originPattern = regexp.MustCompile(`\(([^)]+)\)`)
+
+func trafficTime(raw string) string {
+	for i := 0; i+8 <= len(raw); i++ {
+		if i > 0 && raw[i-1] >= '0' && raw[i-1] <= '9' {
+			continue
+		}
+		s := raw[i : i+8]
+		if s[2] != ':' || s[5] != ':' {
+			continue
+		}
+		valid := true
+		for _, j := range []int{0, 1, 3, 4, 6, 7} {
+			if s[j] < '0' || s[j] > '9' {
+				valid = false
+			}
+		}
+		if valid {
+			return s
+		}
+	}
+	return ""
+}
+
+var authPattern = regexp.MustCompile(`(Accepted|Failed) (\S+) for (invalid user )?(\S+) from (\S+)`)
+var disconnectPattern = regexp.MustCompile(`Disconnected from (?:authenticating )?user (\S+) (\S+)`)
+
+func trafficSessions(raw string) []any {
+	out := []any{}
+	for _, line := range strings.Split(raw, "\n") {
+		f := strings.Fields(line)
+		if len(f) < 4 {
+			continue
+		}
+		origin, idle, what := "local", ".", ""
+		if m := originPattern.FindStringSubmatch(line); m != nil {
+			origin = m[1]
+		}
+		if len(f) > 4 {
+			idle = f[4]
+		}
+		if len(f) > 5 {
+			what = f[5]
+		}
+		out = append(out, object{"user": f[0], "tty": f[1], "loginAt": strings.Join(f[2:4], " "), "idle": idle, "what": what, "from": origin})
+		if len(out) == 1000 {
+			break
+		}
+	}
+	return out
+}
+func trafficLogins(raw, status string) []any {
+	out := []any{}
+	for _, line := range strings.Split(raw, "\n") {
+		f := strings.Fields(line)
+		if len(f) < 4 || f[0] == "wtmp" || f[0] == "btmp" || f[0] == "reboot" {
+			continue
+		}
+		from := "local"
+		if strings.ContainsAny(f[2], ".:") {
+			from = f[2]
+		}
+		state := status
+		if strings.Contains(line, "still logged in") {
+			state = "still"
+		}
+		when := strings.Join(f[max(0, len(f)-7):len(f)-3], " ")
+		if when == "" {
+			when = strings.Join(f[3:min(7, len(f))], " ")
+		}
+		out = append(out, object{"user": f[0], "tty": f[1], "from": from, "when": when, "status": state})
+		if len(out) == 40 {
+			break
+		}
+	}
+	return out
+}
+func trafficSSH(raw string) []any {
+	out := []any{}
+	for _, line := range strings.Split(raw, "\n") {
+		if !strings.Contains(line, "sshd") {
+			continue
+		}
+		stamp := trafficTime(line)
+		if m := authPattern.FindStringSubmatch(line); m != nil {
+			action := "failed"
+			if m[1] == "Accepted" {
+				action = "accepted"
+			} else if m[3] != "" {
+				action = "invalid"
+			}
+			out = append(out, object{"time": stamp, "action": action, "user": m[4], "from": m[5], "method": m[2]})
+		} else if m := disconnectPattern.FindStringSubmatch(line); m != nil {
+			out = append(out, object{"time": stamp, "action": "disconnect", "user": m[1], "from": m[2], "method": "-"})
+		}
+	}
+	return out[max(0, len(out)-40):]
+}
+func tailLog(path string) (string, os.FileInfo, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", nil, err
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		return "", nil, err
+	}
+	start := max(int64(0), info.Size()-256*1024)
+	if _, err = f.Seek(start, io.SeekStart); err != nil {
+		return "", nil, err
+	}
+	raw, err := io.ReadAll(io.LimitReader(f, 256*1024))
+	if start > 0 {
+		if cut := strings.IndexByte(string(raw), '\n'); cut >= 0 {
+			raw = raw[cut+1:]
+		} else {
+			raw = nil
+		}
+	}
+	return string(raw), info, err
+}
+
+var combinedPattern = regexp.MustCompile(`^(\S+) \S+ \S+ \[([^\]]+)\] "(\S+) (\S+)[^"]*" (\d{3}) (\d+|-)`)
+
+func httpStats(raw, source string) object {
+	recent := []any{}
+	maps := []map[string]int{{}, {}, {}, {}}
+	orders := make([][]string, 4)
+	upgrades := 0
+	for _, line := range strings.Split(raw, "\n") {
+		f := combinedPattern.FindStringSubmatch(line)
+		if f == nil {
+			continue
+		}
+		path, _, _ := strings.Cut(f[4], "?")
+		runes := []rune(path)
+		path = string(runes[:min(60, len(runes))])
+		values := []string{f[5][:1] + "xx", path, f[1], f[3]}
+		for i, v := range values {
+			if maps[i][v] == 0 {
+				orders[i] = append(orders[i], v)
+			}
+			maps[i][v]++
+		}
+		if f[5] == "101" {
+			upgrades++
+		}
+		recent = append(recent, object{"time": trafficTime(f[2]), "method": f[3], "path": path, "status": f[5], "client": f[1], "bytes": number(f[6])})
+	}
+	result := object{"source": source, "requestsPerSecond": 0., "total": float64(len(recent)), "upgrades": float64(upgrades), "history": []any{}}
+	for i, key := range []string{"statusClasses", "topPaths", "topClients", "methods"} {
+		order := orders[i]
+		counts := maps[i]
+		sort.SliceStable(order, func(i, j int) bool { return counts[order[i]] > counts[order[j]] })
+		rows := []any{}
+		for _, v := range order[:min([]int{6, 10, 8, 6}[i], len(order))] {
+			rows = append(rows, object{[]string{"class", "path", "client", "method"}[i]: v, "count": float64(counts[v])})
+		}
+		result[key] = rows
+	}
+	rows := []any{}
+	for i := len(recent) - 1; i >= max(0, len(recent)-40); i-- {
+		rows = append(rows, recent[i])
+	}
+	result["recent"] = rows
+	return result
+}
+
+type httpCollector struct {
+	path    string
+	info    os.FileInfo
+	at      time.Time
+	history []any
+}
+
+func (h *httpCollector) sample(root string, now time.Time) any {
+	for _, candidate := range []string{"var/log/nginx/access.log", "var/log/apache2/access.log", "var/log/httpd/access_log", "var/log/caddy/access.log"} {
+		path := filepath.Join(root, candidate)
+		raw, info, err := tailLog(path)
+		if err != nil || raw == "" {
+			continue
+		}
+		result := httpStats(raw, path)
+		rate := 0.
+		if h.info != nil && h.path == path && os.SameFile(h.info, info) && info.Size() > h.info.Size() && now.After(h.at) {
+			average := float64(len(raw)) / float64(max(1, len(strings.Split(strings.TrimSpace(raw), "\n"))))
+			rate = float64(info.Size()-h.info.Size()) / max(1, average) / now.Sub(h.at).Seconds()
+		}
+		h.path, h.info, h.at = path, info, now
+		h.history = append(h.history, rate)
+		h.history = h.history[max(0, len(h.history)-240):]
+		result["requestsPerSecond"] = rate
+		result["history"] = append([]any{}, h.history...)
+		return result
+	}
+	*h = httpCollector{}
+	return nil
+}
+func (c *collector) trafficCollect(missing *[]string) {
+	t := obj(c.sample["telemetry"])
+	run := func(label string, args ...string) string {
+		raw, ok := command(args...)
+		if !ok {
+			*missing = append(*missing, label)
+		}
+		return raw
+	}
+	for key, value := range socketBreakdown(arr(t["connections"]), arr(t["listeners"])) {
+		t[key] = value
+	}
+	t["logins"] = trafficLogins(run("login history", "last", "-n", "20", "-w"), "ok")
+	t["failedLogins"] = trafficLogins(run("failed login history", "lastb", "-n", "15", "-w"), "failed")
+	raw, ok := command("journalctl", "-u", "ssh", "-u", "sshd", "-n", "80", "--no-pager", "--output=short-iso")
+	if len(trafficSSH(raw)) == 0 {
+		if fallback, _, err := tailLog("/var/log/auth.log"); err == nil {
+			raw = fallback
+			ok = true
+		}
+	}
+	t["ssh"] = trafficSSH(raw)
+	if !ok {
+		*missing = append(*missing, "SSH authentication log")
+	}
+	t["http"] = c.http.sample("/", time.Now())
+	if t["http"] == nil {
+		*missing = append(*missing, "HTTP access log")
+	}
+}

--- a/ports/go/internal/demo/traffic_test.go
+++ b/ports/go/internal/demo/traffic_test.go
@@ -1,0 +1,123 @@
+package demo
+
+import (
+	"encoding/json"
+	ui "github.com/profullstack/hqtui/ports/go"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func trafficFixture(t *testing.T) object {
+	t.Helper()
+	raw, err := os.ReadFile("../../../conformance/fixtures/demo-traffic.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out object
+	if err = json.Unmarshal(raw, &out); err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+func TestTrafficSourcesAndTabs(t *testing.T) {
+	f := trafficFixture(t)
+	s := newState(true, 42)
+	tele := obj(s.sample["telemetry"])
+	for key, value := range socketBreakdown(arr(f["connections"]), arr(f["listeners"])) {
+		tele[key] = value
+	}
+	if num(tele["inboundConnections"]) != 1 || num(tele["outboundConnections"]) != 2 || len(arr(tele["protocols"])) != 3 {
+		t.Fatal(tele["protocols"])
+	}
+	tele["sessions"] = trafficSessions(str(f["who"]))
+	if str(obj(arr(tele["sessions"])[0])["from"]) != "203.0.113.4" {
+		t.Fatal(tele["sessions"])
+	}
+	tele["logins"] = trafficLogins(str(f["last"]), "ok")
+	if len(arr(tele["logins"])) != 1 || str(obj(arr(tele["logins"])[0])["status"]) != "still" {
+		t.Fatal(tele["logins"])
+	}
+	tele["failedLogins"] = trafficLogins(str(f["lastb"]), "failed")
+	tele["ssh"] = trafficSSH(str(f["ssh"]))
+	events := arr(tele["ssh"])
+	if len(events) != 3 {
+		t.Fatal(events)
+	}
+	for i, action := range []string{"accepted", "invalid", "disconnect"} {
+		if str(obj(events[i])["action"]) != action {
+			t.Fatal(events)
+		}
+	}
+	h := httpStats(str(f["http"]), "fixture")
+	if str(obj(arr(h["recent"])[0])["time"]) != "10:01:02" {
+		t.Fatal("bad HTTP timestamp")
+	}
+	tele["http"] = h
+	if num(h["total"]) != 3 || num(h["upgrades"]) != 1 || str(obj(arr(h["recent"])[0])["path"]) != "/chat" {
+		t.Fatal(h)
+	}
+	raw, _ := json.Marshal(h)
+	if strings.Contains(string(raw), "secret") {
+		t.Fatal("query leaked")
+	}
+	for screen, labels := range map[int][]string{1: {"HTTPS", "SSH", "accepted", "/chat"}, 2: {"alice", "eve", "Failed Logins", "still"}} {
+		s.screen = screen
+		frame := ui.RenderToScreen(240, 80, "dark", s.render)
+		for _, label := range labels {
+			if !frame.Contains(label) {
+				t.Fatalf("screen %d missing %s", screen, label)
+			}
+		}
+	}
+	if len(trafficSSH("")) != 0 || len(trafficLogins("", "ok")) != 0 {
+		t.Fatal("fabricated events")
+	}
+}
+func TestHTTPTailGrowthRotationAndDisappearance(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "var/log/nginx/access.log")
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatal(err)
+	}
+	raw := str(trafficFixture(t)["http"])
+	write := func(s string) {
+		if err := os.WriteFile(path, []byte(s), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(raw)
+	var c httpCollector
+	now := time.Now()
+	if num(obj(c.sample(root, now))["requestsPerSecond"]) != 0 {
+		t.Fatal("first rate")
+	}
+	write(raw + raw)
+	if num(obj(c.sample(root, now.Add(time.Second)))["requestsPerSecond"]) <= 0 {
+		t.Fatal("no growth")
+	}
+	if err := os.Rename(path, path+".old"); err != nil {
+		t.Fatal(err)
+	}
+	write(raw + raw + raw)
+	if num(obj(c.sample(root, now.Add(2*time.Second)))["requestsPerSecond"]) != 0 {
+		t.Fatal("rotation spike")
+	}
+	write(raw)
+	if num(obj(c.sample(root, now.Add(3*time.Second)))["requestsPerSecond"]) != 0 {
+		t.Fatal("truncate spike")
+	}
+	write(strings.Repeat("x", 300000) + "\n" + raw)
+	tail, _, err := tailLog(path)
+	if err != nil || len(tail) > 256*1024 {
+		t.Fatal("unbounded tail")
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	if c.sample(root, now.Add(4*time.Second)) != nil {
+		t.Fatal("stale HTTP")
+	}
+}

--- a/ports/go/internal/demo/view.go
+++ b/ports/go/internal/demo/view.go
@@ -135,7 +135,7 @@ func (s *state) dashboard(p *ui.Container) {
 				}
 				graph(p, c["history"], "CPU History")
 			}},
-			panelView{"Temperatures & Sensors", func(p *ui.Container) {
+			panelView{"Temperatures", func(p *ui.Container) {
 				temps := arr(s.sample["temperatures"])
 				if len(temps) == 0 {
 					p.Label("No thermal sensors available")
@@ -143,6 +143,16 @@ func (s *state) dashboard(p *ui.Container) {
 				for _, v := range temps {
 					t := obj(v)
 					p.Meter(ui.MeterOptions{Value: num(t["value"]) / 100, Label: str(t["label"]), Text: fmt.Sprintf("%.0f°C", num(t["value"]))})
+				}
+			}},
+			panelView{"Sensors", func(p *ui.Container) {
+				rows := arr(s.sample["sensors"])
+				if len(rows) == 0 {
+					p.Label("No sensor readings available")
+				}
+				for _, v := range rows {
+					row := obj(v)
+					p.Label(str(row["label"]) + ": " + str(row["value"]))
 				}
 			}},
 			panelView{"Logs", func(p *ui.Container) {
@@ -190,6 +200,12 @@ func (s *state) telemetry(p *ui.Container) {
 	cols := 2
 	if s.screen == 1 && p.Width() >= 120 {
 		cols = 3
+	}
+	if s.screen == 2 {
+		panels = append(panels, tab("Failed Logins", "failedLogins", []column{{"user", "User"}, {"tty", "TTY"}, {"from", "From"}, {"when", "When"}, {"status", "Status"}}))
+	}
+	if s.screen == 1 && s.real {
+		p.Label("Protocol/direction: port-based estimates; HTTP rate: estimated from log growth")
 	}
 	grid(p, panels, cols)
 }

--- a/ports/python/hqtui_demo/collect.py
+++ b/ports/python/hqtui_demo/collect.py
@@ -17,6 +17,8 @@ import time
 from pathlib import Path
 
 from .model import blank_sample, push
+from . import sensors as hardware
+from . import traffic
 
 MAX_OUTPUT=1024*1024
 
@@ -64,6 +66,7 @@ class Collector:
         self.root=Path(root); self.sysroot=Path(sysroot); self.clock=clock
         self.sample=blank_sample(); self.unavailable=[]
         self.slow_missing=[]
+        self.http=traffic.HttpCollector()
         self.previous={}; self.last=0.; self.last_slow=-1e9; self.cpu_previous={}; self.proc_previous={}
         self.sample["system"].update(os=platform.system(),kernel=platform.release(),hostname=socket.gethostname(),shell=os.environ.get("SHELL",""),terminal=os.environ.get("TERM",""))
         self.sample["cpu"]["model"]=platform.processor() or platform.machine()
@@ -84,6 +87,7 @@ class Collector:
         except (OSError,ValueError,IndexError,KeyError) as error: self.unavailable.append("procfs: "+type(error).__name__)
         if now-self.last_slow>=5:
             self.last_slow=now; self.slow()
+        self.sensors()
         self.unavailable.extend(self.slow_missing)
 
     def portable(self):
@@ -139,7 +143,7 @@ class Collector:
         uptime=read(self.root/"uptime").split()
         s["system"]["uptime"]=float(uptime[0]) if uptime else 0
         s["system"]["contextSwitches"]=t["kernel"]["contextSwitches"]
-        self.network(dt); self.disks(dt); self.sensors()
+        self.network(dt); self.disks(dt)
 
     def processes(self,dt):
         s=self.sample; rows=[]; current={}; ticks=os.sysconf("SC_CLK_TCK"); pages=os.sysconf("SC_PAGE_SIZE")
@@ -194,6 +198,7 @@ class Collector:
         net=s["telemetry"]["net"]
         for key in list(net):
             source=key[:3].capitalize()+key[3:] if key.startswith(("tcp","udp")) else "Icmp"+key[4:]
+            if key=="tcpEstablished": source="TcpCurrEstab"
             if source in counters: net[key]=counters[source]
         for key,source in (("inSegs","tcpInSegs"),("outSegs","tcpOutSegs"),("retrans","tcpRetransSegs"),("activeOpens","tcpActiveOpens"),("passiveOpens","tcpPassiveOpens"),("udpIn","udpInDatagrams"),("udpOut","udpOutDatagrams")):
             net["rates"][key]=self.delta(source,net[source],dt)
@@ -213,31 +218,22 @@ class Collector:
         self.sample["disks"]=disks[:128]
 
     def sensors(self):
-        temps=[]; sensors=[]
-        for folder in (self.sysroot/"class/hwmon").glob("hwmon*"):
-            name=read(folder/"name",256).strip()
-            for entry in folder.glob("temp*_input"):
-                try:
-                    value=float(read(entry,256))/1000
-                    label=read(entry.with_name(entry.name.replace("_input","_label")),256).strip() or entry.stem
-                    if -50<=value<=200: temps.append(dict(label=f"{name} {label}",value=value,max=100))
-                except ValueError: continue
-            for entry in folder.glob("fan*_input"):
-                value=read(entry,256).strip()
-                if value: sensors.append(dict(label=name+" "+entry.stem,value=value+" RPM"))
-        self.sample["temperatures"]=temps[:128]; self.sample["sensors"]=sensors[:128]
-        self.sensor_note="" if temps else "Thermal sensors are not exposed by this host"
+        result=hardware.collect(self.sysroot,read(self.root/"cpuinfo"),self.sample["telemetry"]["gpus"],lambda:command(["sensors","-j"]))
+        self.sample["temperatures"]=result["temperatures"]; self.sample["sensors"]=result["sensors"]
+        self.sample["telemetry"]["power"]=result["power"]
+        self.sensor_note="" if result["temperatures"] else "Thermal sensors are not exposed by this host"
+        if not result["temperatures"]: self.unavailable.append("temperatures")
+        if not result["hardware_count"]: self.unavailable.append("fans/voltage/power")
 
     def slow(self):
         t=self.sample["telemetry"]; missing=[]
+        t["gpus"]=hardware.parse_gpus(command(["nvidia-smi","--query-gpu=name,utilization.gpu,memory.used,memory.total,temperature.gpu,power.draw","--format=csv,noheader,nounits"]) or "")
+        if not t["gpus"]: missing.append("GPU telemetry")
         def run(label,args):
             result=command(args)
             if result is None: missing.append(label)
             return result or ""
-        sessions=[]
-        for line in run("sessions",["who"]).splitlines():
-            f=line.split()
-            if len(f)>=4: sessions.append(dict(user=f[0],tty=f[1],loginAt=" ".join(f[2:4]),idle="—",what="—",**{"from":" ".join(f[4:]).strip("()") or "local"}))
+        sessions=traffic.sessions(run("sessions",["who","-u"]))
         t["sessions"]=sessions
         services=[]
         for line in run("services",["systemctl","list-units","--type=service","--all","--no-legend","--no-pager","--plain"]).splitlines()[:1000]:
@@ -250,13 +246,10 @@ class Collector:
             if len(f)<6: continue
             proto,state,_,_,local,remote=f[:6]; process=f[6] if len(f)>6 else "—"
             connections.append(dict(proto=proto,state=state,local=local,remote=remote,process=process))
-            if state in ("LISTEN","UNCONN"):
+            if state == "LISTEN":
                 address,_,port=local.rpartition(":"); listeners.append(dict(proto=proto,address=address,port=port,process=process))
         t["connections"]=connections; t["listeners"]=listeners
-        # Socket snapshots alone do not establish connection direction or the
-        # application protocol. Do not invent HTTP/SSH attribution from ports.
-        t["protocols"]=[]; t["remotes"]=[dict(host=host,connections=count,protocols="—") for host,count in collections.Counter(c["remote"] for c in connections).most_common(200)]
-        missing.append("connection direction/application protocols")
+        t.update(traffic.breakdown(connections,listeners))
         push(t["connectionHistory"],len(connections)); push(t["sessionHistory"],len(sessions))
         journal=[]
         for line in run("journal",["journalctl","-n","100","--no-pager","-o","json"]).splitlines():
@@ -275,6 +268,14 @@ class Collector:
                     if device.rsplit("/",1)[-1]==d["device"]: d.update(mount=mount,total=int(total),used=int(used))
             except ValueError: continue
         t["filesystems"]=filesystems
-        # Protected sources are absent, not populated from the simulation.
-        missing.extend(["login history", "SSH authentication log", "HTTP access log", "GPU/power"])
+        t["logins"]=traffic.logins(run("login history",["last","-n","20","-w"]),"ok")
+        t["failedLogins"]=traffic.logins(run("failed login history",["lastb","-n","15","-w"]),"failed")
+        auth=command(["journalctl","-u","ssh","-u","sshd","-n","80","--no-pager","--output=short-iso"])
+        if not auth or not traffic.ssh(auth):
+            fallback=traffic.tail(Path("/var/log/auth.log"))
+            if fallback: auth=fallback[0]
+        t["ssh"]=traffic.ssh(auth or "")
+        if auth is None: missing.append("SSH authentication log")
+        t["http"]=self.http.sample(Path("/"),self.clock())
+        if t["http"] is None: missing.append("HTTP access log")
         self.slow_missing=missing

--- a/ports/python/hqtui_demo/sensors.py
+++ b/ports/python/hqtui_demo/sensors.py
@@ -1,0 +1,145 @@
+"""Native read-only Linux sensors. Explicit roots/command callback keep tests isolated."""
+import json
+import math
+import re
+from itertools import islice
+from pathlib import Path
+
+
+def read(path):
+    try:
+        with Path(path).open('rb') as stream:
+            return stream.read(1024 * 1024).decode('utf-8', 'replace').strip()
+    except (OSError, ValueError):
+        return ''
+
+
+def entries(path):
+    try:
+        return sorted(islice(Path(path).iterdir(), 4096))
+    except OSError:
+        return []
+
+
+def finite(raw):
+    try:
+        value = float(raw)
+        return value if math.isfinite(value) else None
+    except (ValueError, TypeError):
+        return None
+
+
+def positive(raw):
+    value = finite(raw)
+    return value if value is not None and value > 0 else None
+
+
+def parse_gpus(raw):
+    result = []
+    for line in raw.splitlines()[:16]:
+        fields = [v.strip() for v in line.split(',')]
+        if len(fields) != 6 or not fields[0]:
+            continue
+        row = dict(name=fields[0])
+        for key, raw_value, scale in zip(
+                ('utilization', 'memoryUsed', 'memoryTotal', 'temperature', 'power'),
+                fields[1:], (.01, 1048576, 1048576, 1, 1)):
+            value = finite(raw_value)
+            row[key] = value * scale if value is not None and value >= 0 else None
+        result.append(row)
+    return result
+
+
+def battery(sysroot):
+    supplies = entries(sysroot / 'class/power_supply')[:128]
+    ac = any(read(p / 'type') == 'Mains' and read(p / 'online') == '1' for p in supplies)
+    for folder in supplies:
+        if read(folder / 'type') != 'Battery':
+            continue
+        capacity = finite(read(folder / 'capacity'))
+        if capacity is None or not 0 <= capacity <= 100:
+            continue
+        status = read(folder / 'status')
+        watts = finite(read(folder / 'power_now'))
+        if watts is not None:
+            watts /= 1e6
+        else:
+            amps, volts = finite(read(folder / 'current_now')), finite(read(folder / 'voltage_now'))
+            watts = amps * volts / 1e12 if amps is not None and volts is not None else None
+        return dict(battery=capacity, charging=status == 'Charging', timeRemaining=status,
+                    powerDraw=watts, acConnected=ac)
+    return None
+
+
+def collect(sysroot, cpuinfo, gpus=(), lm_sensors=lambda: None):
+    sysroot = Path(sysroot)
+    temps, rows = [], []
+    for folder in entries(sysroot / 'class/hwmon')[:128]:
+        chip = read(folder / 'name') or read(folder / 'device/name') or folder.name
+        for base in (folder, folder / 'device'):
+            for entry in entries(base):
+                match = re.fullmatch(r'(temp|fan|in|power|curr)(\d+)_(input|average)', entry.name)
+                if not match:
+                    continue
+                kind, index, suffix = match.groups()
+                if suffix == 'average' and kind != 'power':
+                    continue
+                value = positive(read(entry))
+                if value is None:
+                    continue
+                fallback = f'Fan {index}' if kind == 'fan' else kind + index
+                label = read(base / f'{kind}{index}_label') or f'{chip} {fallback}'
+                if kind == 'temp':
+                    if value <= 150000 and len(temps) < 12:
+                        maximum = (positive(read(base / f'temp{index}_crit')) or 100000) / 1000
+                        temps.append(dict(label=label, value=value / 1000, max=maximum))
+                elif len(rows) < 14:
+                    formatted = {'fan': lambda: f'{math.floor(value + .5)} RPM',
+                                 'in': lambda: f'{value / 1000:.2f} V',
+                                 'power': lambda: f'{value / 1e6:.1f} W',
+                                 'curr': lambda: f'{value / 1000:.2f} A'}[kind]()
+                    rows.append(dict(label=label, value=formatted))
+    if not temps:
+        for folder in entries(sysroot / 'class/thermal')[:128]:
+            value = positive(read(folder / 'temp'))
+            if folder.name.startswith('thermal_zone') and value is not None and value <= 150000:
+                temps.append(dict(label=read(folder / 'type') or folder.name, value=value / 1000, max=100))
+                if len(temps) == 12:
+                    break
+    if not temps:
+        try:
+            chips = json.loads(lm_sensors() or '{}')
+        except (ValueError, TypeError):
+            chips = {}
+        for chip, features in sorted(chips.items()) if isinstance(chips, dict) else ():
+            for feature, values in sorted(features.items()) if isinstance(features, dict) else ():
+                for key, value in sorted(values.items()) if isinstance(values, dict) else ():
+                    if re.fullmatch(r'temp\d+_input', key) and isinstance(value, (int, float)) and 0 < value <= 150:
+                        temps.append(dict(label=f'{chip.split("-")[0]} {feature}', value=value, max=100))
+                        break
+        temps = temps[:12]
+    hardware_count = len(rows)
+    power = battery(sysroot)
+    if power:
+        rows.append(dict(label='Battery', value=f'{power["battery"]:g}% ({power["timeRemaining"]})'))
+        if power['powerDraw'] is not None and power['powerDraw'] > 0:
+            rows.append(dict(label='Battery draw', value=f'{power["powerDraw"]:.1f} W'))
+    for gpu in gpus[:16]:
+        usage = f'{math.floor(gpu["utilization"] * 100 + .5)}%' if gpu.get('utilization') is not None else 'unavailable'
+        temperature = f'{gpu["temperature"]:g}°C' if gpu.get('temperature') is not None else 'temperature unavailable'
+        rows.append(dict(label=gpu['name'], value=f'{usage} · {temperature}'))
+    clocks = []
+    cpus = [p for p in entries(sysroot / 'devices/system/cpu') if re.fullmatch(r'cpu\d+', p.name)]
+    for folder in sorted(cpus, key=lambda p: int(p.name[3:]))[:4]:
+        value = positive(read(folder / 'cpufreq/scaling_cur_freq'))
+        if value is not None:
+            clocks.append(dict(label=f'{folder.name} clock', value=f'{value / 1e6:.2f} GHz'))
+    if not clocks:
+        for line in cpuinfo.splitlines():
+            key, _, raw = line.partition(':')
+            value = positive(raw)
+            if key.strip() == 'cpu MHz' and value is not None:
+                clocks.append(dict(label=f'cpu{len(clocks)} clock', value=f'{value / 1000:.2f} GHz'))
+                if len(clocks) == 4:
+                    break
+    return dict(temperatures=temps, sensors=(rows + clocks)[:14], power=power, hardware_count=hardware_count)

--- a/ports/python/hqtui_demo/traffic.py
+++ b/ports/python/hqtui_demo/traffic.py
@@ -1,0 +1,151 @@
+"""Read-only Traffic/Sessions sources, matching the TypeScript demo routes.
+
+Socket direction and application labels are port-based estimates, not packet inspection.
+"""
+import collections
+import math
+import re
+from pathlib import Path
+
+PORTS = dict(pair.split('=') for pair in (
+    '20=FTP 21=FTP 22=SSH 23=Telnet 25=SMTP 53=DNS 67=DHCP 68=DHCP 80=HTTP '
+    '110=POP3 111=RPC 123=NTP 143=IMAP 161=SNMP 389=LDAP 443=HTTPS 445=SMB '
+    '465=SMTPS 514=Syslog 587=SMTP 631=IPP 636=LDAPS 993=IMAPS 995=POP3S '
+    '1194=OpenVPN 1433=MSSQL 1521=Oracle 2049=NFS 2379=etcd 3000=HTTP-dev '
+    '3306=MySQL 3389=RDP 4000=HTTP-dev 5000=HTTP-dev 5432=Postgres 5672=AMQP '
+    '5900=VNC 6379=Redis 8000=HTTP-alt 8080=HTTP-alt 8443=HTTPS-alt 9000=HTTP-alt '
+    '9090=Prometheus 9200=Elasticsearch 11211=Memcached 27017=MongoDB 41641=Tailscale 51820=WireGuard'
+).split())
+ACCESS_LOGS = ('var/log/nginx/access.log', 'var/log/apache2/access.log', 'var/log/httpd/access_log', 'var/log/caddy/access.log')
+COMBINED = re.compile(r'^(\S+) \S+ \S+ \[([^\]]+)\] "(\S+) (\S+)[^"]*" (\d{3}) (\d+|-)')
+
+
+def sessions(raw):
+    out = []
+    for line in raw.splitlines()[:1000]:
+        f = line.split()
+        if len(f) < 4:
+            continue
+        origin = re.search(r'\(([^)]+)\)', line)
+        out.append(dict(user=f[0], tty=f[1], loginAt=' '.join(f[2:4]), idle=f[4] if len(f)>4 else '.',
+                        what=f[5] if len(f)>5 else '', **{'from': origin[1] if origin else 'local'}))
+    return out
+
+
+def logins(raw, status):
+    out = []
+    for line in raw.splitlines():
+        f = line.split()
+        if len(f)<4 or f[0] in ('wtmp', 'btmp', 'reboot'):
+            continue
+        out.append(dict(user=f[0], tty=f[1], **{'from': f[2] if '.' in f[2] or ':' in f[2] else 'local'},
+                        when=' '.join(f[-7:-3]) or ' '.join(f[3:7]), status='still' if 'still logged in' in line else status))
+        if len(out)==40:
+            break
+    return out
+
+
+def ssh(raw):
+    out = []
+    for line in raw.splitlines():
+        if 'sshd' not in line:
+            continue
+        stamp = re.search(r'(?<!\d)\d{2}:\d{2}:\d{2}', line)
+        match = re.search(r'(Accepted|Failed) (\S+) for (invalid user )?(\S+) from (\S+)', line)
+        if match:
+            action = 'accepted' if match[1]=='Accepted' else 'invalid' if match[3] else 'failed'
+            out.append(dict(time=stamp[0] if stamp else '', action=action, user=match[4], **{'from': match[5]}, method=match[2]))
+        else:
+            match = re.search(r'Disconnected from (?:authenticating )?user (\S+) (\S+)', line)
+            if match:
+                out.append(dict(time=stamp[0] if stamp else '', action='disconnect', user=match[1], **{'from': match[2]}, method='-'))
+    return out[-40:]
+
+
+def breakdown(connections, listeners):
+    listening = {str(row['port']) for row in listeners}
+    buckets, remotes = {}, {}
+    inbound = outbound = 0
+    for c in connections:
+        if c.get('state') == 'LISTEN' or not (c.get('state') == 'ESTAB' or c.get('proto','').startswith('udp')):
+            continue
+        local_port, remote_port = c['local'].rpartition(':')[2], c['remote'].rpartition(':')[2]
+        incoming = local_port in listening
+        port = local_port if incoming else remote_port
+        protocol = PORTS.get(port, 'ephemeral' if port.isdecimal() and int(port)>=32768 else 'port '+port)
+        bucket = buckets.setdefault(protocol, dict(protocol=protocol, inbound=0, outbound=0, total=0))
+        bucket['inbound' if incoming else 'outbound'] += 1
+        bucket['total'] += 1
+        inbound += incoming; outbound += not incoming
+        host = c['remote'].rpartition(':')[0]
+        if host and host not in ('*','0.0.0.0'):
+            remote = remotes.setdefault(host, dict(host=host, connections=0, protocols=[]))
+            remote['connections'] += 1
+            if protocol not in remote['protocols']:
+                remote['protocols'].append(protocol)
+    rows = sorted(remotes.values(), key=lambda v:-v['connections'])[:12]
+    return dict(protocols=sorted(buckets.values(), key=lambda v:-v['total']),
+                remotes=[{**r,'protocols':', '.join(r['protocols'][:3])} for r in rows],
+                inboundConnections=inbound, outboundConnections=outbound)
+
+
+def tail(path, limit=256*1024):
+    try:
+        with Path(path).open('rb') as stream:
+            import os
+            info = os.fstat(stream.fileno())
+            start = max(0, info.st_size-limit)
+            stream.seek(start)
+            raw = stream.read(limit)
+        if start:
+            raw = raw.partition(b'\n')[2]
+        return raw.decode('utf-8','replace'), info
+    except (OSError, ValueError):
+        return None
+
+
+def http_stats(raw, source):
+    recent = []
+    for line in raw.splitlines():
+        match = COMBINED.match(line)
+        if not match:
+            continue
+        client, stamp, method, path, status, size = match.groups()
+        timestamp = re.search(r'(?<!\d)\d{2}:\d{2}:\d{2}',stamp)
+        recent.append(dict(time=timestamp[0] if timestamp else '', method=method, path=path.split('?')[0][:60],
+                           status=status, client=client, bytes=int(size) if size.isdecimal() else 0))
+    def top(key, name, limit):
+        return [{name:k,'count':v} for k,v in collections.Counter(key(r) for r in recent).most_common(limit)]
+    return dict(source=source, requestsPerSecond=0, total=len(recent),
+                statusClasses=top(lambda r:r['status'][0]+'xx','class',6),
+                topPaths=top(lambda r:r['path'],'path',10), topClients=top(lambda r:r['client'],'client',8),
+                methods=top(lambda r:r['method'],'method',6), upgrades=sum(r['status']=='101' for r in recent),
+                recent=list(reversed(recent[-40:])), history=[])
+
+
+class HttpCollector:
+    def __init__(self):
+        self.previous = None
+        self.history = []
+
+    def sample(self, root, now):
+        for candidate in ACCESS_LOGS:
+            path = Path(root) / candidate
+            result = tail(path)
+            if not result or not result[0]:
+                continue
+            raw, info = result
+            stats = http_stats(raw, str(path))
+            identity = (str(path), info.st_dev, info.st_ino)
+            rate = 0
+            if self.previous:
+                old, size, at = self.previous
+                if old == identity and info.st_size > size and now > at:
+                    rate = (info.st_size-size) / max(1, len(raw.encode()) / max(1,len(raw.splitlines()))) / (now-at)
+            self.previous = (identity,info.st_size,now)
+            self.history = (self.history + [rate if math.isfinite(rate) else 0])[-240:]
+            stats.update(requestsPerSecond=self.history[-1], history=self.history[:])
+            return stats
+        self.previous = None
+        self.history = []
+        return None

--- a/ports/python/hqtui_demo/view.py
+++ b/ports/python/hqtui_demo/view.py
@@ -89,14 +89,15 @@ def dashboard(ui, s: State):
         p.label(f'Down {size(n["downRate"])}/s   Up {size(n["upRate"])}/s')
         graph(p, n["downHistory"], "down", n["upHistory"])
         pairs(p, [("Received", size(n["downTotal"])), ("Sent", size(n["upTotal"]))])
-    def sensors(p):
-        for t in data["temperatures"][:8]:
+    def temperatures(p):
+        for t in data["temperatures"][:12]:
             p.meter(w.MeterOptions(label=t["label"], value=t["value"], max=t.get("max") or 100, text=f'{t["value"]:.0f}°C'))
         if not data["temperatures"]: p.label("No thermal sensors available")
-        for sensor in data["sensors"][:6]: p.label(f'{sensor["label"]}: {sensor["value"]}')
-        if s.sensor_note: p.label(s.sensor_note)
+    def sensors(p):
+        for sensor in data["sensors"][:14]: p.label(f'{sensor["label"]}: {sensor["value"]}')
+        if not data["sensors"]: p.label("No sensor readings available")
     def logs(p): table(p,s,"dashboard.logs", data["logs"], [("time","Time"),("level","Level"),("message","Message")])
-    panels = [("CPU Overview",cpu),("Memory & Swap",memory),("Disks",disks),("System",system),("Processes",procs),("Network",network),("Temperatures & Sensors",sensors),("Logs",logs)]
+    panels = [("CPU Overview",cpu),("Memory & Swap",memory),("Disks",disks),("System",system),("Processes",procs),("Network",network),("Temperatures",temperatures),("Sensors",sensors),("Logs",logs)]
     # Preserve a useful compact dashboard rather than squeezing eight panels
     # into a terminal too small to show their contents.
     if ui.width < 90 or ui.height < 46: panels = [panels[0],panels[4],panels[1],panels[5]]
@@ -138,6 +139,8 @@ def telemetry(ui, s: State):
                 ("TCP Segments",lambda p:graph(p,t["netInHistory"],"in",t["netOutHistory"])),trace("Retransmits","retransHistory"),
                 ("HTTP",http),tab("Remote Hosts","remotes",[("host","Host"),("connections","Connections"),("protocols","Protocols")]),
                 tab("SSH Authentication","ssh",[("time","Time"),("action","Action"),("user","User"),("from","From")])]
+    if s.screen=="sessions": panels.append(tab("Failed Logins","failedLogins",[("user","User"),("tty","TTY"),("from","From"),("when","When"),("status","Status")]))
+    if s.screen=="traffic" and s.source=="real": ui.label("Protocol/direction: port-based estimates; HTTP rate: estimated from log growth")
     grid(ui,panels,3 if s.screen=="traffic" and ui.width>=120 else 2)
 
 

--- a/ports/python/tests/test_sensors.py
+++ b/ports/python/tests/test_sensors.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from hqtui_demo.sensors import collect, parse_gpus
+from hqtui_demo.model import State, blank_sample
+from hqtui_demo.view import render
+from hqtui.testing import render_to_screen
+
+
+class SensorTests(unittest.TestCase):
+    def test_shared_sensor_sources_refresh_and_render(self):
+        cases = json.loads((Path(__file__).parents[2] / 'conformance/fixtures/demo-sensors.json').read_text())
+        for case in cases:
+            with self.subTest(case=case['name']), tempfile.TemporaryDirectory(prefix='hqtui-sensors-') as directory:
+                root = Path(directory)
+                def write(files):
+                    for name, value in files.items():
+                        path = root / name
+                        path.parent.mkdir(parents=True, exist_ok=True)
+                        path.write_text(value)
+                write(case['files'])
+                def sample(cpuinfo):
+                    return collect(root / 'sys', cpuinfo, parse_gpus(case.get('gpus', '')), lambda: case.get('lm'))
+                first = sample(case['cpuinfo'])
+                self.assertEqual([t['value'] for t in first['temperatures']], case['temperatures'])
+                self.assertEqual({s['label']: s['value'] for s in first['sensors']}, case['sensors'])
+                data = blank_sample()
+                data.update(temperatures=first['temperatures'], sensors=first['sensors'])
+                state = State(data, 'real')
+                frame = render_to_screen(220, 70, 'dark', lambda ui: render(ui, state))
+                for label, value in case['sensors'].items():
+                    self.assertTrue(frame.contains(label), label)
+                    self.assertTrue(frame.contains(value), value)
+                write(case.get('changes', {}))
+                next_values = {s['label']: s['value'] for s in sample(case.get('nextCpuinfo', case['cpuinfo']))['sensors']}
+                for label, value in case.get('nextSensors', {}).items():
+                    self.assertEqual(next_values[label], value)
+        with tempfile.TemporaryDirectory() as directory:
+            self.assertEqual(collect(Path(directory), '', (), lambda: 'invalid')['sensors'], [])

--- a/ports/python/tests/test_traffic.py
+++ b/ports/python/tests/test_traffic.py
@@ -1,0 +1,64 @@
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from hqtui_demo import traffic
+from hqtui_demo.model import blank_sample, State
+from hqtui_demo.view import render
+from hqtui.testing import render_to_screen
+
+
+class TrafficTests(unittest.TestCase):
+    def fixture(self):
+        return json.loads((Path(__file__).parents[2] / 'conformance/fixtures/demo-traffic.json').read_text())
+
+    def test_sources_and_both_tabs_render(self):
+        f = self.fixture()
+        data = blank_sample(); t = data['telemetry']
+        t.update(traffic.breakdown(f['connections'], f['listeners']))
+        self.assertEqual(t['inboundConnections'], 1)
+        self.assertEqual(t['outboundConnections'], 2)
+        self.assertEqual({r['protocol']:r['total'] for r in t['protocols']}, {'SSH':1,'HTTPS':1,'DNS':1})
+        t['sessions'] = traffic.sessions(f['who'])
+        self.assertEqual(t['sessions'][0]['from'], '203.0.113.4')
+        self.assertEqual(t['sessions'][0]['idle'], '.')
+        t['logins'] = traffic.logins(f['last'], 'ok')
+        self.assertEqual(len(t['logins']), 1)
+        self.assertEqual(t['logins'][0]['status'], 'still')
+        t['failedLogins'] = traffic.logins(f['lastb'], 'failed')
+        self.assertEqual(t['failedLogins'][0]['status'], 'failed')
+        t['ssh'] = traffic.ssh(f['ssh'])
+        self.assertEqual([e['action'] for e in t['ssh']], ['accepted','invalid','disconnect'])
+        self.assertEqual(t['ssh'][0]['time'], '10:01:02')
+        t['http'] = traffic.http_stats(f['http'], 'fixture')
+        self.assertEqual(t['http']['total'], 3)
+        self.assertEqual(t['http']['upgrades'], 1)
+        self.assertEqual(t['http']['recent'][0]['path'], '/chat')
+        self.assertEqual(t['http']['recent'][0]['time'], '10:01:02')
+        self.assertNotIn('secret', json.dumps(t['http']))
+        state = State(data, 'real')
+        for screen, labels in [('traffic',['HTTPS','SSH','accepted','/chat']), ('sessions',['alice','eve','Failed Logins','still'])]:
+            state.screen = screen
+            frame = render_to_screen(240, 80, 'dark', lambda ui: render(ui,state))
+            for label in labels:
+                self.assertTrue(frame.contains(label), (screen,label))
+        self.assertEqual(traffic.ssh(''), [])
+        self.assertEqual(traffic.logins('', 'ok'), [])
+
+    def test_http_tail_growth_rotation_and_disappearance(self):
+        with tempfile.TemporaryDirectory(prefix='hqtui-http-') as directory:
+            root = Path(directory); path = root / traffic.ACCESS_LOGS[0]
+            path.parent.mkdir(parents=True); raw = self.fixture()['http']
+            path.write_text(raw)
+            collector = traffic.HttpCollector()
+            self.assertEqual(collector.sample(root, 1)['requestsPerSecond'], 0)
+            with path.open('a') as file: file.write(raw)
+            self.assertGreater(collector.sample(root, 2)['requestsPerSecond'], 0)
+            path.rename(path.with_suffix('.old')); path.write_text(raw * 3)
+            self.assertEqual(collector.sample(root, 3)['requestsPerSecond'], 0)
+            path.write_text(raw)
+            self.assertEqual(collector.sample(root, 4)['requestsPerSecond'], 0)
+            path.write_text('x' * 300000 + '\n' + raw)
+            self.assertLessEqual(len(traffic.tail(path)[0].encode()), 256 * 1024)
+            path.unlink()
+            self.assertIsNone(collector.sample(root, 5))

--- a/ports/rust/demo/src/collect.rs
+++ b/ports/rust/demo/src/collect.rs
@@ -92,6 +92,7 @@ pub fn rate(current: f64, previous: Option<f64>, dt: f64) -> f64 {
     }
 }
 pub struct Collector {
+    http: crate::traffic::HttpCollector,
     pub sample: Value,
     pub missing: Vec<String>,
     slow_missing: Vec<String>,
@@ -109,6 +110,7 @@ impl Collector {
         s["system"]["hostname"] = json!(read("/proc/sys/kernel/hostname").trim());
         s["system"]["shell"] = json!(std::env::var("SHELL").unwrap_or_default());
         Self {
+            http: Default::default(),
             sample: s,
             missing: vec![],
             slow_missing: vec![],
@@ -309,6 +311,17 @@ impl Collector {
         self.procs = current;
         self.sample["system"]["processCount"] = json!(rows.len());
         self.sample["system"]["threadCount"] = json!(threads);
+        let count = |states: &str| {
+            rows.iter()
+                .filter(|row| {
+                    text(&row["state"])
+                        .chars()
+                        .next()
+                        .is_some_and(|c| states.contains(c))
+                })
+                .count()
+        };
+        self.sample["telemetry"]["states"] = json!({"total":rows.len(),"running":count("R"),"sleeping":count("SD"),"stopped":count("Tt"),"zombie":count("Z")});
         self.sample["processes"] = json!(rows);
         if hz == 0. || pages == 0. {
             self.missing.push("process CPU clock/page size".into())
@@ -474,8 +487,8 @@ impl Collector {
                 String::new()
             })
         };
-        let sessions:Vec<Value>=run("sessions",&["who"]).lines().filter_map(|line|{let f:Vec<_>=line.split_whitespace().collect();if f.len()<4{return None}Some(json!({"user":f[0],"tty":f[1],"loginAt":f[2..4].join(" "),"from":f[4..].join(" "),"idle":"—","what":"—"}))}).collect();
-        let count = sessions.len() as f64;
+        let sessions = crate::traffic::sessions(&run("sessions", &["who", "-u"]));
+        let count = array(&sessions).len() as f64;
         self.sample["telemetry"]["sessions"] = json!(sessions);
         push(&mut self.sample["telemetry"], "sessionHistory", count);
         let services: Vec<Value> = run(
@@ -515,7 +528,7 @@ impl Collector {
             connections.push(
                 json!({"proto":f[0],"state":f[1],"local":f[4],"remote":f[5],"process":process}),
             );
-            if matches!(f[1], "LISTEN" | "UNCONN") {
+            if f[1] == "LISTEN" {
                 if let Some((address, port)) = f[4].rsplit_once(':') {
                     listeners.push(
                         json!({"proto":f[0],"address":address,"port":port,"process":process}),
@@ -542,15 +555,46 @@ impl Collector {
             }
         }
         self.sample["telemetry"]["filesystems"] = json!(filesystems);
-        missing.extend(
-            [
-                "connection direction/application protocols",
-                "login history",
-                "SSH authentication log",
-                "HTTP access log",
-            ]
-            .map(str::to_owned),
+        let t = &mut self.sample["telemetry"];
+        let split = crate::traffic::breakdown(&t["connections"], &t["listeners"]);
+        for key in [
+            "protocols",
+            "remotes",
+            "inboundConnections",
+            "outboundConnections",
+        ] {
+            t[key] = split[key].clone();
+        }
+        t["logins"] =
+            crate::traffic::logins(&run("login history", &["last", "-n", "20", "-w"]), "ok");
+        t["failedLogins"] = crate::traffic::logins(
+            &run("failed login history", &["lastb", "-n", "15", "-w"]),
+            "failed",
         );
+        let mut auth = command(&[
+            "journalctl",
+            "-u",
+            "ssh",
+            "-u",
+            "sshd",
+            "-n",
+            "80",
+            "--no-pager",
+            "--output=short-iso",
+        ]);
+        if array(&crate::traffic::ssh(auth.as_deref().unwrap_or(""))).is_empty() {
+            if let Some((raw, _)) = crate::traffic::tail(Path::new("/var/log/auth.log")) {
+                auth = Some(raw);
+            }
+        }
+        t["ssh"] = crate::traffic::ssh(auth.as_deref().unwrap_or(""));
+        if auth.is_none() {
+            missing.push("SSH authentication log".into());
+        }
+        t["http"] = self.http.sample(Path::new("/"), Instant::now());
+        if t["http"].is_null() {
+            missing.push("HTTP access log".into());
+        }
         self.slow_missing = missing;
     }
 }

--- a/ports/rust/demo/src/main.rs
+++ b/ports/rust/demo/src/main.rs
@@ -1,5 +1,6 @@
 mod collect;
 mod sensors;
+mod traffic;
 mod components;
 mod dashboard;
 mod model;

--- a/ports/rust/demo/src/telemetry.rs
+++ b/ports/rust/demo/src/telemetry.rs
@@ -387,6 +387,9 @@ pub fn services<'a>(ui: &mut Container<'a>, s: &'a State) {
     );
 }
 pub fn traffic<'a>(ui: &mut Container<'a>, s: &'a State) {
+    if s.real {
+        ui.label("Protocol/direction: port-based estimates; HTTP rate: estimated from log growth");
+    }
     let d = &s.sample["telemetry"];
     let net = &d["net"];
     let http = &d["http"];

--- a/ports/rust/demo/src/tests.rs
+++ b/ports/rust/demo/src/tests.rs
@@ -177,6 +177,12 @@ fn real_collector_wires_available_sensors_into_dashboard() {
     }
     let mut collector = collect::Collector::new();
     collector.refresh();
+    assert_eq!(
+        collector.sample["telemetry"]["states"]["total"]
+            .as_u64()
+            .unwrap() as usize,
+        model::array(&collector.sample["processes"]).len()
+    );
     let mut state = State::new(true, 42);
     state.sample = collector.sample;
     let frame = render_to_screen(200, 60, "dark", |ui| dashboard::render(ui, &state));

--- a/ports/rust/demo/src/traffic.rs
+++ b/ports/rust/demo/src/traffic.rs
@@ -1,0 +1,384 @@
+//! Native Traffic/Sessions sources. Port classification is an estimate, not DPI.
+use crate::model::{array, n, text};
+use serde_json::{json, Value};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs::{File, Metadata},
+    io::{Read, Seek, SeekFrom},
+    path::Path,
+    time::Instant,
+};
+const PORTS:&str="20=FTP 21=FTP 22=SSH 23=Telnet 25=SMTP 53=DNS 67=DHCP 68=DHCP 80=HTTP 110=POP3 111=RPC 123=NTP 143=IMAP 161=SNMP 389=LDAP 443=HTTPS 445=SMB 465=SMTPS 514=Syslog 587=SMTP 631=IPP 636=LDAPS 993=IMAPS 995=POP3S 1194=OpenVPN 1433=MSSQL 1521=Oracle 2049=NFS 2379=etcd 3000=HTTP-dev 3306=MySQL 3389=RDP 4000=HTTP-dev 5000=HTTP-dev 5432=Postgres 5672=AMQP 5900=VNC 6379=Redis 8000=HTTP-alt 8080=HTTP-alt 8443=HTTPS-alt 9000=HTTP-alt 9090=Prometheus 9200=Elasticsearch 11211=Memcached 27017=MongoDB 41641=Tailscale 51820=WireGuard";
+fn classify(port: &str) -> String {
+    for pair in PORTS.split_whitespace() {
+        if let Some((key, value)) = pair.split_once('=') {
+            if key == port {
+                return value.into();
+            }
+        }
+    }
+    if port.parse::<u32>().unwrap_or(0) >= 32768 {
+        "ephemeral".into()
+    } else {
+        format!("port {port}")
+    }
+}
+fn endpoint(s: &str) -> (&str, &str) {
+    s.rsplit_once(':').unwrap_or((s, ""))
+}
+pub fn breakdown(connections: &Value, listeners: &Value) -> Value {
+    let listening: BTreeSet<_> = array(listeners).iter().map(|v| text(&v["port"])).collect();
+    let mut buckets: BTreeMap<String, (u64, u64)> = BTreeMap::new();
+    let mut remotes: BTreeMap<String, (u64, BTreeSet<String>)> = BTreeMap::new();
+    let (mut inbound, mut outbound) = (0, 0);
+    for c in array(connections) {
+        let state = text(&c["state"]);
+        if state == "LISTEN" || (state != "ESTAB" && !text(&c["proto"]).starts_with("udp")) {
+            continue;
+        }
+        let local = text(&c["local"]);
+        let remote = text(&c["remote"]);
+        let (_, lp) = endpoint(&local);
+        let (host, rp) = endpoint(&remote);
+        let incoming = listening.contains(lp);
+        let protocol = classify(if incoming { lp } else { rp });
+        let bucket = buckets.entry(protocol.clone()).or_default();
+        if incoming {
+            bucket.0 += 1;
+            inbound += 1
+        } else {
+            bucket.1 += 1;
+            outbound += 1
+        }
+        if !host.is_empty() && host != "*" && host != "0.0.0.0" {
+            let entry = remotes.entry(host.into()).or_default();
+            entry.0 += 1;
+            entry.1.insert(protocol);
+        }
+    }
+    let mut protocols: Vec<Value> = buckets
+        .into_iter()
+        .map(|(protocol, (i, o))| json!({"protocol":protocol,"inbound":i,"outbound":o,"total":i+o}))
+        .collect();
+    protocols.sort_by(|a, b| n(&b["total"]).total_cmp(&n(&a["total"])));
+    let mut remotes:Vec<Value>=remotes.into_iter().map(|(host,(count,protocols))|json!({"host":host,"connections":count,"protocols":protocols.into_iter().take(3).collect::<Vec<_>>().join(", ")})).collect();
+    remotes.sort_by(|a, b| n(&b["connections"]).total_cmp(&n(&a["connections"])));
+    remotes.truncate(12);
+    json!({"protocols":protocols,"remotes":remotes,"inboundConnections":inbound,"outboundConnections":outbound})
+}
+pub fn sessions(raw: &str) -> Value {
+    json!(raw.lines().filter_map(|line|{let f:Vec<_>=line.split_whitespace().collect();if f.len()<4{return None}let origin=line.split_once('(').and_then(|(_,s)|s.split_once(')')).map(|(s,_)|s).unwrap_or("local");Some(json!({"user":f[0],"tty":f[1],"loginAt":f[2..4].join(" "),"idle":f.get(4).unwrap_or(&"."),"what":f.get(5).unwrap_or(&""),"from":origin}))}).take(1000).collect::<Vec<_>>())
+}
+pub fn logins(raw: &str, status: &str) -> Value {
+    json!(raw.lines().filter_map(|line|{let f:Vec<_>=line.split_whitespace().collect();if f.len()<4||matches!(f[0],"wtmp"|"btmp"|"reboot"){return None}let when=f[f.len().saturating_sub(7)..f.len()-3].join(" ");Some(json!({"user":f[0],"tty":f[1],"from":if f[2].contains(['.',':']){f[2]}else{"local"},"when":if when.is_empty(){f[3..f.len().min(7)].join(" ")}else{when},"status":if line.contains("still logged in"){"still"}else{status}}))}).take(40).collect::<Vec<_>>())
+}
+fn timestamp(line: &str) -> &str {
+    for (i, w) in line.as_bytes().windows(8).enumerate() {
+        if i > 0 && line.as_bytes()[i - 1].is_ascii_digit() {
+            continue;
+        }
+        if w[2] == b':' && w[5] == b':' && [0, 1, 3, 4, 6, 7].iter().all(|j| w[*j].is_ascii_digit())
+        {
+            return &line[i..i + 8];
+        }
+    }
+    ""
+}
+pub fn ssh(raw: &str) -> Value {
+    let mut out = vec![];
+    for line in raw.lines() {
+        if !line.contains("sshd") {
+            continue;
+        }
+        let f: Vec<_> = line.split_whitespace().collect();
+        let mut row = None;
+        for (i, word) in f.iter().enumerate() {
+            if matches!(*word, "Accepted" | "Failed") && f.get(i + 2) == Some(&"for") {
+                let invalid = f.get(i + 3) == Some(&"invalid") && f.get(i + 4) == Some(&"user");
+                let at = i + if invalid { 5 } else { 3 };
+                if f.get(at + 1) == Some(&"from") {
+                    if let Some(origin) = f.get(at + 2) {
+                        row = Some(
+                            json!({"time":timestamp(line),"action":if *word=="Accepted"{"accepted"}else if invalid{"invalid"}else{"failed"},"method":f[i+1],"user":f[at],"from":origin}),
+                        );
+                        break;
+                    }
+                }
+            }
+            if *word == "Disconnected" && f.get(i + 1) == Some(&"from") {
+                let at = i + if f.get(i + 2) == Some(&"authenticating") {
+                    3
+                } else {
+                    2
+                };
+                if f.get(at) == Some(&"user") {
+                    if let (Some(user), Some(origin)) = (f.get(at + 1), f.get(at + 2)) {
+                        row = Some(
+                            json!({"time":timestamp(line),"action":"disconnect","user":user,"from":origin,"method":"-"}),
+                        );
+                        break;
+                    }
+                }
+            }
+        }
+        if let Some(row) = row {
+            out.push(row)
+        }
+    }
+    let start = out.len().saturating_sub(40);
+    json!(out[start..])
+}
+pub fn tail(path: &Path) -> Option<(String, Metadata)> {
+    let mut f = File::open(path).ok()?;
+    let info = f.metadata().ok()?;
+    let start = info.len().saturating_sub(256 * 1024);
+    f.seek(SeekFrom::Start(start)).ok()?;
+    let mut raw = vec![];
+    f.take(256 * 1024).read_to_end(&mut raw).ok()?;
+    let start = if start > 0 {
+        raw.iter()
+            .position(|b| *b == b'\n')
+            .map(|i| i + 1)
+            .unwrap_or(raw.len())
+    } else {
+        0
+    };
+    Some((String::from_utf8_lossy(&raw[start..]).into_owned(), info))
+}
+pub fn http_stats(raw: &str, source: &str) -> Value {
+    let mut recent = vec![];
+    let mut counts: [BTreeMap<String, u64>; 4] = std::array::from_fn(|_| BTreeMap::new());
+    let mut upgrades = 0;
+    for line in raw.lines() {
+        let Some((prefix, rest)) = line.split_once(" [") else {
+            continue;
+        };
+        let Some((stamp, rest)) = rest.split_once("] \"") else {
+            continue;
+        };
+        let Some((request, suffix)) = rest.split_once("\" ") else {
+            continue;
+        };
+        let f: Vec<_> = request.split_whitespace().collect();
+        let stats: Vec<_> = suffix.split_whitespace().collect();
+        if f.len() < 2
+            || stats.len() < 2
+            || stats[0].len() != 3
+            || !stats[0].bytes().all(|b| b.is_ascii_digit())
+        {
+            continue;
+        }
+        let Some(client) = prefix.split_whitespace().next() else {
+            continue;
+        };
+        let path: String = f[1]
+            .split('?')
+            .next()
+            .unwrap_or("")
+            .chars()
+            .take(60)
+            .collect();
+        let status = stats[0];
+        let keys = [
+            format!("{}xx", &status[..1]),
+            path.clone(),
+            client.into(),
+            f[0].into(),
+        ];
+        for (i, key) in keys.into_iter().enumerate() {
+            *counts[i].entry(key).or_default() += 1
+        }
+        if status == "101" {
+            upgrades += 1
+        }
+        recent.push(json!({"time":timestamp(stamp),"method":f[0],"path":path,"status":status,"client":client,"bytes":stats[1].parse::<u64>().unwrap_or(0)}));
+    }
+    let total = recent.len();
+    recent.reverse();
+    recent.truncate(40);
+    let mut out = json!({"source":source,"requestsPerSecond":0,"total":total,"upgrades":upgrades,"recent":recent,"history":[]});
+    for (i, (dest, key, limit)) in [
+        ("statusClasses", "class", 6),
+        ("topPaths", "path", 10),
+        ("topClients", "client", 8),
+        ("methods", "method", 6),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let mut items: Vec<_> = counts[i].iter().collect();
+        items.sort_by(|a, b| b.1.cmp(a.1));
+        out[dest] = json!(items
+            .into_iter()
+            .take(limit)
+            .map(|(name, count)| json!({key:name,"count":count}))
+            .collect::<Vec<_>>());
+    }
+    out
+}
+#[derive(Default)]
+pub struct HttpCollector {
+    previous: Option<(String, u64, u64, Instant)>,
+    history: Vec<f64>,
+}
+fn inode(info: &Metadata) -> u64 {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        info.ino()
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = info;
+        0
+    }
+}
+impl HttpCollector {
+    pub fn sample(&mut self, root: &Path, now: Instant) -> Value {
+        for candidate in [
+            "var/log/nginx/access.log",
+            "var/log/apache2/access.log",
+            "var/log/httpd/access_log",
+            "var/log/caddy/access.log",
+        ] {
+            let path = root.join(candidate);
+            let Some((raw, info)) = tail(&path) else {
+                continue;
+            };
+            if raw.is_empty() {
+                continue;
+            }
+            let path = path.to_string_lossy().into_owned();
+            let mut out = http_stats(&raw, &path);
+            let mut rate = 0.;
+            if let Some((old, ino, size, at)) = &self.previous {
+                if *old == path && *ino == inode(&info) && info.len() > *size && now > *at {
+                    let average = raw.len() as f64 / raw.lines().count().max(1) as f64;
+                    rate = (info.len() - size) as f64
+                        / average.max(1.)
+                        / now.duration_since(*at).as_secs_f64();
+                }
+            }
+            self.previous = Some((path, inode(&info), info.len(), now));
+            self.history.push(rate);
+            if self.history.len() > 240 {
+                self.history.remove(0);
+            }
+            out["requestsPerSecond"] = json!(rate);
+            out["history"] = json!(self.history);
+            return out;
+        }
+        self.previous = None;
+        self.history.clear();
+        Value::Null
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn fixture() -> Value {
+        serde_json::from_str(include_str!(
+            "../../../conformance/fixtures/demo-traffic.json"
+        ))
+        .unwrap()
+    }
+    #[test]
+    fn sources_and_tabs_render() {
+        let f = fixture();
+        let mut state = crate::model::State::new(true, 42);
+        let t = &mut state.sample["telemetry"];
+        let split = breakdown(&f["connections"], &f["listeners"]);
+        assert_eq!(split["inboundConnections"], 1);
+        assert_eq!(split["outboundConnections"], 2);
+        assert_eq!(array(&split["protocols"]).len(), 3);
+        for key in [
+            "protocols",
+            "remotes",
+            "inboundConnections",
+            "outboundConnections",
+        ] {
+            t[key] = split[key].clone();
+        }
+        t["sessions"] = sessions(f["who"].as_str().unwrap());
+        assert_eq!(t["sessions"][0]["from"], "203.0.113.4");
+        t["logins"] = logins(f["last"].as_str().unwrap(), "ok");
+        assert_eq!(array(&t["logins"]).len(), 1);
+        assert_eq!(t["logins"][0]["status"], "still");
+        t["failedLogins"] = logins(f["lastb"].as_str().unwrap(), "failed");
+        t["ssh"] = ssh(f["ssh"].as_str().unwrap());
+        assert_eq!(
+            array(&t["ssh"])
+                .iter()
+                .map(|e| text(&e["action"]))
+                .collect::<Vec<_>>(),
+            vec!["accepted", "invalid", "disconnect"]
+        );
+        t["http"] = http_stats(f["http"].as_str().unwrap(), "fixture");
+        assert_eq!(t["http"]["total"], 3);
+        assert_eq!(t["http"]["upgrades"], 1);
+        assert_eq!(t["http"]["recent"][0]["path"], "/chat");
+        assert_eq!(t["http"]["recent"][0]["time"], "10:01:02");
+        assert!(!t["http"].to_string().contains("secret"));
+        assert_eq!(t["http"]["statusClasses"][0]["count"], 1);
+        for (screen, labels) in [
+            (1, vec!["HTTPS", "SSH", "accepted", "/chat"]),
+            (2, vec!["alice", "eve", "still"]),
+        ] {
+            state.screen = screen;
+            let frame =
+                crate::render_to_screen(240, 80, "dark", |ui| crate::view::render(ui, &state));
+            for label in labels {
+                assert!(frame.contains(label), "screen {screen}: {label}");
+            }
+        }
+        assert!(array(&ssh("")).is_empty());
+        assert!(array(&logins("", "ok")).is_empty());
+    }
+    #[test]
+    fn http_growth_rotation_and_missing() {
+        struct Temp(std::path::PathBuf);
+        impl Drop for Temp {
+            fn drop(&mut self) {
+                std::fs::remove_dir_all(&self.0).unwrap();
+            }
+        }
+        let root = Temp(std::env::temp_dir().join(format!(
+                "hqtui-http-{}-{}",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_nanos()
+            )));
+        let path = root.0.join("var/log/nginx/access.log");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let raw = text(&fixture()["http"]);
+        std::fs::write(&path, &raw).unwrap();
+        let mut c = HttpCollector::default();
+        let now = Instant::now();
+        assert_eq!(n(&c.sample(&root.0, now)["requestsPerSecond"]), 0.);
+        std::fs::write(&path, raw.repeat(2)).unwrap();
+        assert!(
+            n(&c.sample(&root.0, now + std::time::Duration::from_secs(1))["requestsPerSecond"])
+                > 0.
+        );
+        std::fs::rename(&path, path.with_extension("old")).unwrap();
+        std::fs::write(&path, raw.repeat(3)).unwrap();
+        assert_eq!(
+            n(&c.sample(&root.0, now + std::time::Duration::from_secs(2))["requestsPerSecond"]),
+            0.
+        );
+        std::fs::write(&path, &raw).unwrap();
+        assert_eq!(
+            n(&c.sample(&root.0, now + std::time::Duration::from_secs(3))["requestsPerSecond"]),
+            0.
+        );
+        std::fs::write(&path, format!("{}\n{raw}", "x".repeat(300000))).unwrap();
+        assert!(tail(&path).unwrap().0.len() <= 256 * 1024);
+        std::fs::remove_file(&path).unwrap();
+        assert!(c
+            .sample(&root.0, now + std::time::Duration::from_secs(4))
+            .is_null());
+    }
+}

--- a/ports/zig/build.zig
+++ b/ports/zig/build.zig
@@ -15,9 +15,10 @@ pub fn build(b: *std.Build) void {
     // option keeps them free of assumptions about the working directory.
     const options = b.addOptions();
     options.addOptionPath("fixtures", b.path("../conformance/fixtures"));
+    const fixture_options = options.createModule();
 
     const tests = b.addTest(.{ .root_module = hqtui });
-    tests.root_module.addOptions("build_options", options);
+    tests.root_module.addImport("build_options", fixture_options);
     const run_tests = b.addRunArtifact(tests);
     const test_step = b.step("test", "Run the conformance suite and dashboard regression tests");
     test_step.dependOn(&run_tests.step);
@@ -37,6 +38,7 @@ pub fn build(b: *std.Build) void {
     b.step("run-demo", "Run the native ten-screen reference demo").dependOn(&run_demo.step);
     b.step("run-dashboard", "Run the native ten-screen reference demo").dependOn(&run_demo.step);
     const demo_tests = b.addTest(.{ .root_module = demo.root_module });
+    demo_tests.root_module.addImport("build_options", fixture_options);
     const run_demo_tests = b.addRunArtifact(demo_tests);
     b.step("test-demo", "Run native demo acceptance tests").dependOn(&run_demo_tests.step);
     b.getInstallStep().dependOn(&demo.step);

--- a/ports/zig/demo/collect.zig
+++ b/ports/zig/demo/collect.zig
@@ -2,9 +2,11 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const m = @import("model.zig");
+const sensors = @import("sensors.zig");
+const traffic = @import("traffic.zig");
 const Value = m.Value;
 fn read(a: std.mem.Allocator, io: std.Io, path: []const u8) []const u8 {
-    return std.Io.Dir.cwd().readFileAlloc(io, path, a, .limited(1024 * 1024)) catch "";
+    return @import("native_io.zig").read(a, io, path);
 }
 fn number(v: []const u8) f64 {
     return std.fmt.parseFloat(f64, v) catch 0;
@@ -155,7 +157,7 @@ pub fn refresh(state: *m.State, io: std.Io) !void {
     m.set(s, "network.upPeak", up);
     try history(a, s, "network.downHistory", &state.rx_history, state.history_count, down);
     try history(a, s, "network.upHistory", &state.tx_history, state.history_count, up);
-    state.history_count = @min(240, state.history_count + 1);
+    try packetCounters(state, read(a, io, "/proc/net/snmp"), dt);
     var missing: std.ArrayList([]const u8) = .empty;
     const ps = command(a, io, &.{ "ps", "-axo", "pid=,pcpu=,pmem=,rss=,nlwp=,stat=,user=,comm=" }) orelse blk: {
         try missing.append(a, "processes");
@@ -173,16 +175,26 @@ pub fn refresh(state: *m.State, io: std.Io) !void {
     }
     m.set(s, "system.processCount", @floatFromInt(m.arr(m.at(s.*, "processes")).len));
     m.set(s, "system.threadCount", threads);
-    const who = command(a, io, &.{"who"}) orelse blk: {
+    const processes = m.arr(m.at(s.*, "processes"));
+    m.set(s, "telemetry.states.total", @floatFromInt(processes.len));
+    for (processes) |process| {
+        const value = m.string(m.get(process, "state"));
+        if (value.len == 0) continue;
+        const key = switch (value[0]) {
+            'R' => "running",
+            'S', 'D' => "sleeping",
+            'T', 't' => "stopped",
+            'Z' => "zombie",
+            else => continue,
+        };
+        const target = m.ptr(s, "telemetry.states").object.getPtr(key).?;
+        target.* = f(m.num(target.*) + 1);
+    }
+    const who = command(a, io, &.{ "who", "-u" }) orelse blk: {
         try missing.append(a, "sessions");
         break :blk "";
     };
-    lines = std.mem.splitScalar(u8, who, '\n');
-    while (lines.next()) |line| {
-        const parts = try fields(a, line);
-        if (parts.len < 4) continue;
-        try add(a, s, "telemetry.sessions", try object(a, &.{ "user", "tty", "loginAt", "from", "idle", "what" }, &.{ string(parts[0]), string(parts[1]), string(try std.mem.join(a, " ", parts[2..4])), string(try std.mem.join(a, " ", parts[4..])), string("—"), string("—") }));
-    }
+    m.ptr(s, "telemetry.sessions").* = try traffic.sessions(a, who);
     const services = command(a, io, &.{ "systemctl", "list-units", "--type=service", "--all", "--no-legend", "--no-pager", "--plain" }) orelse blk: {
         try missing.append(a, "services");
         break :blk "";
@@ -204,7 +216,7 @@ pub fn refresh(state: *m.State, io: std.Io) !void {
         if (parts.len < 6) continue;
         const process = try std.mem.join(a, " ", parts[6..]);
         try add(a, s, "telemetry.connections", try object(a, &.{ "proto", "state", "local", "remote", "process" }, &.{ string(parts[0]), string(parts[1]), string(parts[4]), string(parts[5]), string(process) }));
-        if (m.eq(parts[1], "LISTEN") or m.eq(parts[1], "UNCONN")) {
+        if (m.eq(parts[1], "LISTEN")) {
             const cut = std.mem.lastIndexOfScalar(u8, parts[4], ':') orelse continue;
             try add(a, s, "telemetry.listeners", try object(a, &.{ "proto", "address", "port", "process" }, &.{ string(parts[0]), string(parts[4][0..cut]), string(parts[4][cut + 1 ..]), string(process) }));
         }
@@ -233,7 +245,74 @@ pub fn refresh(state: *m.State, io: std.Io) !void {
         try add(a, s, "telemetry.filesystems", try object(a, &.{ "device", "type", "size", "used", "mount" }, &.{ string(parts[0]), string(parts[1]), f(number(parts[2])), f(number(parts[3])), string(parts[6]) }));
         if (m.arr(m.at(s.*, "telemetry.filesystems")).len >= 128) break;
     }
-    // No fabricated sensors, disk rates, TCP counters, or privileged log data.
-    try missing.append(a, "disk I/O, thermal sensors, TCP packet counters, login/SSH/HTTP logs, GPU/power, application attribution; process CPU = ps average");
+    const gpus = try sensors.parseGPUs(a, command(a, io, &.{ "nvidia-smi", "--query-gpu=name,utilization.gpu,memory.used,memory.total,temperature.gpu,power.draw", "--format=csv,noheader,nounits" }) orelse "");
+    m.ptr(s, "telemetry.gpus").* = gpus;
+    const source: sensors.Source = .{ .a = a, .io = io, .root = "/" };
+    var readings = try sensors.collect(source, read(a, io, "/proc/cpuinfo"), gpus, null);
+    if (m.arr(readings.temperatures).len == 0) {
+        if (command(a, io, &.{ "sensors", "-j" })) |raw| readings.temperatures = .{ .array = try sensors.parseTemperatures(a, raw) };
+    }
+    m.ptr(s, "temperatures").* = readings.temperatures;
+    m.ptr(s, "sensors").* = readings.sensors;
+    m.ptr(s, "telemetry.power").* = readings.power;
+    if (m.arr(readings.temperatures).len == 0) try missing.append(a, "temperatures");
+    if (readings.hardware_count == 0) try missing.append(a, "fans/voltage/power");
+    if (m.arr(gpus).len == 0) try missing.append(a, "GPU telemetry");
+    const split = try traffic.breakdown(a, m.at(s.*, "telemetry.connections"), m.at(s.*, "telemetry.listeners"));
+    inline for (.{ "protocols", "remotes", "inboundConnections", "outboundConnections" }) |key| m.ptr(s, "telemetry." ++ key).* = m.get(split, key);
+    const login_raw = command(a, io, &.{ "last", "-n", "20", "-w" }) orelse blk: {
+        try missing.append(a, "login history");
+        break :blk "";
+    };
+    const failed_raw = command(a, io, &.{ "lastb", "-n", "15", "-w" }) orelse blk: {
+        try missing.append(a, "failed login history");
+        break :blk "";
+    };
+    m.ptr(s, "telemetry.logins").* = try traffic.logins(a, login_raw, "ok");
+    m.ptr(s, "telemetry.failedLogins").* = try traffic.logins(a, failed_raw, "failed");
+    var auth = command(a, io, &.{ "journalctl", "-u", "ssh", "-u", "sshd", "-n", "80", "--no-pager", "--output=short-iso" });
+    if (m.arr(try traffic.ssh(a, auth orelse "")).len == 0) {
+        if (traffic.tail(a, io, "/var/log/auth.log")) |fallback| auth = fallback.raw;
+    }
+    m.ptr(s, "telemetry.ssh").* = try traffic.ssh(a, auth orelse "");
+    if (auth == null) try missing.append(a, "SSH authentication log");
+    m.ptr(s, "telemetry.http").* = try state.http.sample(a, io, "/", now);
+    if (m.at(s.*, "telemetry.http") == .null) try missing.append(a, "HTTP access log");
+    try history(a, s, "telemetry.sessionHistory", &state.session_history, state.history_count, @floatFromInt(m.arr(m.at(s.*, "telemetry.sessions")).len));
+    try history(a, s, "telemetry.connectionHistory", &state.connection_history, state.history_count, @floatFromInt(m.arr(m.at(s.*, "telemetry.connections")).len));
+    state.history_count = @min(240, state.history_count + 1);
+    try missing.append(a, "disk I/O; process CPU = ps average");
     state.missing = try std.mem.join(a, ", ", missing.items);
+}
+
+pub fn packetCounters(state: *m.State, raw: []const u8, dt: f64) !void {
+    const a = state.allocator();
+    const s = &state.parsed.value;
+    const sources = [_][]const u8{ "TcpActiveOpens", "TcpPassiveOpens", "TcpCurrEstab", "TcpInSegs", "TcpOutSegs", "TcpRetransSegs", "TcpInErrs", "TcpOutRsts", "UdpInDatagrams", "UdpOutDatagrams", "UdpInErrors", "IcmpInMsgs", "IcmpOutMsgs" };
+    const targets = [_][]const u8{ "tcpActiveOpens", "tcpPassiveOpens", "tcpEstablished", "tcpInSegs", "tcpOutSegs", "tcpRetransSegs", "tcpInErrs", "tcpOutRsts", "udpInDatagrams", "udpOutDatagrams", "udpInErrors", "icmpInMsgs", "icmpOutMsgs" };
+    var current: [13]f64 = [_]f64{0} ** 13;
+    var lines = std.mem.splitScalar(u8, raw, '\n');
+    while (lines.next()) |line| {
+        const h = try fields(a, line);
+        const v = try fields(a, lines.next() orelse break);
+        if (h.len == 0 or v.len == 0 or !m.eq(h[0], v[0])) continue;
+        const prefix = std.mem.trimEnd(u8, h[0], ":");
+        for (1..@min(h.len, v.len)) |j| {
+            const key = try std.mem.concat(a, u8, &.{ prefix, h[j] });
+            for (sources, 0..) |source, i| {
+                if (m.eq(key, source)) current[i] = number(v[j]);
+            }
+        }
+    }
+    for (targets, 0..) |target, i| {
+        try m.ptr(s, "telemetry.net").object.put(a, target, f(current[i]));
+    }
+    for ([_][]const u8{ "inSegs", "outSegs", "retrans", "activeOpens", "passiveOpens", "udpIn", "udpOut" }, [_]usize{ 3, 4, 5, 0, 1, 8, 9 }) |key, i| {
+        try m.ptr(s, "telemetry.net.rates").object.put(a, key, f(rate(current[i], state.snmp_previous[i], dt)));
+    }
+    state.snmp_previous = current;
+    m.set(s, "telemetry.net.retransRatio", current[5] / @max(1, current[4]));
+    try history(a, s, "telemetry.netInHistory", &state.packet_history[0], state.history_count, m.num(m.at(s.*, "telemetry.net.rates.inSegs")));
+    try history(a, s, "telemetry.netOutHistory", &state.packet_history[1], state.history_count, m.num(m.at(s.*, "telemetry.net.rates.outSegs")));
+    try history(a, s, "telemetry.retransHistory", &state.packet_history[2], state.history_count, m.num(m.at(s.*, "telemetry.net.retransRatio")) * 100);
 }

--- a/ports/zig/demo/model.zig
+++ b/ports/zig/demo/model.zig
@@ -104,6 +104,7 @@ pub const Pane = struct {
     }
 };
 pub const State = struct {
+    http: @import("traffic.zig").HttpCollector = .{},
     parsed: std.json.Parsed(Value),
     gpa: std.mem.Allocator,
     real: bool,
@@ -142,6 +143,10 @@ pub const State = struct {
     rx_history: [240]f64 = [_]f64{0} ** 240,
     tx_history: [240]f64 = [_]f64{0} ** 240,
     history_count: usize = 0,
+    snmp_previous: [13]f64 = [_]f64{0} ** 13,
+    packet_history: [3][240]f64 = [_][240]f64{[_]f64{0} ** 240} ** 3,
+    session_history: [240]f64 = [_]f64{0} ** 240,
+    connection_history: [240]f64 = [_]f64{0} ** 240,
     pub fn init(gpa: std.mem.Allocator, real: bool, seed: u32) !State {
         var result = State{ .parsed = try std.json.parseFromSlice(Value, gpa, @embedFile("sample.json"), .{}), .gpa = gpa, .real = real, .seed = seed };
         if (real) {

--- a/ports/zig/demo/native_io.zig
+++ b/ports/zig/demo/native_io.zig
@@ -1,0 +1,9 @@
+//! procfs/sysfs report synthetic sizes; stream to EOF instead of trusting stat.
+const std = @import("std");
+pub fn read(a: std.mem.Allocator, io: std.Io, path: []const u8) []const u8 {
+    const file = std.Io.Dir.cwd().openFile(io, path, .{}) catch return "";
+    defer file.close(io);
+    var buffer: [4096]u8 = undefined;
+    var reader = file.readerStreaming(io, &buffer);
+    return reader.interface.allocRemaining(a, .limited(1024 * 1024)) catch "";
+}

--- a/ports/zig/demo/sensors.zig
+++ b/ports/zig/demo/sensors.zig
@@ -1,0 +1,236 @@
+//! Native Linux sensor collection; all allocation belongs to the sample arena.
+const std = @import("std");
+const m = @import("model.zig");
+const Value = m.Value;
+const Allocator = std.mem.Allocator;
+fn text(v: []const u8) Value {
+    return .{ .string = v };
+}
+fn numeric(v: f64) Value {
+    return .{ .float = v };
+}
+fn object(a: Allocator, keys: []const []const u8, values: []const Value) !Value {
+    return .{ .object = try std.json.ObjectMap.init(a, keys, values) };
+}
+fn finite(raw: []const u8) ?f64 {
+    const value = std.fmt.parseFloat(f64, std.mem.trim(u8, raw, " \t\r\n")) catch return null;
+    return if (std.math.isFinite(value)) value else null;
+}
+fn positive(raw: []const u8) ?f64 {
+    const v = finite(raw) orelse return null;
+    return if (v > 0) v else null;
+}
+fn input(name: []const u8, prefix: []const u8, suffix: []const u8) bool {
+    if (!std.mem.startsWith(u8, name, prefix) or !std.mem.endsWith(u8, name, suffix) or name.len <= prefix.len + suffix.len) return false;
+    for (name[prefix.len .. name.len - suffix.len]) |c| {
+        if (!std.ascii.isDigit(c)) return false;
+    }
+    return true;
+}
+pub const Source = struct {
+    a: Allocator,
+    io: std.Io,
+    root: []const u8,
+    fn join(self: Source, left: []const u8, right: []const u8) ![]const u8 {
+        return std.fs.path.join(self.a, &.{ left, right });
+    }
+    pub fn read(self: Source, path: []const u8) []const u8 {
+        const full = self.join(self.root, path) catch return "";
+        const raw = @import("native_io.zig").read(self.a, self.io, full);
+        return std.mem.trim(u8, raw, " \t\r\n");
+    }
+    fn entries(self: Source, path: []const u8) ![][]const u8 {
+        const full = try self.join(self.root, path);
+        var dir = std.Io.Dir.cwd().openDir(self.io, full, .{ .iterate = true }) catch return &.{};
+        defer dir.close(self.io);
+        var iter = dir.iterate();
+        var names: std.ArrayList([]const u8) = .empty;
+        while (names.items.len < 4096) {
+            const entry = (iter.next(self.io) catch break) orelse break;
+            try names.append(self.a, try self.a.dupe(u8, entry.name));
+        }
+        std.mem.sort([]const u8, names.items, {}, struct {
+            fn less(_: void, a: []const u8, b: []const u8) bool {
+                return std.mem.lessThan(u8, a, b);
+            }
+        }.less);
+        return names.items;
+    }
+    fn label(self: Source, dir: []const u8, stem: []const u8, chip: []const u8) ![]const u8 {
+        const named = self.read(try self.join(dir, try std.fmt.allocPrint(self.a, "{s}_label", .{stem})));
+        if (named.len > 0) return named;
+        if (std.mem.startsWith(u8, stem, "fan")) return std.fmt.allocPrint(self.a, "{s} Fan {s}", .{ chip, stem[3..] });
+        return std.fmt.allocPrint(self.a, "{s} {s}", .{ chip, stem });
+    }
+};
+pub const Readings = struct { temperatures: Value, sensors: Value, power: Value, hardware_count: usize };
+fn row(a: Allocator, label: []const u8, value: []const u8) !Value {
+    return object(a, &.{ "label", "value" }, &.{ text(label), text(value) });
+}
+pub fn collect(src: Source, cpuinfo: []const u8, gpus: Value, lm_raw: ?[]const u8) !Readings {
+    const a = src.a;
+    var temps = std.json.Array.init(a);
+    var rows = std.json.Array.init(a);
+    const chips = try src.entries("sys/class/hwmon");
+    for (chips[0..@min(128, chips.len)]) |name| {
+        const base = try src.join("sys/class/hwmon", name);
+        var chip = src.read(try src.join(base, "name"));
+        if (chip.len == 0) chip = src.read(try src.join(base, "device/name"));
+        if (chip.len == 0) chip = name;
+        for ([_][]const u8{ base, try src.join(base, "device") }) |dir| {
+            for (try src.entries(dir)) |file| {
+                const is_temp = input(file, "temp", "_input");
+                const fan = input(file, "fan", "_input");
+                const volts = input(file, "in", "_input");
+                const watts = input(file, "power", "_input") or input(file, "power", "_average");
+                const amps = input(file, "curr", "_input");
+                if (!is_temp and !fan and !volts and !watts and !amps) continue;
+                const value = positive(src.read(try src.join(dir, file))) orelse continue;
+                const stem = file[0..std.mem.lastIndexOfScalar(u8, file, '_').?];
+                const label = try src.label(dir, stem, chip);
+                if (is_temp) {
+                    if (value > 150000 or temps.items.len >= 12) continue;
+                    const maximum = positive(src.read(try src.join(dir, try std.fmt.allocPrint(a, "{s}_crit", .{stem})))) orelse 100000;
+                    try temps.append(try object(a, &.{ "label", "value", "max" }, &.{ text(label), numeric(value / 1000), numeric(maximum / 1000) }));
+                } else if (rows.items.len < 14) {
+                    const formatted = if (fan) try std.fmt.allocPrint(a, "{d:.0} RPM", .{@floor(value + 0.5)}) else if (volts) try std.fmt.allocPrint(a, "{d:.2} V", .{value / 1000}) else if (watts) try std.fmt.allocPrint(a, "{d:.1} W", .{value / 1e6}) else try std.fmt.allocPrint(a, "{d:.2} A", .{value / 1000});
+                    try rows.append(try row(a, label, formatted));
+                }
+            }
+        }
+    }
+    if (temps.items.len == 0) {
+        const zones = try src.entries("sys/class/thermal");
+        for (zones[0..@min(128, zones.len)]) |zone| {
+            if (!std.mem.startsWith(u8, zone, "thermal_zone")) continue;
+            const dir = try src.join("sys/class/thermal", zone);
+            const value = positive(src.read(try src.join(dir, "temp"))) orelse continue;
+            if (value > 150000) continue;
+            const label = src.read(try src.join(dir, "type"));
+            try temps.append(try object(a, &.{ "label", "value", "max" }, &.{ text(if (label.len > 0) label else zone), numeric(value / 1000), numeric(100) }));
+            if (temps.items.len == 12) break;
+        }
+    }
+    if (temps.items.len == 0) {
+        if (lm_raw) |raw| {
+            temps = try parseTemperatures(a, raw);
+        }
+    }
+    const hardware_count = rows.items.len;
+    const power = try battery(src);
+    if (power == .object) {
+        try rows.append(try row(a, "Battery", try std.fmt.allocPrint(a, "{d}% ({s})", .{ m.num(m.get(power, "battery")), m.string(m.get(power, "timeRemaining")) })));
+        const watts = m.num(m.get(power, "powerDraw"));
+        if (watts > 0) try rows.append(try row(a, "Battery draw", try std.fmt.allocPrint(a, "{d:.1} W", .{watts})));
+    }
+    const gpu_rows = m.arr(gpus);
+    for (gpu_rows[0..@min(16, gpu_rows.len)]) |gpu| {
+        const usage = m.get(gpu, "utilization");
+        const temperature = m.get(gpu, "temperature");
+        const u = if (usage == .null) "unavailable" else try std.fmt.allocPrint(a, "{d:.0}%", .{@floor(m.num(usage) * 100 + 0.5)});
+        const t = if (temperature == .null) "temperature unavailable" else try std.fmt.allocPrint(a, "{d}°C", .{m.num(temperature)});
+        try rows.append(try row(a, m.string(m.get(gpu, "name")), try std.fmt.allocPrint(a, "{s} · {s}", .{ u, t })));
+    }
+    var cpus: std.ArrayList(u32) = .empty;
+    for (try src.entries("sys/devices/system/cpu")) |name| {
+        if (!std.mem.startsWith(u8, name, "cpu")) continue;
+        try cpus.append(a, std.fmt.parseInt(u32, name[3..], 10) catch continue);
+    }
+    std.mem.sort(u32, cpus.items, {}, std.sort.asc(u32));
+    var clocks = std.json.Array.init(a);
+    for (cpus.items[0..@min(4, cpus.items.len)]) |cpu| {
+        const value = positive(src.read(try std.fmt.allocPrint(a, "sys/devices/system/cpu/cpu{d}/cpufreq/scaling_cur_freq", .{cpu}))) orelse continue;
+        try clocks.append(try row(a, try std.fmt.allocPrint(a, "cpu{d} clock", .{cpu}), try std.fmt.allocPrint(a, "{d:.2} GHz", .{value / 1e6})));
+    }
+    if (clocks.items.len == 0) {
+        var lines = std.mem.splitScalar(u8, cpuinfo, '\n');
+        while (lines.next()) |line| {
+            const cut = std.mem.indexOfScalar(u8, line, ':') orelse continue;
+            if (!m.eq(std.mem.trim(u8, line[0..cut], " \t"), "cpu MHz")) continue;
+            const mhz = positive(line[cut + 1 ..]) orelse continue;
+            try clocks.append(try row(a, try std.fmt.allocPrint(a, "cpu{d} clock", .{clocks.items.len}), try std.fmt.allocPrint(a, "{d:.2} GHz", .{mhz / 1000})));
+            if (clocks.items.len == 4) break;
+        }
+    }
+    try rows.appendSlice(clocks.items);
+    rows.shrinkRetainingCapacity(@min(14, rows.items.len));
+    return .{ .temperatures = .{ .array = temps }, .sensors = .{ .array = rows }, .power = power, .hardware_count = hardware_count };
+}
+pub fn parseTemperatures(a: Allocator, raw: []const u8) !std.json.Array {
+    var out = std.json.Array.init(a);
+    const chips = std.json.parseFromSliceLeaky(Value, a, raw, .{ .allocate = .alloc_always }) catch return out;
+    if (chips != .object) return out;
+    var chip_iter = chips.object.iterator();
+    while (chip_iter.next()) |chip| {
+        if (chip.value_ptr.* != .object) continue;
+        var features = chip.value_ptr.object.iterator();
+        while (features.next()) |feature| {
+            if (feature.value_ptr.* != .object) continue;
+            var values = feature.value_ptr.object.iterator();
+            while (values.next()) |value| {
+                const v = m.num(value.value_ptr.*);
+                if (!input(value.key_ptr.*, "temp", "_input") or v <= 0 or v > 150) continue;
+                const name = chip.key_ptr.*;
+                const cut = std.mem.indexOfScalar(u8, name, '-') orelse name.len;
+                try out.append(try object(a, &.{ "label", "value", "max" }, &.{ text(try std.fmt.allocPrint(a, "{s} {s}", .{ name[0..cut], feature.key_ptr.* })), numeric(v), numeric(100) }));
+                if (out.items.len == 12) return out;
+                break;
+            }
+        }
+    }
+    return out;
+}
+pub fn parseGPUs(a: Allocator, raw: []const u8) !Value {
+    var out = std.json.Array.init(a);
+    var lines = std.mem.splitScalar(u8, raw, '\n');
+    while (lines.next()) |line| {
+        var fields = std.mem.splitScalar(u8, line, ',');
+        var parts: [6][]const u8 = undefined;
+        var count: usize = 0;
+        while (fields.next()) |part| {
+            if (count == 6) {
+                count += 1;
+                break;
+            }
+            parts[count] = std.mem.trim(u8, part, " \r\t");
+            count += 1;
+        }
+        if (count != 6 or parts[0].len == 0) continue;
+        var values: [6]Value = .{ text(parts[0]), .null, .null, .null, .null, .null };
+        for (parts[1..], [_]f64{ 0.01, 1048576, 1048576, 1, 1 }, 1..) |part, scale, i| {
+            if (finite(part)) |v| {
+                if (v >= 0) values[i] = numeric(v * scale);
+            }
+        }
+        try out.append(try object(a, &.{ "name", "utilization", "memoryUsed", "memoryTotal", "temperature", "power" }, &values));
+        if (out.items.len == 16) break;
+    }
+    return .{ .array = out };
+}
+fn battery(src: Source) !Value {
+    const names = try src.entries("sys/class/power_supply");
+    var ac = false;
+    for (names[0..@min(128, names.len)]) |name| {
+        const dir = try src.join("sys/class/power_supply", name);
+        if (m.eq(src.read(try src.join(dir, "type")), "Mains") and m.eq(src.read(try src.join(dir, "online")), "1")) ac = true;
+    }
+    for (names[0..@min(128, names.len)]) |name| {
+        const dir = try src.join("sys/class/power_supply", name);
+        if (!m.eq(src.read(try src.join(dir, "type")), "Battery")) continue;
+        const capacity = finite(src.read(try src.join(dir, "capacity"))) orelse continue;
+        if (capacity < 0 or capacity > 100) continue;
+        const status = src.read(try src.join(dir, "status"));
+        var watts: Value = .null;
+        if (finite(src.read(try src.join(dir, "power_now")))) |v| {
+            watts = numeric(v / 1e6);
+        } else {
+            if (finite(src.read(try src.join(dir, "current_now")))) |amps| {
+                if (finite(src.read(try src.join(dir, "voltage_now")))) |volts| {
+                    watts = numeric(amps * volts / 1e12);
+                }
+            }
+        }
+        return object(src.a, &.{ "battery", "charging", "timeRemaining", "powerDraw", "acConnected" }, &.{ numeric(capacity), .{ .bool = m.eq(status, "Charging") }, text(status), watts, .{ .bool = ac } });
+    }
+    return .null;
+}

--- a/ports/zig/demo/tests.zig
+++ b/ports/zig/demo/tests.zig
@@ -4,6 +4,139 @@ const m = @import("model.zig");
 const view = @import("view.zig");
 const cli = @import("main.zig");
 const collect = @import("collect.zig");
+const sensors = @import("sensors.zig");
+const traffic = @import("traffic.zig");
+test "Linux procfs readers do not treat zero stat size as empty" {
+    if (@import("builtin").os.tag != .linux) return;
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const raw = @import("native_io.zig").read(arena.allocator(), std.testing.io, "/proc/meminfo");
+    try std.testing.expect(std.mem.indexOf(u8, raw, "MemTotal:") != null);
+}
+
+test "Traffic and Sessions use shared real-source parsers and render rows" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const raw = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, @import("build_options").fixtures ++ "/demo-traffic.json", a, .limited(1024 * 1024));
+    const fixture = try std.json.parseFromSliceLeaky(m.Value, a, raw, .{});
+    var state = try m.State.init(std.testing.allocator, true, 42);
+    defer state.deinit();
+    const data = &state.parsed.value;
+    const split = try traffic.breakdown(a, m.get(fixture, "connections"), m.get(fixture, "listeners"));
+    try std.testing.expectEqual(@as(f64, 1), m.num(m.get(split, "inboundConnections")));
+    try std.testing.expectEqual(@as(f64, 2), m.num(m.get(split, "outboundConnections")));
+    try std.testing.expectEqual(@as(usize, 3), m.arr(m.get(split, "protocols")).len);
+    inline for (.{ "protocols", "remotes", "inboundConnections", "outboundConnections" }) |key| m.ptr(data, "telemetry." ++ key).* = m.get(split, key);
+    m.ptr(data, "telemetry.sessions").* = try traffic.sessions(a, m.string(m.get(fixture, "who")));
+    m.ptr(data, "telemetry.logins").* = try traffic.logins(a, m.string(m.get(fixture, "last")), "ok");
+    m.ptr(data, "telemetry.failedLogins").* = try traffic.logins(a, m.string(m.get(fixture, "lastb")), "failed");
+    m.ptr(data, "telemetry.ssh").* = try traffic.ssh(a, m.string(m.get(fixture, "ssh")));
+    try std.testing.expectEqualStrings("203.0.113.4", m.string(m.get(m.arr(m.at(data.*, "telemetry.sessions"))[0], "from")));
+    const logins = m.arr(m.at(data.*, "telemetry.logins"));
+    try std.testing.expectEqual(@as(usize, 1), logins.len);
+    try std.testing.expectEqualStrings("still", m.string(m.get(logins[0], "status")));
+    const events = m.arr(m.at(data.*, "telemetry.ssh"));
+    try std.testing.expectEqual(@as(usize, 3), events.len);
+    for (events, [_][]const u8{ "accepted", "invalid", "disconnect" }) |event, action| try std.testing.expectEqualStrings(action, m.string(m.get(event, "action")));
+    const http = try traffic.httpStats(a, m.string(m.get(fixture, "http")), "fixture");
+    m.ptr(data, "telemetry.http").* = http;
+    try std.testing.expectEqual(@as(f64, 3), m.num(m.get(http, "total")));
+    try std.testing.expectEqual(@as(f64, 1), m.num(m.get(http, "upgrades")));
+    try std.testing.expectEqualStrings("/chat", m.string(m.get(m.arr(m.get(http, "recent"))[0], "path")));
+    try std.testing.expectEqualStrings("10:01:02", m.string(m.get(m.arr(m.get(http, "recent"))[0], "time")));
+    const serialized = try std.json.Stringify.valueAlloc(a, http, .{});
+    try std.testing.expect(std.mem.indexOf(u8, serialized, "secret") == null);
+    for ([_]usize{ 1, 2 }) |screen| {
+        state.screen = screen;
+        var frame = try h.renderToScreen(std.testing.allocator, 240, 80, "dark", h.Body.with(&state, view.render));
+        defer frame.deinit();
+        for (if (screen == 1) &[_][]const u8{ "HTTPS", "SSH", "accepted", "/chat" } else &[_][]const u8{ "alice", "eve", "Failed Logins", "still" }) |label| try std.testing.expect(frame.contains(label));
+    }
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(std.testing.io, "var/log/nginx");
+    const root = try tmp.dir.realPathFileAlloc(std.testing.io, ".", a);
+    const path = "var/log/nginx/access.log";
+    const log = m.string(m.get(fixture, "http"));
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = path, .data = log });
+    var collector: traffic.HttpCollector = .{};
+    try std.testing.expectEqual(@as(f64, 0), m.num(m.get(try collector.sample(a, std.testing.io, root, 1), "requestsPerSecond")));
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = path, .data = try std.mem.concat(a, u8, &.{ log, log }) });
+    try std.testing.expect(m.num(m.get(try collector.sample(a, std.testing.io, root, 2), "requestsPerSecond")) > 0);
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = path, .data = log });
+    try std.testing.expectEqual(@as(f64, 0), m.num(m.get(try collector.sample(a, std.testing.io, root, 3), "requestsPerSecond")));
+    try tmp.dir.deleteFile(std.testing.io, path);
+    try std.testing.expect((try collector.sample(a, std.testing.io, root, 4)) == .null);
+}
+
+test "packet counters refresh and resets do not spike" {
+    var state = try m.State.init(std.testing.allocator, true, 42);
+    defer state.deinit();
+    try collect.packetCounters(&state, "Tcp: ActiveOpens PassiveOpens CurrEstab InSegs OutSegs RetransSegs\nTcp: 10 20 3 100 200 2\nUdp: InDatagrams OutDatagrams\nUdp: 50 60\n", 0);
+    try std.testing.expectEqual(@as(f64, 3), m.num(m.at(state.data(), "telemetry.net.tcpEstablished")));
+    try std.testing.expectEqual(@as(f64, 0), m.num(m.at(state.data(), "telemetry.net.rates.inSegs")));
+    try collect.packetCounters(&state, "Tcp: ActiveOpens PassiveOpens CurrEstab InSegs OutSegs RetransSegs\nTcp: 11 21 4 150 300 3\n", 2);
+    try std.testing.expectEqual(@as(f64, 25), m.num(m.at(state.data(), "telemetry.net.rates.inSegs")));
+    try collect.packetCounters(&state, "Tcp: InSegs OutSegs\nTcp: 2 3\n", 1);
+    try std.testing.expectEqual(@as(f64, 0), m.num(m.at(state.data(), "telemetry.net.rates.inSegs")));
+}
+
+fn writeSensorFiles(dir: std.Io.Dir, files: m.Value) !void {
+    if (files != .object) return;
+    var iter = files.object.iterator();
+    while (iter.next()) |entry| {
+        if (std.fs.path.dirname(entry.key_ptr.*)) |parent| try dir.createDirPath(std.testing.io, parent);
+        try dir.writeFile(std.testing.io, .{ .sub_path = entry.key_ptr.*, .data = m.string(entry.value_ptr.*) });
+    }
+}
+fn checkSensorValues(readings: m.Value, expected: m.Value) !void {
+    if (expected != .object) return;
+    var iter = expected.object.iterator();
+    while (iter.next()) |entry| {
+        var found = false;
+        for (m.arr(readings)) |sensor| {
+            if (!m.eq(m.string(m.get(sensor, "label")), entry.key_ptr.*)) continue;
+            try std.testing.expectEqualStrings(m.string(entry.value_ptr.*), m.string(m.get(sensor, "value")));
+            found = true;
+        }
+        try std.testing.expect(found);
+    }
+}
+test "shared sensor sources refresh and render" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const raw = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, @import("build_options").fixtures ++ "/demo-sensors.json", a, .limited(1024 * 1024));
+    const cases = try std.json.parseFromSliceLeaky(m.Value, a, raw, .{});
+    for (m.arr(cases)) |case| {
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+        const root = try tmp.dir.realPathFileAlloc(std.testing.io, ".", a);
+        try writeSensorFiles(tmp.dir, m.get(case, "files"));
+        const source: sensors.Source = .{ .a = a, .io = std.testing.io, .root = root };
+        const gpus = try sensors.parseGPUs(a, m.string(m.get(case, "gpus")));
+        const first = try sensors.collect(source, m.string(m.get(case, "cpuinfo")), gpus, m.string(m.get(case, "lm")));
+        const expected = m.arr(m.get(case, "temperatures"));
+        try std.testing.expectEqual(expected.len, m.arr(first.temperatures).len);
+        for (expected, m.arr(first.temperatures)) |value, temp| try std.testing.expectEqual(m.num(value), m.num(m.get(temp, "value")));
+        try checkSensorValues(first.sensors, m.get(case, "sensors"));
+        var state = try m.State.init(std.testing.allocator, true, 42);
+        defer state.deinit();
+        m.ptr(&state.parsed.value, "temperatures").* = first.temperatures;
+        m.ptr(&state.parsed.value, "sensors").* = first.sensors;
+        var frame = try h.renderToScreen(std.testing.allocator, 220, 70, "dark", h.Body.with(&state, view.render));
+        defer frame.deinit();
+        for (m.arr(first.sensors)) |sensor| {
+            try std.testing.expect(frame.contains(m.string(m.get(sensor, "label"))));
+            try std.testing.expect(frame.contains(m.string(m.get(sensor, "value"))));
+        }
+        try writeSensorFiles(tmp.dir, m.get(case, "changes"));
+        const next_cpu = m.get(case, "nextCpuinfo");
+        const next = try sensors.collect(source, m.string(if (next_cpu == .null) m.get(case, "cpuinfo") else next_cpu), gpus, m.string(m.get(case, "lm")));
+        try checkSensorValues(next.sensors, m.get(case, "nextSensors"));
+    }
+}
 
 test "all ten screens, all themes, small and large terminals" {
     var state = try m.State.init(std.testing.allocator, false, 1337);

--- a/ports/zig/demo/traffic.zig
+++ b/ports/zig/demo/traffic.zig
@@ -1,0 +1,280 @@
+//! Read-only Traffic/Sessions parsers. Port labels and directions are estimates.
+const std = @import("std");
+const m = @import("model.zig");
+const Value = m.Value;
+const A = std.mem.Allocator;
+fn text(s: []const u8) Value {
+    return .{ .string = s };
+}
+fn number(n: f64) Value {
+    return .{ .float = n };
+}
+fn object(a: A, keys: []const []const u8, values: []const Value) !Value {
+    return .{ .object = try std.json.ObjectMap.init(a, keys, values) };
+}
+fn words(a: A, raw: []const u8) ![][]const u8 {
+    var out: std.ArrayList([]const u8) = .empty;
+    var iter = std.mem.tokenizeAny(u8, raw, " \t\r");
+    while (iter.next()) |part| try out.append(a, part);
+    return out.items;
+}
+fn stamp(raw: []const u8) []const u8 {
+    if (raw.len < 8) return "";
+    for (0..raw.len - 7) |i| {
+        if (i > 0 and std.ascii.isDigit(raw[i - 1])) continue;
+        const s = raw[i .. i + 8];
+        if (s[2] != ':' or s[5] != ':') continue;
+        var valid = true;
+        for ([_]usize{ 0, 1, 3, 4, 6, 7 }) |j| {
+            if (!std.ascii.isDigit(s[j])) valid = false;
+        }
+        if (valid) return s;
+    }
+    return "";
+}
+const ports = "20=FTP 21=FTP 22=SSH 23=Telnet 25=SMTP 53=DNS 67=DHCP 68=DHCP 80=HTTP 110=POP3 111=RPC 123=NTP 143=IMAP 161=SNMP 389=LDAP 443=HTTPS 445=SMB 465=SMTPS 514=Syslog 587=SMTP 631=IPP 636=LDAPS 993=IMAPS 995=POP3S 1194=OpenVPN 1433=MSSQL 1521=Oracle 2049=NFS 2379=etcd 3000=HTTP-dev 3306=MySQL 3389=RDP 4000=HTTP-dev 5000=HTTP-dev 5432=Postgres 5672=AMQP 5900=VNC 6379=Redis 8000=HTTP-alt 8080=HTTP-alt 8443=HTTPS-alt 9000=HTTP-alt 9090=Prometheus 9200=Elasticsearch 11211=Memcached 27017=MongoDB 41641=Tailscale 51820=WireGuard";
+fn classify(a: A, port: []const u8) ![]const u8 {
+    var pairs = std.mem.tokenizeScalar(u8, ports, ' ');
+    while (pairs.next()) |pair| {
+        const cut = std.mem.indexOfScalar(u8, pair, '=').?;
+        if (m.eq(pair[0..cut], port)) return pair[cut + 1 ..];
+    }
+    const n = std.fmt.parseInt(u32, port, 10) catch 0;
+    return if (n >= 32768) "ephemeral" else std.fmt.allocPrint(a, "port {s}", .{port});
+}
+const Endpoint = struct { host: []const u8, port: []const u8 };
+fn endpoint(raw: []const u8) Endpoint {
+    const cut = std.mem.lastIndexOfScalar(u8, raw, ':') orelse return .{ .host = raw, .port = "" };
+    return .{ .host = raw[0..cut], .port = raw[cut + 1 ..] };
+}
+pub fn breakdown(a: A, connections: Value, listeners: Value) !Value {
+    var buckets = std.json.Array.init(a);
+    var remotes = std.json.Array.init(a);
+    var inbound: f64 = 0;
+    var outbound: f64 = 0;
+    for (m.arr(connections)) |c| {
+        const state = m.string(m.get(c, "state"));
+        if (m.eq(state, "LISTEN") or (!m.eq(state, "ESTAB") and !std.mem.startsWith(u8, m.string(m.get(c, "proto")), "udp"))) continue;
+        const local = endpoint(m.string(m.get(c, "local")));
+        const remote = endpoint(m.string(m.get(c, "remote")));
+        var incoming = false;
+        for (m.arr(listeners)) |l| {
+            if (m.eq(local.port, m.string(m.get(l, "port")))) {
+                incoming = true;
+                break;
+            }
+        }
+        const protocol = try classify(a, if (incoming) local.port else remote.port);
+        var found: ?usize = null;
+        for (buckets.items, 0..) |b, i| {
+            if (m.eq(m.string(m.get(b, "protocol")), protocol)) {
+                found = i;
+                break;
+            }
+        }
+        if (found == null) {
+            found = buckets.items.len;
+            try buckets.append(try object(a, &.{ "protocol", "inbound", "outbound", "total" }, &.{ text(protocol), number(0), number(0), number(0) }));
+        }
+        const bucket = &buckets.items[found.?];
+        const key = if (incoming) "inbound" else "outbound";
+        m.ptr(bucket, key).* = number(m.num(m.get(bucket.*, key)) + 1);
+        m.ptr(bucket, "total").* = number(m.num(m.get(bucket.*, "total")) + 1);
+        if (incoming) {
+            inbound += 1;
+        } else {
+            outbound += 1;
+        }
+        if (remote.host.len == 0 or m.eq(remote.host, "*") or m.eq(remote.host, "0.0.0.0")) continue;
+        found = null;
+        for (remotes.items, 0..) |r, i| {
+            if (m.eq(m.string(m.get(r, "host")), remote.host)) {
+                found = i;
+                break;
+            }
+        }
+        if (found == null) {
+            found = remotes.items.len;
+            try remotes.append(try object(a, &.{ "host", "connections", "protocols", "names" }, &.{ text(remote.host), number(0), text(""), .{ .array = std.json.Array.init(a) } }));
+        }
+        const r = &remotes.items[found.?];
+        m.ptr(r, "connections").* = number(m.num(m.get(r.*, "connections")) + 1);
+        var seen = false;
+        for (m.arr(m.get(r.*, "names"))) |name| {
+            if (m.eq(m.string(name), protocol)) seen = true;
+        }
+        if (!seen) try m.ptr(r, "names").array.append(text(protocol));
+    }
+    std.mem.sort(Value, buckets.items, @as([]const u8, "total"), countOrder);
+    std.mem.sort(Value, remotes.items, @as([]const u8, "connections"), countOrder);
+    remotes.shrinkRetainingCapacity(@min(12, remotes.items.len));
+    for (remotes.items) |*r| {
+        const names = m.arr(m.get(r.*, "names"));
+        var parts: std.ArrayList([]const u8) = .empty;
+        for (names[0..@min(3, names.len)]) |name| try parts.append(a, m.string(name));
+        m.ptr(r, "protocols").* = text(try std.mem.join(a, ", ", parts.items));
+        _ = r.object.swapRemove("names");
+    }
+    return object(a, &.{ "protocols", "remotes", "inboundConnections", "outboundConnections" }, &.{ .{ .array = buckets }, .{ .array = remotes }, number(inbound), number(outbound) });
+}
+fn countOrder(key: []const u8, l: Value, r: Value) bool {
+    return m.num(m.get(l, key)) > m.num(m.get(r, key));
+}
+pub fn sessions(a: A, raw: []const u8) !Value {
+    var out = std.json.Array.init(a);
+    var lines = std.mem.splitScalar(u8, raw, '\n');
+    while (lines.next()) |line| {
+        const f = try words(a, line);
+        if (f.len < 4) continue;
+        var origin: []const u8 = "local";
+        if (std.mem.indexOfScalar(u8, line, '(')) |start| {
+            if (std.mem.indexOfScalar(u8, line[start + 1 ..], ')')) |end| origin = line[start + 1 .. start + 1 + end];
+        }
+        try out.append(try object(a, &.{ "user", "tty", "loginAt", "idle", "what", "from" }, &.{ text(f[0]), text(f[1]), text(try std.mem.join(a, " ", f[2..4])), text(if (f.len > 4) f[4] else "."), text(if (f.len > 5) f[5] else ""), text(origin) }));
+        if (out.items.len == 1000) break;
+    }
+    return .{ .array = out };
+}
+pub fn logins(a: A, raw: []const u8, status: []const u8) !Value {
+    var out = std.json.Array.init(a);
+    var lines = std.mem.splitScalar(u8, raw, '\n');
+    while (lines.next()) |line| {
+        const f = try words(a, line);
+        if (f.len < 4 or m.eq(f[0], "wtmp") or m.eq(f[0], "btmp") or m.eq(f[0], "reboot")) continue;
+        var when = try std.mem.join(a, " ", f[f.len -| 7 .. f.len - 3]);
+        if (when.len == 0) when = try std.mem.join(a, " ", f[3..@min(7, f.len)]);
+        try out.append(try object(a, &.{ "user", "tty", "from", "when", "status" }, &.{ text(f[0]), text(f[1]), text(if (std.mem.indexOfAny(u8, f[2], ".:") != null) f[2] else "local"), text(when), text(if (std.mem.indexOf(u8, line, "still logged in") != null) "still" else status) }));
+        if (out.items.len == 40) break;
+    }
+    return .{ .array = out };
+}
+pub fn ssh(a: A, raw: []const u8) !Value {
+    var out = std.json.Array.init(a);
+    var lines = std.mem.splitScalar(u8, raw, '\n');
+    while (lines.next()) |line| {
+        if (std.mem.indexOf(u8, line, "sshd") == null) continue;
+        const f = try words(a, line);
+        for (f, 0..) |word, i| {
+            if ((m.eq(word, "Accepted") or m.eq(word, "Failed")) and i + 5 < f.len and m.eq(f[i + 2], "for")) {
+                const invalid = i + 7 < f.len and m.eq(f[i + 3], "invalid") and m.eq(f[i + 4], "user");
+                const at = i + @as(usize, if (invalid) 5 else 3);
+                if (at + 2 >= f.len or !m.eq(f[at + 1], "from")) continue;
+                try out.append(try object(a, &.{ "time", "action", "method", "user", "from" }, &.{ text(stamp(line)), text(if (m.eq(word, "Accepted")) "accepted" else if (invalid) "invalid" else "failed"), text(f[i + 1]), text(f[at]), text(f[at + 2]) }));
+                break;
+            }
+            if (m.eq(word, "Disconnected") and i + 4 < f.len and m.eq(f[i + 1], "from")) {
+                const at = i + @as(usize, if (m.eq(f[i + 2], "authenticating")) 3 else 2);
+                if (at + 2 >= f.len or !m.eq(f[at], "user")) continue;
+                try out.append(try object(a, &.{ "time", "action", "user", "from", "method" }, &.{ text(stamp(line)), text("disconnect"), text(f[at + 1]), text(f[at + 2]), text("-") }));
+                break;
+            }
+        }
+    }
+    if (out.items.len > 40) {
+        std.mem.copyForwards(Value, out.items[0..40], out.items[out.items.len - 40 ..]);
+        out.shrinkRetainingCapacity(40);
+    }
+    return .{ .array = out };
+}
+pub const Tail = struct { raw: []const u8, size: u64, inode: std.Io.File.INode };
+pub fn tail(a: A, io: std.Io, path: []const u8) ?Tail {
+    const file = std.Io.Dir.cwd().openFile(io, path, .{}) catch return null;
+    defer file.close(io);
+    const stat = file.stat(io) catch return null;
+    const start = stat.size -| 262144;
+    const buffer = a.alloc(u8, @intCast(@min(stat.size, 262144))) catch return null;
+    const n = file.readPositionalAll(io, buffer, start) catch return null;
+    var raw: []const u8 = buffer[0..n];
+    if (start > 0) {
+        raw = if (std.mem.indexOfScalar(u8, raw, '\n')) |cut| raw[cut + 1 ..] else "";
+    }
+    return .{ .raw = raw, .size = stat.size, .inode = stat.inode };
+}
+pub fn httpStats(a: A, raw: []const u8, source: []const u8) !Value {
+    var recent = std.json.Array.init(a);
+    var counts: [4]std.json.ObjectMap = undefined;
+    for (&counts) |*c| c.* = .empty;
+    var upgrades: f64 = 0;
+    var lines = std.mem.splitScalar(u8, raw, '\n');
+    while (lines.next()) |line| {
+        const first = std.mem.indexOf(u8, line, " [") orelse continue;
+        const after = line[first + 2 ..];
+        const second = std.mem.indexOf(u8, after, "] \"") orelse continue;
+        const date = after[0..second];
+        const rest = after[second + 3 ..];
+        const quote = std.mem.indexOf(u8, rest, "\" ") orelse continue;
+        const request = try words(a, rest[0..quote]);
+        const suffix = try words(a, rest[quote + 2 ..]);
+        if (request.len < 2 or suffix.len < 2 or suffix[0].len != 3) continue;
+        const status = suffix[0];
+        var valid = true;
+        for (status) |c| {
+            if (!std.ascii.isDigit(c)) valid = false;
+        }
+        if (!valid) continue;
+        const prefix = try words(a, line[0..first]);
+        if (prefix.len == 0) continue;
+        const client = prefix[0];
+        const cut = std.mem.indexOfScalar(u8, request[1], '?') orelse request[1].len;
+        var len = @min(60, cut);
+        while (len > 0 and len < cut and request[1][len] & 0xc0 == 0x80) len -= 1;
+        const path = request[1][0..len];
+        const keys = [_][]const u8{ try std.fmt.allocPrint(a, "{c}xx", .{status[0]}), path, client, request[0] };
+        for (keys, 0..) |key, i| {
+            const old = counts[i].get(key) orelse number(0);
+            try counts[i].put(a, key, number(m.num(old) + 1));
+        }
+        if (m.eq(status, "101")) upgrades += 1;
+        try recent.append(try object(a, &.{ "time", "method", "path", "status", "client", "bytes" }, &.{ text(stamp(date)), text(request[0]), text(path), text(status), text(client), number(std.fmt.parseFloat(f64, suffix[1]) catch 0) }));
+    }
+    const total = recent.items.len;
+    std.mem.reverse(Value, recent.items);
+    recent.shrinkRetainingCapacity(@min(40, recent.items.len));
+    var out = try object(a, &.{ "source", "requestsPerSecond", "total", "upgrades", "recent", "history" }, &.{ text(source), number(0), number(@floatFromInt(total)), number(upgrades), .{ .array = recent }, .{ .array = std.json.Array.init(a) } });
+    for ([_][]const u8{ "statusClasses", "topPaths", "topClients", "methods" }, [_][]const u8{ "class", "path", "client", "method" }, [_]usize{ 6, 10, 8, 6 }, 0..) |dest, key, limit, i| {
+        var rows = std.json.Array.init(a);
+        var iter = counts[i].iterator();
+        while (iter.next()) |entry| try rows.append(try object(a, &.{ key, "count" }, &.{ text(entry.key_ptr.*), entry.value_ptr.* }));
+        std.mem.sort(Value, rows.items, @as([]const u8, "count"), countOrder);
+        rows.shrinkRetainingCapacity(@min(limit, rows.items.len));
+        try out.object.put(a, dest, .{ .array = rows });
+    }
+    return out;
+}
+pub const HttpCollector = struct {
+    source: ?usize = null,
+    size: u64 = 0,
+    inode: std.Io.File.INode = 0,
+    at: f64 = 0,
+    history: [240]f64 = [_]f64{0} ** 240,
+    count: usize = 0,
+    pub fn sample(self: *HttpCollector, a: A, io: std.Io, root: []const u8, now: f64) !Value {
+        for ([_][]const u8{ "var/log/nginx/access.log", "var/log/apache2/access.log", "var/log/httpd/access_log", "var/log/caddy/access.log" }, 0..) |candidate, i| {
+            const path = try std.fs.path.join(a, &.{ root, candidate });
+            const result = tail(a, io, path) orelse continue;
+            if (result.raw.len == 0) continue;
+            var out = try httpStats(a, result.raw, path);
+            var rate: f64 = 0;
+            if (self.source == i and self.inode == result.inode and result.size > self.size and now > self.at) {
+                const lines = std.mem.count(u8, std.mem.trim(u8, result.raw, "\r\n"), "\n") + 1;
+                const average = @as(f64, @floatFromInt(result.raw.len)) / @as(f64, @floatFromInt(lines));
+                rate = @as(f64, @floatFromInt(result.size - self.size)) / @max(1, average) / (now - self.at);
+            }
+            self.source = i;
+            self.size = result.size;
+            self.inode = result.inode;
+            self.at = now;
+            if (self.count == 240) {
+                std.mem.copyForwards(f64, self.history[0..239], self.history[1..240]);
+                self.count = 239;
+            }
+            self.history[self.count] = rate;
+            self.count += 1;
+            m.ptr(&out, "requestsPerSecond").* = number(rate);
+            for (self.history[0..self.count]) |v| try m.ptr(&out, "history").array.append(number(v));
+            return out;
+        }
+        self.* = .{};
+        return .null;
+    }
+};

--- a/ports/zig/demo/view.zig
+++ b/ports/zig/demo/view.zig
@@ -99,6 +99,11 @@ fn dashboard(ctx: *Context, p: *Container) !void {
             if (temps.len == 0) try p.label("No thermal sensors available");
             for (temps) |t| try p.meter(.{ .label = m.string(m.get(t, "label")), .value = m.num(m.get(t, "value")), .max = 100, .text = try p.fmt("{d:.0}°C", .{m.num(m.get(t, "value"))}) });
         },
+        8 => {
+            const readings = m.arr(val(s, "sensors"));
+            if (readings.len == 0) try p.label("No sensor readings available");
+            for (readings) |sensor| try p.label(try p.fmt("{s}: {s}", .{ m.string(m.get(sensor, "label")), m.string(m.get(sensor, "value")) }));
+        },
         else => try table(ctx, p, m.arr(val(s, "logs")), &.{ .{ "time", "Time" }, .{ "level", "Level" }, .{ "message", "Message" } }, 0),
     }
 }
@@ -123,6 +128,7 @@ fn telemetry(ctx: *Context, p: *Container) !void {
             0 => try table(ctx, p, m.arr(val(s, "telemetry.sessions")), &.{ .{ "user", "User" }, .{ "tty", "TTY" }, .{ "from", "From" }, .{ "idle", "Idle" }, .{ "what", "Command" } }, 0),
             1 => try table(ctx, p, m.arr(val(s, "telemetry.logins")), &.{ .{ "user", "User" }, .{ "tty", "TTY" }, .{ "from", "From" }, .{ "when", "When" }, .{ "status", "Status" } }, 0),
             2 => try table(ctx, p, m.arr(val(s, "telemetry.ssh")), &.{ .{ "time", "Time" }, .{ "action", "Action" }, .{ "user", "User" }, .{ "from", "From" } }, 0),
+            4 => try table(ctx, p, m.arr(val(s, "telemetry.failedLogins")), &.{ .{ "user", "User" }, .{ "tty", "TTY" }, .{ "from", "From" }, .{ "when", "When" }, .{ "status", "Status" } }, 0),
             else => try graph(p, val(s, "telemetry.sessionHistory"), "Sessions", null),
         },
         3 => switch (ctx.index) {
@@ -215,9 +221,9 @@ fn body(ctx: *Context, p: *Container) anyerror!void {
 }
 fn titles(s: *State, wide: bool) []const []const u8 {
     return switch (s.screen) {
-        0 => if (wide) &.{ "CPU Overview", "Processes", "Memory & Swap", "Network", "Disks", "System", "Temperatures & Sensors", "Logs" } else &.{ "CPU Overview", "Processes", "Memory & Swap", "Network" },
+        0 => if (wide) &.{ "CPU Overview", "Processes", "Memory & Swap", "Network", "Disks", "System", "Temperatures", "Logs", "Sensors" } else &.{ "CPU Overview", "Processes", "Memory & Swap", "Network" },
         1 => &.{ "Protocols", "TCP Segments", "Retransmits", "HTTP", "Remote Hosts", "SSH Authentication" },
-        2 => &.{ "Active Sessions", "Login History", "SSH Authentication", "Session History" },
+        2 => &.{ "Active Sessions", "Login History", "SSH Authentication", "Session History", "Failed Logins" },
         3 => &.{ "Interfaces", "Connections", "Listeners", "Connection History" },
         4 => &.{ "Services", "Filesystems", "Kernel", "Journal" },
         5 => &.{ "Controls", "Meters & Gauge", "Text & Badges" },
@@ -254,6 +260,7 @@ pub fn render(s: *State, ui: *Container) anyerror!void {
         try ui.label("Terminal too small; resize to 30×12");
         try ui.spacer(.fill);
     } else {
+        if (s.real and s.screen == 1) try ui.label("Protocol/direction: port-based estimates; HTTP rate: estimated from log growth");
         const names = titles(s, ui.width() >= 90 and ui.height() >= 50);
         const cols: usize = if (ui.width() < 45) 1 else if (s.screen == 9 and ui.width() >= 120) 4 else if (s.screen == 5 or s.screen == 9 or (s.screen == 1 and ui.width() >= 120) or (s.screen == 0 and ui.width() >= 160)) 3 else 2;
         const columns = try ui.ctx.allocator.alloc(h.layout.Size, cols);


### PR DESCRIPTION
Fill missing native collectors and views, following the TypeScript reference data sources. Go/Python/Zig now collect hwmon, thermal/lm-sensors, CPU clocks, battery and GPU readings. Rust/Go/Python/Zig now derive port-based socket estimates and collect login/failed-login history, SSH events and bounded HTTP log tails. Add missing process states, failed-login views, and Zig packet counters/history. Fix Zig procfs reads: size-based reads treated zero-size procfs files as empty; streaming reads restore real CPU/memory/sensor data.

Shared sensor/traffic fixtures exercise changed values, real-source parsers and rendered rows. HTTP tests cover growth, truncation/rotation and disappearing sources. A new CI test places fixture utilities on a private PATH and runs all four full native CLIs in real mode across Dashboard/Traffic/Sessions. This caught UDP clients incorrectly classified as listeners. Existing TypeScript screen-body comparisons remain intact. Port classification and HTTP rate estimates are explicitly labeled; missing permissions/activity never produce fake events.

Validation: all native test tasks (Go race detector, Python 34 tests, Rust library + 17 demo tests in both entrypoints, Zig conformance and demo tests), 167 Bun tests, site build, real/simulated PTY cleanup, fixture-to-real-CLI checks, and live host snapshots. Full layout/interaction parity remains explicitly unfinished in docs. No hero/logo assets changed.