### PR TITLE
fix: the CoinPay key is a bearer token, and stop leaking the internal host

### DIFF
--- a/apps/web/app/api/book/checkout/route.ts
+++ b/apps/web/app/api/book/checkout/route.ts
@@ -24,6 +24,9 @@ export async function POST(request: Request): Promise<Response> {
   } catch (error) {
     // Never render the upstream body: it can carry the request we signed.
     console.error("hqtui: cookbook checkout failed", error);
-    return NextResponse.redirect(new URL("/book/buy?error=1", request.url), 303);
+    // A relative Location, not one built from request.url: behind Railway's
+    // proxy that is the container's own address, and the browser would be sent
+    // to https://0.0.0.0:8080.
+    return new Response(null, { status: 303, headers: { location: "/book/buy?error=1" } });
   }
 }

--- a/apps/web/lib/coinpay.ts
+++ b/apps/web/lib/coinpay.ts
@@ -98,7 +98,10 @@ export async function createPayment(chain: string = DEFAULT_CHAIN): Promise<Crea
 
   const response = await fetch(`${apiBase()}/payments/create`, {
     method: "POST",
-    headers: { "content-type": "application/json", "x-api-key": key },
+    // The business API key travels as a bearer token. `x-api-key` is refused
+    // with "Missing authorization header", which reads like the key is absent
+    // rather than in the wrong place.
+    headers: { "content-type": "application/json", authorization: `Bearer ${key}` },
     body: JSON.stringify({
       business_id: business,
       amount: PRICE_USD,


### PR DESCRIPTION
Checkout 401'd in production with `Missing authorization header` while the key was plainly being sent. The payments API takes the business key as `Authorization: Bearer`, not `x-api-key`. Verified against the live API: the bearer form returns a payment, the header form does not.

The failure path also redirected to `https://0.0.0.0:8080/book/buy?error=1`, because it built the URL from `request.url` and behind Railway's proxy that is the container's own address. A relative `Location` has no host to get wrong.

Found by running a real checkout against the deployed site rather than trusting that the wiring was right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbGYCRHZsZUsQwRCLafhMF