### PR TITLE
COBOL is a demo language, and the homepage stops counting by hand

### DIFF
--- a/apps/demo/scripts/test-updater.py
+++ b/apps/demo/scripts/test-updater.py
@@ -283,7 +283,12 @@ output.chmod(0o700)
         that cannot succeed.
         """
         launcher = LAUNCHER.read_text()
-        declared = dict(re.findall(r"^\s+(\w+)\) minimum=([0-9.]+) ;;", launcher, re.M))
+        # A case arm may name several languages that share a floor, e.g.
+        # `typescript|cobol)`, because COBOL's toolchain is the adapter's.
+        declared = {}
+        for names, floor in re.findall(r"^\s+([\w|]+)\) minimum=([0-9.]+) ;;", launcher, re.M):
+            for name in names.split("|"):
+                declared[name] = floor
         manifests = {
             "go": (ROOT / "ports/go/go.mod", r"^go\s+([0-9.]+)"),
             "rust": (ROOT / "ports/rust/Cargo.toml", r'rust-version\s*=\s*"([0-9.]+)"'),
@@ -307,6 +312,9 @@ output.chmod(0o700)
         # Bun's floor is not a preference; it is what can read a v2 lockfile.
         self.assertEqual(declared.get("typescript"), "1.4.0")
         self.assertIn('"lockfileVersion": 2', (ROOT / "bun.lock").read_text())
+        # COBOL renders through the TypeScript adapter, so it needs that same
+        # Bun rather than a floor of its own.
+        self.assertEqual(declared.get("cobol"), declared.get("typescript"))
 
     def test_bindings_update_both_managers_and_keep_builds_outside_source(self):
         self.stub_compilers()

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -15,6 +15,14 @@ import { ThemeGallery, type ThemeCard } from "@/components/site/theme-gallery";
 import { recordView, themeVotes, totalViews } from "@/lib/db";
 import { themes } from "@profullstack/hqtui";
 import { LANGUAGES } from "@/lib/languages";
+
+/**
+ * Written out by hand, these went stale the moment a language was added: the
+ * page still said nine after COBOL made ten. Derive them instead.
+ */
+const COUNT = LANGUAGES.length;
+const SPELLED = ["zero", "one", "two", "three", "four", "five", "six", "seven", "eight",
+  "nine", "ten", "eleven", "twelve"][COUNT] ?? String(COUNT);
 import { CommandBlock } from "@/components/site/command";
 
 export const dynamic = "force-dynamic";
@@ -149,7 +157,7 @@ export default async function Home() {
               High Quality Terminal UI for TypeScript, Rust, Go, Python, Zig and C++
             </p>
             <Badge variant="secondary" className="mb-5 font-mono text-xs">
-              v0.2.0 · 9 language demos · MIT
+              v0.2.0 · {COUNT} language demos · MIT
             </Badge>
             <p className="text-balance text-3xl font-bold tracking-tight sm:text-5xl">
               Terminal dashboards that
@@ -227,11 +235,15 @@ export default async function Home() {
       </section>
 
       <section id="languages" className="mx-auto max-w-7xl scroll-mt-14 px-4 pt-20 sm:px-6">
-        <h2 className="text-3xl font-bold tracking-tight">One terminal UI, nine language demos</h2>
+        <h2 className="text-3xl font-bold tracking-tight">
+          One terminal UI, {SPELLED} language demos
+        </h2>
         <p className="mt-3 max-w-3xl text-white/60">
           Build in TypeScript or use a native Rust, Go, Python or Zig implementation.
           C++ now has a native ten-screen demo over the shared C rendering core, with an experimental library API.
           Ruby, PHP and Perl add experimental bindings to that same engine, with APIs for your own CLI applications.
+          COBOL links against nothing at all: it writes fixed-width records that an adapter renders, which is how a
+          language with no binding can still draw a Braille chart.
           The native demos need no JavaScript runtime.
         </p>
         <div className="mt-6 max-w-2xl">

--- a/apps/web/lib/languages.ts
+++ b/apps/web/lib/languages.ts
@@ -12,13 +12,18 @@ export type Language = {
   miseDemo: string;
   native: boolean;
   binding?: boolean;
+  /**
+   * Drives the library without linking against it: it writes records that an
+   * adapter renders. Neither a port nor a binding.
+   */
+  bridge?: boolean;
 };
 
 /** Optional developer checkout; public demo commands do not require it. */
 export const CLONE = "git clone https://github.com/profullstack/hqtui";
 export const LAUNCHER = "https://hqtui.com/demo.sh";
 export function latestDemo(language: string, mise = false): string {
-  if (!["typescript", "rust", "go", "python", "zig", "cpp", "ruby", "php", "perl"].includes(language)) throw new Error("Unsupported demo language");
+  if (!["typescript", "rust", "go", "python", "zig", "cpp", "ruby", "php", "perl", "cobol"].includes(language)) throw new Error("Unsupported demo language");
   return `curl -fsSL ${LAUNCHER} | sh -s -- --${mise ? "mise" : "system"} ${language}`;
 }
 
@@ -94,6 +99,21 @@ export const LANGUAGES: readonly Language[] = [
     interactiveDemo: latestDemo("zig"),
     miseDemo: latestDemo("zig", true),
     native: true,
+  },
+  {
+    name: "COBOL",
+    id: "cobol",
+    description:
+      "Writes 80-column records that a TypeScript or Rust adapter renders. Needs GnuCOBOL; there is no mise package for it, so this one is --system only.",
+    href: "/widgets",
+    demo: latestDemo("cobol"),
+    snapshotDemo: latestDemo("cobol"),
+    interactiveDemo: latestDemo("cobol"),
+    // No mise package provides a COBOL compiler, so the pinned form is the
+    // same command. Saying otherwise would print advice that cannot work.
+    miseDemo: latestDemo("cobol"),
+    native: false,
+    bridge: true,
   },
 ];
 

--- a/apps/web/public/demo.sh
+++ b/apps/web/public/demo.sh
@@ -9,7 +9,7 @@ main() (
     note() { printf 'hqtui-demo: %s\n' "$*" >&2; }
     usage() {
         printf '%s\n' 'Usage: demo.sh [--mise|--system] [--check] LANGUAGE [demo arguments...]' \
-          'Languages: typescript (ts), rust, go, python, zig, cpp (c++), ruby, php, perl' \
+          'Languages: typescript (ts), rust, go, python, zig, cpp (c++), ruby, php, perl, cobol' \
           'Every invocation fetches latest main. --check prints the revision without building.' \
           'Defaults to mise when installed, otherwise uses your installed compiler/runtime.' \
           'Examples: demo.sh rust --sim; demo.sh --mise rust --snapshot'
@@ -33,12 +33,18 @@ main() (
         rust|go|python|zig|ruby|perl) tool=$language ;;
         php) tool=conda:php ;;
         cpp|c++) language=cpp; tool=cmake ;;
-        *) fail "Unsupported language '$language'. Use typescript, rust, go, python, zig, cpp, ruby, php or perl. The C-only demo is not ready." ;;
+        # COBOL does not link against the library: it writes records that an
+        # adapter renders, so the toolchain it needs is the adapter's.
+        cob|cobol) language=cobol; tool=bun ;;
+        *) fail "Unsupported language '$language'. Use typescript, rust, go, python, zig, cpp, ruby, php, perl or cobol. The C-only demo is not ready." ;;
     esac
     # When invoked through curl | sh, the pipe is not the demo's keyboard.
     # Connect only interactive runs to the controlling terminal; preserve pipes
     # for headless output. Do this before any update/build work.
     headless=$check
+    # The COBOL demo prints its rendered widgets and exits; it never takes over
+    # the terminal, so a pipe is a perfectly good destination for it.
+    [ "$language" != cobol ] || headless=1
     for argument in "$@"; do
         case "$argument" in --snapshot|--help|-h|--version|-V) headless=1 ;; esac
     done
@@ -57,7 +63,7 @@ main() (
         command -v mise >/dev/null 2>&1 || fail 'mise was requested but is not installed. Install mise or omit --mise.'
     fi
     if [ "$manager" = system ] && [ "$check" -eq 0 ]; then
-        case "$language" in rust) driver=cargo ;; typescript) driver=bun ;; python) driver=python3 ;; cpp) driver=cmake ;; *) driver=$language ;; esac
+        case "$language" in rust) driver=cargo ;; typescript|cobol) driver=bun ;; python) driver=python3 ;; cpp) driver=cmake ;; *) driver=$language ;; esac
         driver_path=$(command -v "$driver") || fail "$driver is not installed. Install it, or use --mise."
         # Resolve a mise shim BEFORE entering the fetched checkout. Vanilla must
         # not accidentally load or ask to trust the downloaded mise.toml. Keep the
@@ -160,7 +166,7 @@ main() (
     # apps/demo/scripts/test-updater.py checks this table against those files.
     minimum=
     case "$language" in
-        typescript) minimum=1.4.0 ;;
+        typescript|cobol) minimum=1.4.0 ;;
         rust) minimum=1.75 ;;
         go) minimum=1.22 ;;
         python) minimum=3.10 ;;
@@ -183,7 +189,7 @@ main() (
     }
     if [ "$manager" = system ]; then
         case "$language" in
-            typescript|rust|python|cpp|ruby) installed=$("$driver_path" --version 2>/dev/null) ;;
+            typescript|cobol|rust|python|cpp|ruby) installed=$("$driver_path" --version 2>/dev/null) ;;
             go|zig) installed=$("$driver_path" version 2>/dev/null) ;;
             php) installed=$("$driver_path" -r 'echo PHP_VERSION;' 2>/dev/null) ;;
             perl) installed=$("$driver_path" -e 'printf "%vd", $^V' 2>/dev/null) ;;
@@ -378,6 +384,27 @@ main() (
                 printf '%s\n' "$revision" > "$bins/zig.ready"
             fi
             launch "$bins/zig/bin/hqtui-demo-zig" "$@"
+            ;;
+        cobol)
+            cd "$source"
+            # No mise package provides a COBOL compiler, so this one is the
+            # system's or nothing. Say what to install rather than failing with
+            # "cobc: not found" from three frames down.
+            command -v cobc >/dev/null 2>&1 || case "$(uname -s)" in
+                Darwin) fail 'GnuCOBOL is required. Install it with "brew install gnu-cobol", then run this again.' ;;
+                *) fail 'GnuCOBOL is required. Install it with your package manager (for example "apt install gnucobol4"), then run this again.' ;;
+            esac
+            if [ ! -f "$bins/cobol.ready" ] || [ ! -x "$bins/widgets" ]; then
+                note 'Compiling the COBOL program and building the adapter (first run of this revision)…'
+                run_tool bun install --frozen-lockfile --ignore-scripts
+                run_tool bun run --bun build
+                cobc -x -free "$source/ports/cobol/examples/widgets.cbl" -o "$bins/widgets" >&2
+                printf '%s\n' "$revision" > "$bins/cobol.ready"
+            fi
+            # COBOL writes records; the adapter draws them. That pipe is the
+            # whole design, so the demo runs it rather than hiding it.
+            "$bins/widgets" > "$cache/tmp/cobol-records.txt"
+            launch bun ports/cobol/adapter/render.ts < "$cache/tmp/cobol-records.txt"
             ;;
         typescript)
             cd "$source"

--- a/apps/web/test/languages.test.ts
+++ b/apps/web/test/languages.test.ts
@@ -7,13 +7,25 @@ import { LANGUAGES, PORTS, LAUNCHER, latestDemo } from "../lib/languages.ts";
 const root = resolve(import.meta.dirname, "../../..");
 
 test("every supported language has latest-source vanilla and mise demo commands", () => {
-  assert.deepEqual(LANGUAGES.map(({ id }) => id), ["ruby", "php", "perl", "cpp", "typescript", "rust", "go", "python", "zig"]);
+  assert.deepEqual(LANGUAGES.map(({ id }) => id),
+    ["ruby", "php", "perl", "cpp", "typescript", "rust", "go", "python", "zig", "cobol"]);
   for (const language of LANGUAGES) {
     assert.ok(language.interactiveDemo.length > 0, language.id);
     assert.ok(language.interactiveDemo.startsWith(`curl -fsSL ${LAUNCHER} | sh -s -- --system ${language.id}`));
-    assert.ok(language.miseDemo.startsWith(`curl -fsSL ${LAUNCHER} | sh -s -- --mise ${language.id}`));
     assert.ok(!language.interactiveDemo.includes("screenshot"));
+    if (language.bridge) {
+      // No mise package provides a COBOL compiler, so there is no pinned form
+      // to offer. Printing a --mise command would be advice that cannot work.
+      assert.equal(language.miseDemo, language.interactiveDemo, language.id);
+      continue;
+    }
+    assert.ok(language.miseDemo.startsWith(`curl -fsSL ${LAUNCHER} | sh -s -- --mise ${language.id}`));
   }
+});
+
+test("the bridge is the only language without a pinned toolchain", () => {
+  const bridges = LANGUAGES.filter((language) => language.bridge).map(({ id }) => id);
+  assert.deepEqual(bridges, ["cobol"]);
 });
 
 test("native updater commands retain full-dashboard source entrypoints", () => {


### PR DESCRIPTION
The widget gallery lists eleven languages. The homepage listed nine and never mentioned COBOL — spotted on `/#languages`.

## COBOL is a real demo command now

`curl -fsSL https://hqtui.com/demo.sh | sh -s -- cobol` compiles the COBOL program, builds the adapter and pipes one into the other. Verified end to end in a container with GnuCOBOL and Bun, rendering all 20 widgets.

Two things it needs that the other languages do not:

- **`--system` only.** No mise package provides a COBOL compiler, so there is no pinned form to offer. Rather than print a `--mise` command that cannot work, the entry carries a `bridge` flag and a test asserts it is the only language without a pinned toolchain. When `cobc` is missing, the launcher names the install command for the platform (`brew install gnu-cobol`, `apt install gnucobol4`) rather than failing three frames down with "cobc: not found".
- **Headless by default.** The COBOL demo prints its widgets and exits; it never takes over the terminal, so it no longer refuses to run when stdout is a pipe.

## The counts were stale

"9 language demos" in the badge and "nine language demos" in the heading were written out by hand, and were already wrong before this change. Both derive from the list now.

## Verified

- COBOL demo end to end through the launcher, 20/20 widgets
- 15/15 launcher tests, including the floors guard — which caught its own regex not understanding the new `typescript|cobol` case arm
- 16 web tests, `typecheck`, `next build`
- `sh -n`, `dash -n`, shellcheck clean apart from the pre-existing SC2016

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbGYCRHZsZUsQwRCLafhMF
