### PR TITLE
Fix quota-limited /tmp failures in all demo builds

### DIFF
--- a/apps/demo/scripts/test-updater.py
+++ b/apps/demo/scripts/test-updater.py
@@ -47,7 +47,7 @@ class Updater(unittest.TestCase):
         (path / "__init__.py").write_text("")
         (path / "dashboard.py").write_text(
             'import json, os, sys\n'
-            f'print(json.dumps({{"revision": {label!r}, "args": sys.argv[1:], "cwd": os.getcwd(), "tty": os.isatty(0)}}), flush=True)\n'
+            f'print(json.dumps({{"revision": {label!r}, "args": sys.argv[1:], "cwd": os.getcwd(), "tty": os.isatty(0), "tmpdir": os.environ.get("TMPDIR")}}), flush=True)\n'
             'if "--wait" in sys.argv: input()\n')
         for language in ("rust", "go", "zig", "cpp", "ruby", "php", "perl"):
             (self.repo / "ports" / language).mkdir(exist_ok=True)
@@ -107,10 +107,16 @@ class Updater(unittest.TestCase):
 
     def stub_compilers(self):
         code = '''#!/usr/bin/env python3
-import json, os, pathlib, sys
+import json, os, pathlib, sys, tempfile
 tool=pathlib.Path(sys.argv[0]).name
 args=sys.argv[1:]
 with open(os.environ["UPDATER_TEST_LOG"],"a") as log: log.write(json.dumps([tool,*args])+"\\n")
+if tool in ('cmake','cargo','go','zig'):
+    expected=pathlib.Path(os.environ['HQTUI_DEMO_CACHE'])/'v1/tmp'
+    assert pathlib.Path(os.environ['TMPDIR'])==expected, 'compiler scratch escaped demo cache'
+    with tempfile.TemporaryFile(dir=os.environ['TMPDIR']) as scratch: scratch.write(b'compiler scratch')
+    if os.environ.get('UPDATER_FAIL_BUILD')=='1' and tool=='cmake' and args[0]=='--build':
+        print('fixture linker failure',file=sys.stderr);sys.exit(1)
 if tool=="mise":
     assert args[0:2]==["--no-config","exec"]
     assert args[3]=="--"
@@ -200,6 +206,30 @@ output.chmod(0o700)
             self.assertEqual(json.loads(result.stdout)['revision'],'second')
         self.assertEqual(builds(),count+4)
         self.assertFalse((self.root/'cache/v1/update.lock').exists())
+
+    def test_failed_binding_build_retries_with_private_scratch_without_ready_marker(self):
+        self.stub_compilers()
+        poisoned={**self.env,'TMPDIR':str(self.root/'unusable-global-tmp')}
+        failed=self.run_demo('--mise','ruby','--snapshot',env={**poisoned,'UPDATER_FAIL_BUILD':'1'})
+        self.assertNotEqual(failed.returncode,0)
+        self.assertIn('fixture linker failure',failed.stderr)
+        self.assertEqual(list((self.root/'cache/v1/build').rglob('ready')),[])
+        self.assertFalse((self.root/'cache/v1/update.lock').exists())
+        for manager in ['--mise','--system']:
+            for language in ['ruby','php','perl','cpp','rust','go','zig']:
+                result=self.run_demo(manager,language,'--snapshot',env=poisoned)
+                self.assertEqual(result.returncode,0,result.stderr)
+        self.assertTrue((self.root/'cache/v1/tmp').is_dir())
+        self.assertFalse((self.root/'unusable-global-tmp').exists())
+
+    def test_build_scratch_does_not_change_the_runtime_environment(self):
+        for value in [None,str(self.root/'caller-temp')]:
+            env={**self.env}
+            if value is None: env.pop('TMPDIR',None)
+            else: env['TMPDIR']=value
+            result=self.run_demo('--system','python','--snapshot',env=env)
+            self.assertEqual(result.returncode,0,result.stderr)
+            self.assertEqual(json.loads(result.stdout)['tmpdir'],value)
 
     def test_php_upgrade_rebuilds_adapter_and_mismatched_headers_are_rejected(self):
         self.stub_compilers()

--- a/apps/web/public/demo.sh
+++ b/apps/web/public/demo.sh
@@ -100,6 +100,16 @@ main() (
     done
     locked=1
     printf '%s\n' "$$" > "$lock/pid"
+    # Compilers (including GCC's LTO subprocesses), Git and dependency installers
+    # need scratch space too. /tmp may have a separate quota even when the build
+    # filesystem has ample room. Keep build scratch on the demo-cache filesystem.
+    caller_tmpdir_set=${TMPDIR+x}
+    caller_tmpdir=${TMPDIR-}
+    TMPDIR=$cache/tmp
+    [ ! -L "$TMPDIR" ] || fail 'Refusing symlinked build scratch directory.'
+    mkdir -p "$TMPDIR" || fail "Cannot create build scratch: $TMPDIR"
+    [ -w "$TMPDIR" ] || fail "Build scratch is not writable: $TMPDIR"
+    export TMPDIR
     repository=https://github.com/profullstack/hqtui.git
     mirror=$cache/repository.git
     [ ! -L "$mirror" ] || fail 'Refusing a symlinked repository cache.'
@@ -146,6 +156,8 @@ main() (
     launch() {
         cleanup; locked=0
         trap - EXIT INT TERM HUP
+        # This is a build setting, not an override of the application's environment.
+        if [ "$caller_tmpdir_set" = x ]; then TMPDIR=$caller_tmpdir; export TMPDIR; else unset TMPDIR; fi
         if [ "$manager" = mise ]; then
             exec mise --no-config exec "$tool_spec@$version" -- "$@"
         else

--- a/ports/bindings/README.md
+++ b/ports/bindings/README.md
@@ -23,6 +23,8 @@ curl -fsSL https://hqtui.com/demo.sh | sh -s -- --mise perl
 Replace `--mise` with `--system` for installed runtimes/build tools. Every launch
 fetches current main and prints the source revision. First builds compile native
 code; later launches reuse that revision. Host GCC/Clang and Make are required.
+Build scratch also lives under the demo cache, so a separate `/tmp` quota does
+not break linking. Failed builds are retried; they never get a ready marker.
 Mise supplies pinned CMake and runtimes; PHP uses `conda:php` prebuilt packages.
 Vanilla additionally requires CMake, Ruby Fiddle, Perl cpanm (if Platypus is missing),
 and PHP development headers/php-config or enabled FFI. Perl dependencies go in a


### PR DESCRIPTION
Keep Git/compiler/LTO/dependency scratch under the private demo cache instead of system /tmp. Restore the caller TMPDIR before launching the application. No global cleanup, no disabled LTO, no user-checkout changes. Eleven updater tests cover poisoned TMPDIR, all seven compiled demos with both managers, failed-build retries with no ready marker, and runtime environment preservation. Fresh Ruby/PHP/Perl native builds completed on the affected host with TMPDIR explicitly unset; /tmp still has its quota restriction.