### PR TITLE
fix(demo): make [c] actually collapse borders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,12 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - run: bun install --frozen-lockfile
+      # Same reason the `test` job typechecks first: apps/demo imports
+      # `@profullstack/hqtui` by name, and the package resolves to dist. Without
+      # this, any demo test that touches a screen fails to load — and a test
+      # that cannot load is not a test that passed.
+      - name: Build
+        run: bun run build
       - name: Test under Node
         run: node --test packages/hqtui/test/*.test.ts apps/demo/test/*.test.ts apps/web/test/*.test.ts
 

--- a/apps/demo/src/main.ts
+++ b/apps/demo/src/main.ts
@@ -212,8 +212,12 @@ async function main(): Promise<void> {
       case "f3": state.filtering = true; return;
       case "c":
         // Shows what collapseBorders does, live. Worth a key because the
-        // difference is only visible when panels sit next to each other.
-        app.setCollapseBorders(!app.collapseBorders);
+        // difference is only visible when panels sit next to each other —
+        // which is also why the screens have to close their one-column gaps
+        // at the same time. The library only merges a seam where two bordered
+        // siblings already touch, so toggling the flag alone moved nothing.
+        state.collapsed = !state.collapsed;
+        app.setCollapseBorders(state.collapsed);
         return;
       case "f6": {
         const order = ["cpu", "mem", "pid", "name"] as const;

--- a/apps/demo/src/screens/components.ts
+++ b/apps/demo/src/screens/components.ts
@@ -1,5 +1,5 @@
 import type { Container, Theme } from "@profullstack/hqtui";
-import { focusPane, pane, scrollPane, type DemoState } from "../state.ts";
+import { focusPane, pane, panelGap, scrollPane, type DemoState } from "../state.ts";
 import { bytes, percent } from "../format.ts";
 
 const FILES = [
@@ -39,8 +39,9 @@ const TREE = [
 
 /** Every widget in the library, in one screen. Also the interaction sandbox. */
 export function componentsScreen(ui: Container, state: DemoState, theme: Theme): void {
+  const gap = panelGap(state);
   ui.row({ size: "1fr", gap: 1 }, (row) => {
-    row.column({ gap: 1 }, (left) => {
+    row.column({ gap }, (left) => {
       left.panel({ title: "Buttons & Inputs", size: 13 }, (p) => {
         p.row({ size: 1, gap: 1 }, (r) => {
           r.button({ label: "Primary", width: 11, size: 11, onPress: () => { state.showModal = true; } });
@@ -115,7 +116,7 @@ export function componentsScreen(ui: Container, state: DemoState, theme: Theme):
       });
     });
 
-    row.column({ gap: 1 }, (right) => {
+    row.column({ gap }, (right) => {
       right.panel({ title: "Process Tree", size: 13 }, (p) => {
         p.row({ size: 1 }, (r) => {
           r.text("Name", { fg: theme.muted, bold: true });

--- a/apps/demo/src/screens/dashboard.ts
+++ b/apps/demo/src/screens/dashboard.ts
@@ -1,13 +1,13 @@
-import type { Container, Theme } from "@profullstack/hqtui";
+import type { Container, Size, Theme } from "@profullstack/hqtui";
 import { heatColor } from "@profullstack/hqtui";
-import { focusPane, pane, scrollPane, type DemoState } from "../state.ts";
+import { focusPane, pane, panelGap, scrollPane, type DemoState } from "../state.ts";
 import { bitRate, byteRate, bytes, clock, duration, num, percent } from "../format.ts";
 
 const TIME_LABELS = ["60s", "45s", "30s", "15s", "0s"];
 
-function cpuPanel(ui: Container, state: DemoState, theme: Theme, coreColumns: number): void {
+function cpuPanel(ui: Container, state: DemoState, theme: Theme, coreColumns: number, width?: Size): void {
   const cpu = state.sample.cpu;
-  ui.panel({ title: "CPU Overview", subtitle: percent(cpu.total) }, (p) => {
+  ui.panel({ title: "CPU Overview", subtitle: percent(cpu.total), width }, (p) => {
     p.label(`${cpu.model}   ${num(cpu.frequencyGhz, 1)} GHz`, { size: 1 });
     p.graph({ values: cpu.history, min: 0, max: 100, fill: true, color: theme.success, size: "1fr" });
     p.meters(
@@ -26,11 +26,11 @@ function cpuPanel(ui: Container, state: DemoState, theme: Theme, coreColumns: nu
   });
 }
 
-function memoryPanel(ui: Container, state: DemoState, theme: Theme): void {
+function memoryPanel(ui: Container, state: DemoState, theme: Theme, width?: Size): void {
   const memory = state.sample.memory;
   const used = memory.used / Math.max(1, memory.total);
   const swap = memory.swapTotal > 0 ? memory.swapUsed / memory.swapTotal : 0;
-  ui.panel({ title: "Memory & Swap" }, (p) => {
+  ui.panel({ title: "Memory & Swap", width }, (p) => {
     p.text(`Memory${" ".repeat(6)}${bytes(memory.used)} / ${bytes(memory.total)} (${percent(used)})`, {
       fg: theme.foreground,
       size: 1,
@@ -58,9 +58,9 @@ function memoryPanel(ui: Container, state: DemoState, theme: Theme): void {
   });
 }
 
-function disksPanel(ui: Container, state: DemoState, theme: Theme): void {
+function disksPanel(ui: Container, state: DemoState, theme: Theme, width?: Size): void {
   const disks = state.sample.disks;
-  ui.panel({ title: "Disks" }, (p) => {
+  ui.panel({ title: "Disks", width }, (p) => {
     if (disks.length === 0) {
       p.label("No disks reported");
       return;
@@ -87,9 +87,9 @@ function disksPanel(ui: Container, state: DemoState, theme: Theme): void {
   });
 }
 
-function systemPanel(ui: Container, state: DemoState, theme: Theme): void {
+function systemPanel(ui: Container, state: DemoState, theme: Theme, width?: Size): void {
   const s = state.sample;
-  ui.panel({ title: "System" }, (p) => {
+  ui.panel({ title: "System", width }, (p) => {
     p.row({ size: 6, gap: 2, min: 6 }, (r) => {
       r.keyValues([
         { label: "OS:", value: s.system.os },
@@ -147,12 +147,13 @@ function systemPanel(ui: Container, state: DemoState, theme: Theme): void {
   });
 }
 
-function processesPanel(ui: Container, state: DemoState, theme: Theme): void {
+function processesPanel(ui: Container, state: DemoState, theme: Theme, width?: Size): void {
   const rows = visibleProcesses(state);
   ui.panel({
     title: `Processes (sorted by ${state.sort.toUpperCase()})`,
     subtitle: state.filter ? `filter: ${state.filter}` : undefined,
     focusable: true,
+    width,
   }, (p) => {
     const procs = pane(state, "dashboard.processes", rows.length);
     p.table({
@@ -179,9 +180,9 @@ function processesPanel(ui: Container, state: DemoState, theme: Theme): void {
   });
 }
 
-function networkPanel(ui: Container, state: DemoState, theme: Theme): void {
+function networkPanel(ui: Container, state: DemoState, theme: Theme, width?: Size): void {
   const net = state.sample.network;
-  ui.panel({ title: "Network" }, (p) => {
+  ui.panel({ title: "Network", width }, (p) => {
     p.row({ size: 1 }, (r) => {
       r.text(`Download: ${bitRate(net.downRate)}`, { fg: theme.primary });
       r.text(`Upload: ${bitRate(net.upRate)}`, { fg: theme.secondary, align: "right" });
@@ -204,9 +205,9 @@ function networkPanel(ui: Container, state: DemoState, theme: Theme): void {
   });
 }
 
-function diskUsagePanel(ui: Container, state: DemoState, theme: Theme): void {
+function diskUsagePanel(ui: Container, state: DemoState, theme: Theme, width?: Size): void {
   const disks = state.sample.disks;
-  ui.panel({ title: "Disk Usage", subtitle: disks[0]?.device }, (p) => {
+  ui.panel({ title: "Disk Usage", subtitle: disks[0]?.device, width }, (p) => {
     disks.forEach((disk) => {
       const used = disk.total > 0 ? disk.used / disk.total : 0;
       p.meter({
@@ -268,8 +269,8 @@ function sensorsPanel(ui: Container, state: DemoState, theme: Theme): void {
   });
 }
 
-function logsPanel(ui: Container, state: DemoState): void {
-  ui.panel({ title: "Logs" }, (p) => {
+function logsPanel(ui: Container, state: DemoState, width?: Size): void {
+  ui.panel({ title: "Logs", width }, (p) => {
     const logs = pane(state, "dashboard.logs", state.sample.logs.length, "log");
     p.log({
       entries: state.sample.logs.map((l) => ({
@@ -304,51 +305,59 @@ export function visibleProcesses(state: DemoState): DemoState["sample"]["process
   return sorted;
 }
 
-/** The reference dashboard. Three layouts, chosen by terminal width. */
+/**
+ * The reference dashboard. Three layouts, chosen by terminal width.
+ *
+ * Panels go straight into their row rather than each inside a sizing column.
+ * A column is not a bordered child, so a row of them has no seam to merge and
+ * [c] could never change this screen; `width` on the panel does the same job
+ * and leaves the borders adjacent to each other.
+ */
 export function dashboardScreen(ui: Container, state: DemoState, theme: Theme): void {
+  const gap = panelGap(state);
   ui.responsive({
     150: (wide) => {
       // The System column holds nested panels, so it gets the extra width —
       // and extra height whenever the terminal is tall enough to spare it.
-      wide.row({ size: wide.height >= 44 ? 19 : 16, gap: 1 }, (r) => {
-        r.column({ width: "1fr" }, (c) => cpuPanel(c, state, theme, 2));
-        r.column({ width: "0.95fr" }, (c) => memoryPanel(c, state, theme));
-        r.column({ width: "0.95fr" }, (c) => disksPanel(c, state, theme));
-        r.column({ width: "1.35fr" }, (c) => systemPanel(c, state, theme));
+      wide.row({ size: wide.height >= 44 ? 19 : 16, gap }, (r) => {
+        cpuPanel(r, state, theme, 2, "1fr");
+        memoryPanel(r, state, theme, "0.95fr");
+        disksPanel(r, state, theme, "0.95fr");
+        systemPanel(r, state, theme, "1.35fr");
       });
-      wide.row({ size: "1fr", gap: 1 }, (r) => {
-        r.column({ width: "2fr" }, (c) => processesPanel(c, state, theme));
-        r.column({ width: "1.2fr" }, (c) => networkPanel(c, state, theme));
-        r.column({ width: "1.2fr" }, (c) => diskUsagePanel(c, state, theme));
+      wide.row({ size: "1fr", gap }, (r) => {
+        processesPanel(r, state, theme, "2fr");
+        networkPanel(r, state, theme, "1.2fr");
+        diskUsagePanel(r, state, theme, "1.2fr");
       });
-      wide.row({ size: 12, gap: 1 }, (r) => {
+      wide.row({ size: 12, gap }, (r) => {
         temperaturesPanel(r, state, theme);
         sensorsPanel(r, state, theme);
-        r.column({ width: "1.6fr" }, (c) => logsPanel(c, state));
+        logsPanel(r, state, "1.6fr");
       });
     },
     100: (medium) => {
-      medium.row({ size: 14, gap: 1 }, (r) => {
+      medium.row({ size: 14, gap }, (r) => {
         cpuPanel(r, state, theme, 2);
         memoryPanel(r, state, theme);
         systemPanel(r, state, theme);
       });
-      medium.row({ size: "1fr", gap: 1 }, (r) => {
-        r.column({ width: "1.6fr" }, (c) => processesPanel(c, state, theme));
-        r.column({}, (c) => networkPanel(c, state, theme));
+      medium.row({ size: "1fr", gap }, (r) => {
+        processesPanel(r, state, theme, "1.6fr");
+        networkPanel(r, state, theme);
       });
-      medium.row({ size: 10, gap: 1 }, (r) => {
+      medium.row({ size: 10, gap }, (r) => {
         temperaturesPanel(r, state, theme);
         logsPanel(r, state);
       });
     },
     0: (compact) => {
-      compact.row({ size: 10, gap: 1 }, (r) => {
+      compact.row({ size: 10, gap }, (r) => {
         cpuPanel(r, state, theme, 1);
         memoryPanel(r, state, theme);
       });
       compact.column({ size: "1fr" }, (c) => processesPanel(c, state, theme));
-      compact.row({ size: 8, gap: 1 }, (r) => networkPanel(r, state, theme));
+      compact.row({ size: 8, gap }, (r) => networkPanel(r, state, theme));
     },
   });
 }

--- a/apps/demo/src/screens/graphics.ts
+++ b/apps/demo/src/screens/graphics.ts
@@ -1,6 +1,6 @@
 import type { Container, Theme } from "@profullstack/hqtui";
 import { gradientSteps } from "@profullstack/hqtui";
-import type { DemoState } from "../state.ts";
+import { panelGap, type DemoState } from "../state.ts";
 
 function wave(count: number, phase: number, freq: number): number[] {
   return Array.from({ length: count }, (_, i) => Math.sin(i / freq + phase) * 50 + 50);
@@ -8,13 +8,14 @@ function wave(count: number, phase: number, freq: number): number[] {
 
 /** Rendering-mode comparison: braille vs block vs ascii, plus raw canvas access. */
 export function graphicsScreen(ui: Container, state: DemoState, theme: Theme): void {
+  const gap = panelGap(state);
   const t = state.sample.time;
   const a = wave(240, t / 3, 9);
   const b = wave(240, t / 3 + 2, 5);
   const c = wave(240, t / 2, 17);
 
   ui.row({ size: "1fr", gap: 1 }, (row) => {
-    row.column({ gap: 1 }, (left) => {
+    row.column({ gap }, (left) => {
       left.panel({ title: "Braille (2×4 pixels per cell)" }, (p) => {
         p.graph({ values: a, min: 0, max: 100, fill: true, color: theme.accent, grid: true });
       });
@@ -26,7 +27,7 @@ export function graphicsScreen(ui: Container, state: DemoState, theme: Theme): v
       });
     });
 
-    row.column({ gap: 1 }, (right) => {
+    row.column({ gap }, (right) => {
       right.panel({ title: "Multi-series" }, (p) => {
         p.multiGraph(
           [

--- a/apps/demo/src/screens/input.ts
+++ b/apps/demo/src/screens/input.ts
@@ -1,9 +1,10 @@
 import type { Container, Theme } from "@profullstack/hqtui";
-import type { DemoState } from "../state.ts";
+import { panelGap, type DemoState } from "../state.ts";
 
 /** Keyboard and mouse event visualizer — useful when debugging bindings. */
 export function inputScreen(ui: Container, state: DemoState, theme: Theme): void {
-  ui.row({ size: "1fr", gap: 1 }, (row) => {
+  const gap = panelGap(state);
+  ui.row({ size: "1fr", gap }, (row) => {
     row.panel({ title: "Last Events" }, (p) => {
       p.keyValues([
         { label: "Key", value: state.lastKey, color: theme.accent },

--- a/apps/demo/src/screens/network.ts
+++ b/apps/demo/src/screens/network.ts
@@ -1,14 +1,15 @@
 import type { Container, Theme } from "@profullstack/hqtui";
-import { focusPane, pane, scrollPane, type DemoState } from "../state.ts";
+import { focusPane, pane, panelGap, scrollPane, type DemoState } from "../state.ts";
 import { byteRate, bytes } from "../format.ts";
 
 /** Interfaces, live throughput, open connections and listening ports. */
 export function networkScreen(ui: Container, state: DemoState, theme: Theme): void {
+  const gap = panelGap(state);
   const t = state.sample.telemetry;
   const active = t.interfaces.filter((i) => i.rxTotal > 0 || i.state === "up");
   const shown = (active.length ? active : t.interfaces).slice(0, 3);
 
-  ui.row({ size: 13, gap: 1 }, (row) => {
+  ui.row({ size: 13, gap }, (row) => {
     if (shown.length === 0) {
       row.panel({ title: "Interfaces" }, (p) => p.label("No interfaces reported."));
       return;
@@ -74,7 +75,7 @@ export function networkScreen(ui: Container, state: DemoState, theme: Theme): vo
       });
     });
 
-    row.column({ width: "0.7fr", gap: 1 }, (column) => {
+    row.column({ width: "0.7fr", gap }, (column) => {
       column.panel({ title: "Listening Ports", subtitle: String(t.listeners.length), borderColor: theme.warning }, (p) => {
         const listeners = pane(state, "network.listeners", t.listeners.length);
         p.table({

--- a/apps/demo/src/screens/services.ts
+++ b/apps/demo/src/screens/services.ts
@@ -1,5 +1,5 @@
 import type { Container, Theme } from "@profullstack/hqtui";
-import { focusPane, pane, scrollPane, type DemoState } from "../state.ts";
+import { focusPane, pane, panelGap, scrollPane, type DemoState } from "../state.ts";
 import { bytes, num, percent } from "../format.ts";
 
 function rate(value: number): string {
@@ -9,6 +9,7 @@ function rate(value: number): string {
 
 /** Services, containers, kernel counters, filesystems and hardware sensors. */
 export function servicesScreen(ui: Container, state: DemoState, theme: Theme): void {
+  const gap = panelGap(state);
   const t = state.sample.telemetry;
   const failed = t.services.filter((s) => s.active === "failed");
 
@@ -49,7 +50,7 @@ export function servicesScreen(ui: Container, state: DemoState, theme: Theme): v
       });
     });
 
-    row.column({ width: "0.85fr", gap: 1 }, (column) => {
+    row.column({ width: "0.85fr", gap }, (column) => {
       column.panel({ title: "Kernel", size: 11, borderColor: theme.accent }, (p) => {
         const k = t.kernel;
         p.keyValues([

--- a/apps/demo/src/screens/sessions.ts
+++ b/apps/demo/src/screens/sessions.ts
@@ -1,11 +1,12 @@
 import type { Container, Theme } from "@profullstack/hqtui";
-import { focusPane, pane, scrollPane, type DemoState } from "../state.ts";
+import { focusPane, pane, panelGap, scrollPane, type DemoState } from "../state.ts";
 
 /** Who is on this machine, who has been, and who failed to get in. */
 export function sessionsScreen(ui: Container, state: DemoState, theme: Theme): void {
+  const gap = panelGap(state);
   const t = state.sample.telemetry;
 
-  ui.row({ size: 9, gap: 1 }, (row) => {
+  ui.row({ size: 9, gap }, (row) => {
     row.panel({ title: "Active Sessions", subtitle: String(t.sessions.length), borderColor: theme.success }, (p) => {
       if (t.sessions.length === 0) {
         p.label("No interactive sessions.");
@@ -74,7 +75,7 @@ export function sessionsScreen(ui: Container, state: DemoState, theme: Theme): v
       });
     });
 
-    row.column({ width: "0.8fr", gap: 1 }, (column) => {
+    row.column({ width: "0.8fr", gap }, (column) => {
       column.panel({ title: "Failed Logins", borderColor: theme.danger }, (p) => {
         if (t.failedLogins.length === 0) {
           p.label("None recorded.");

--- a/apps/demo/src/screens/stress.ts
+++ b/apps/demo/src/screens/stress.ts
@@ -1,12 +1,13 @@
 import type { Container, Theme } from "@profullstack/hqtui";
 import { gradient } from "@profullstack/hqtui";
-import type { DemoState } from "../state.ts";
+import { panelGap, type DemoState } from "../state.ts";
 import { num } from "../format.ts";
 
 /** Every cell changes every frame — the worst case for a differential renderer. */
 export function stressScreen(ui: Container, state: DemoState, theme: Theme): void {
+  const gap = panelGap(state);
   const t = state.sample.time;
-  ui.row({ size: 3, gap: 1 }, (r) => {
+  ui.row({ size: 3, gap }, (r) => {
     r.panel({ title: "Render" }, (p) => {
       p.text(`${num(state.renderMs, 2)} ms/frame`, { fg: theme.success });
     });

--- a/apps/demo/src/screens/traffic.ts
+++ b/apps/demo/src/screens/traffic.ts
@@ -1,6 +1,6 @@
 import type { Container, Theme } from "@profullstack/hqtui";
 import { seriesColor } from "@profullstack/hqtui";
-import { focusPane, pane, scrollPane, type DemoState } from "../state.ts";
+import { focusPane, pane, panelGap, scrollPane, type DemoState } from "../state.ts";
 import { num, percent } from "../format.ts";
 
 function rate(value: number): string {
@@ -19,11 +19,12 @@ const STATUS_COLORS = (theme: Theme): Record<string, number> => ({
 
 /** Every protocol in and out of this host: sockets, TCP counters, SSH, HTTP. */
 export function trafficScreen(ui: Container, state: DemoState, theme: Theme): void {
+  const gap = panelGap(state);
   const t = state.sample.telemetry;
   const net = t.net;
   const http = t.http;
 
-  ui.row({ size: 13, gap: 1 }, (row) => {
+  ui.row({ size: 13, gap }, (row) => {
     row.panel({
       title: "Protocols",
       subtitle: `${t.inboundConnections} in / ${t.outboundConnections} out`,
@@ -86,7 +87,7 @@ export function trafficScreen(ui: Container, state: DemoState, theme: Theme): vo
   });
 
   ui.row({ size: "1fr", gap: 1 }, (row) => {
-    row.column({ gap: 1 }, (column) => {
+    row.column({ gap }, (column) => {
       column.panel({
         title: "HTTP",
         subtitle: http ? `${num(http.requestsPerSecond, 1)} req/s` : "no access log",
@@ -135,7 +136,7 @@ export function trafficScreen(ui: Container, state: DemoState, theme: Theme): vo
       });
     });
 
-    row.column({ width: "0.85fr", gap: 1 }, (column) => {
+    row.column({ width: "0.85fr", gap }, (column) => {
       column.panel({ title: "SSH Activity", subtitle: String(t.ssh.length), borderColor: theme.warning }, (p) => {
         if (t.ssh.length === 0) {
           p.label("No sshd events in the journal.");

--- a/apps/demo/src/state.ts
+++ b/apps/demo/src/state.ts
@@ -26,6 +26,13 @@ export interface DemoState {
   /** Which pane the arrow keys drive, per screen. Clicking a pane sets it. */
   focused: Partial<Record<ScreenName, string>>;
   sort: "cpu" | "mem" | "pid" | "name";
+  /**
+   * Whether the [c] key has merged adjacent panel borders. Collapsing only
+   * happens where two bordered siblings actually touch, so the screens read
+   * this to lay out at a gap of zero; leaving them at one meant the key
+   * toggled a flag that could never reach a seam and nothing moved.
+   */
+  collapsed: boolean;
   filter: string;
   filtering: boolean;
   showHelp: boolean;
@@ -49,6 +56,11 @@ export interface DemoState {
   renderMs: number;
   changedCells: number;
   bytes: number;
+}
+
+/** The seam between panels: zero while collapsed, so their borders can merge. */
+export function panelGap(state: DemoState): number {
+  return state.collapsed ? 0 : 1;
 }
 
 export interface Pane {
@@ -129,6 +141,7 @@ export function createState(
     panes: {},
     focused: {},
     sort: "cpu",
+    collapsed: false,
     filter: "",
     filtering: false,
     showHelp: false,

--- a/apps/demo/test/collapse-key.test.ts
+++ b/apps/demo/test/collapse-key.test.ts
@@ -2,6 +2,10 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { renderToText } from "@profullstack/hqtui/testing";
+import { createCollector } from "../src/system/index.ts";
+import { createState, type DemoState } from "../src/state.ts";
+import * as screens from "../src/screens/index.ts";
 
 /**
  * The `c` key is the only way most people will ever see what collapsed borders
@@ -12,7 +16,7 @@ const main = readFileSync(join(import.meta.dirname, "..", "src", "main.ts"), "ut
 
 test("c is bound and toggles the app's collapse setting", () => {
   assert.match(main, /case "c":/);
-  assert.match(main, /setCollapseBorders\(!app\.collapseBorders\)/);
+  assert.match(main, /app\.setCollapseBorders\(state\.collapsed\)/);
 });
 
 test("the status bar shows collapse and reflects whether it is on", () => {
@@ -21,4 +25,60 @@ test("the status bar shows collapse and reflects whether it is on", () => {
 
 test("the help screen mentions it", () => {
   assert.match(main, /c collapses adjacent panel borders/);
+});
+
+/**
+ * The three tests above only read the source, which is how the key spent its
+ * whole life bound to a flag that changed nothing: the library merges a seam
+ * only where two bordered siblings already touch, and every screen laid its
+ * panels out a column apart. These render both ways and compare the pixels.
+ */
+const collector = await createCollector({ real: false, seed: 20260830 });
+for (let i = 0; i < 30; i++) await collector.refresh(0.1);
+
+function frame(
+  screen: (ui: never, state: DemoState, theme: never) => void,
+  state: DemoState,
+  width: number,
+): string {
+  return renderToText(
+    ({ ui, theme, height }) => {
+      ui.column({ size: height }, (body) => screen(body as never, state, theme as never));
+    },
+    { width, height: 46, collapseBorders: state.collapsed },
+  );
+}
+
+const SCREENS = {
+  dashboard: screens.dashboardScreen,
+  traffic: screens.trafficScreen,
+  sessions: screens.sessionsScreen,
+  network: screens.networkScreen,
+  services: screens.servicesScreen,
+  components: screens.componentsScreen,
+  graphics: screens.graphicsScreen,
+  input: screens.inputScreen,
+  stress: screens.stressScreen,
+} as const;
+
+// 180 and 90 straddle the dashboard's responsive breakpoints, so both its wide
+// and its compact layout are covered.
+for (const [name, screen] of Object.entries(SCREENS)) {
+  for (const width of [180, 120, 90]) {
+    test(`${name} at ${width} columns looks different once collapsed`, () => {
+      const state = createState(collector.current(), collector.source, collector.unavailable);
+      const open = frame(screen as never, state, width);
+      state.collapsed = true;
+      const merged = frame(screen as never, state, width);
+      assert.notEqual(merged, open, "pressing c changed nothing on this screen");
+      // A merged seam is a junction glyph, not just panels shifted over.
+      assert.match(merged, /[┬┴├┤┼]/);
+    });
+  }
+}
+
+test("collapsing is off until the key is pressed", () => {
+  const state = createState(collector.current(), collector.source, collector.unavailable);
+  assert.equal(state.collapsed, false);
+  assert.doesNotMatch(frame(screens.dashboardScreen as never, state, 180), /[┬┴┼]/);
 });

--- a/apps/demo/test/collapse-key.test.ts
+++ b/apps/demo/test/collapse-key.test.ts
@@ -2,6 +2,9 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+// By package name, the way the demo itself resolves the library, so the
+// screens and the renderer are one module instance rather than two. That
+// means dist has to exist: CI's Node job builds before it tests.
 import { renderToText } from "@profullstack/hqtui/testing";
 import { createCollector } from "../src/system/index.ts";
 import { createState, type DemoState } from "../src/state.ts";


### PR DESCRIPTION
## The bug

Pressing `c` in the demo toggles `app.collapseBorders` and the status-bar
indicator lights up, but the screen does not change. Reproduced with
`curl -fsSL https://hqtui.com/demo.sh | sh -s -- --mise typescript --sim`.

Rendering each screen with `collapseBorders` off and on and diffing the text
gave **IDENTICAL on all 9 screens at 3 widths** — 27 of 27 pairs.

## Why

Two independent blockers.

1. `Container.seams()` (`packages/hqtui/src/ui.ts:161`) returns the gap
   unchanged unless it is already `0` — the library merges a seam only where
   two bordered siblings actually touch. Every demo screen laid its panels out
   with `gap: 1`, so the flag could never reach a seam.
2. The wide dashboard wrapped each panel in a sizing column
   (`r.column({ width: "1fr" }, c => cpuPanel(c, ...))`). Only `panel()` passes
   `bordered = true` to `add()`, so that row's children were all unbordered and
   had no eligible seam even at gap 0.

## The fix

- `DemoState.collapsed` plus `panelGap(state)` — `0` while collapsed, `1`
  otherwise. The `c` handler sets both it and `app.setCollapseBorders`.
- Every container whose direct children are panels takes its gap from
  `panelGap`. Rows of *columns* stay at gap 1 deliberately: they have no
  bordered seam, so closing them would just butt two borders together and read
  as a bug rather than a collapse.
- The wide dashboard passes `width` to the panels instead of wrapping them.

All 27 screen/width pairs now differ, with junction glyphs at the seams.

## Rendering at gap 1 is unchanged

Both fixture generators reproduce byte for byte:

- `bun ports/conformance/generate.ts` — no drift
- `bun apps/demo/scripts/native-parity.ts` — 120 cases, no drift

So the six native ports stay in parity and need no change for this.

## Test

`apps/demo/test/collapse-key.test.ts` only grepped `main.ts` for the binding,
which is exactly how the key stayed inert while looking tested. It now renders
each screen both ways at 180/120/90 columns and asserts the frames differ and
carry junction glyphs. Reverting `panelGap` to a constant `1` fails 27 of its
31 cases.

208 tests pass under both `bun test` and `bun run test:node`; `bun run typecheck` is clean.

## Left alone

Two library limitations, each needing the same change across all six ports:

- `GridContainer` has no seam logic, so the **themes** screen still cannot
  merge. I tried converting it to rows of panels and reverted — see below.
- `surface.box()` fills the panel background over the shared column *before*
  `mergeBorder` reads it, so a panel with a `background` (only the themes
  screen) collapses into doubled `╭╭` corners instead of `┬` junctions.

The **native ports' demos have the same inert `c` key** — same `gap(1)` layouts
in `ports/{rust,go,python,zig,cpp}`. Not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Df2FNu5DhinMV2soRz3cy