### PR TITLE
Styled text spans: more than one colour per line

### DIFF
--- a/packages/hqtui/src/index.ts
+++ b/packages/hqtui/src/index.ts
@@ -52,6 +52,11 @@ export { InputParser, matchKey, type InputEvent, type KeyEvent, type MouseEvent,
 
 // Text
 export { stringWidth, truncate, fit, wrap, graphemes, charWidth } from "./unicode.ts";
+export {
+  isRich, spanStyle, spanText, spanWidth, toSpanLines,
+  truncateSpans, fitSpans, wrapSpans, wrapRich,
+  type Span, type SpanLine, type RichText,
+} from "./richtext.ts";
 
 // Graphics
 export { BrailleCanvas } from "./graphics/braille.ts";

--- a/packages/hqtui/src/richtext.ts
+++ b/packages/hqtui/src/richtext.ts
@@ -1,0 +1,273 @@
+/**
+ * Styled text: more than one colour on a line.
+ *
+ * A `Span` is a run of text with its own style; a line is a list of spans; text
+ * is a list of lines. Every widget that took a `string` takes `RichText` too,
+ * and a bare string is simply the one-span case, so nothing that worked before
+ * has to change.
+ *
+ * The measuring and cutting here mirrors `unicode.ts` exactly rather than
+ * approximating it. `truncateSpans`, `fitSpans` and `wrapSpans` produce the
+ * same columns as `truncate`, `fit` and `wrap` for single-span input — there
+ * are tests that assert precisely that over a corpus, because two text layout
+ * engines that disagree by one column is a bug you find in a screenshot six
+ * months later.
+ */
+import { Attr, type Style } from "./buffer.ts";
+import type { Color } from "./color.ts";
+import { cellText, graphemes, stringWidth } from "./unicode.ts";
+
+export interface Span {
+  text: string;
+  fg?: Color;
+  bg?: Color;
+  attrs?: number;
+  bold?: boolean;
+  dim?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+}
+
+/** One line of styled text. */
+export type SpanLine = Span[];
+
+/**
+ * Anything a widget will accept where it used to take a string.
+ *
+ * A plain string is one unstyled span. `Span[]` is one line. `Span[][]` is
+ * several. Embedded newlines split into lines wherever they appear, so a span
+ * carrying "a\nb" behaves like the string "a\nb" always did.
+ */
+export type RichText = string | SpanLine | SpanLine[];
+
+/** True when the value carries styling rather than being a bare string. */
+export function isRich(value: RichText): value is SpanLine | SpanLine[] {
+  return typeof value !== "string";
+}
+
+function isLines(value: SpanLine | SpanLine[]): value is SpanLine[] {
+  return value.length === 0 || Array.isArray(value[0]);
+}
+
+/** The style a span paints with, over whatever the widget already decided. */
+export function spanStyle(span: Span, base: Style = {}): Style {
+  let attrs = span.attrs ?? base.attrs ?? 0;
+  if (span.bold) attrs |= Attr.Bold;
+  if (span.dim) attrs |= Attr.Dim;
+  if (span.italic) attrs |= Attr.Italic;
+  if (span.underline) attrs |= Attr.Underline;
+  return {
+    fg: span.fg ?? base.fg,
+    bg: span.bg ?? base.bg,
+    attrs,
+  };
+}
+
+/** Everything except the text, for cloning a span's styling onto new text. */
+function styleOf(span: Span): Omit<Span, "text"> {
+  const { text: _text, ...rest } = span;
+  return rest;
+}
+
+/**
+ * Normalise any accepted shape into lines of spans, splitting on newlines.
+ *
+ * Empty spans are dropped, but a line that ends up with no spans is kept: a
+ * blank line between two paragraphs is content, not absence.
+ */
+export function toSpanLines(value: RichText): SpanLine[] {
+  if (typeof value === "string") {
+    return value.split("\n").map((line) => (line === "" ? [] : [{ text: line }]));
+  }
+  const lines: SpanLine[] = isLines(value) ? value : [value];
+  const out: SpanLine[] = [];
+  for (const line of lines) {
+    let current: SpanLine = [];
+    for (const span of line) {
+      if (span.text === "") continue;
+      const parts = span.text.split("\n");
+      current.push({ ...styleOf(span), text: parts[0] as string });
+      for (let i = 1; i < parts.length; i++) {
+        out.push(dropEmpty(current));
+        current = [{ ...styleOf(span), text: parts[i] as string }];
+      }
+    }
+    out.push(dropEmpty(current));
+  }
+  return out;
+}
+
+function dropEmpty(line: SpanLine): SpanLine {
+  return line.filter((s) => s.text !== "");
+}
+
+/** Display width of a line in terminal columns. */
+export function spanWidth(line: SpanLine): number {
+  let w = 0;
+  for (const span of line) w += stringWidth(span.text);
+  return w;
+}
+
+/** Concatenated text of a line, with styling discarded. */
+export function spanText(line: SpanLine): string {
+  let out = "";
+  for (const span of line) out += span.text;
+  return out;
+}
+
+/**
+ * Truncate a line to `max` columns, appending `ellipsis` when it does not fit.
+ *
+ * The ellipsis takes the style of the span it interrupts, so cutting a red
+ * error message short leaves a red ellipsis rather than a stray default-coloured
+ * one.
+ */
+export function truncateSpans(line: SpanLine, max: number, ellipsis = "…"): SpanLine {
+  if (max <= 0) return [];
+  if (spanWidth(line) <= max) return line;
+  const limit = Math.max(0, max - stringWidth(ellipsis));
+  const out: SpanLine = [];
+  let w = 0;
+  let last: Span | undefined;
+  for (const span of line) {
+    let text = "";
+    for (const g of graphemes(span.text)) {
+      if (w + g.width > limit) break;
+      text += cellText(g.value);
+      w += g.width;
+    }
+    if (text !== "") {
+      last = span;
+      out.push({ ...styleOf(span), text });
+    }
+    if (w >= limit) break;
+  }
+  const source = last ?? line[0];
+  out.push({ ...(source ? styleOf(source) : {}), text: ellipsis });
+  return out;
+}
+
+/** Pad or truncate a line to exactly `width` columns. */
+export function fitSpans(
+  line: SpanLine,
+  width: number,
+  align: "left" | "right" | "center" = "left",
+): SpanLine {
+  const cut = truncateSpans(line, width);
+  const pad = width - spanWidth(cut);
+  if (pad <= 0) return cut;
+  // Padding carries no style of its own so it picks up the widget's, which is
+  // what the string path has always done by padding before it draws.
+  const space = (n: number): Span[] => (n > 0 ? [{ text: " ".repeat(n) }] : []);
+  if (align === "right") return [...space(pad), ...cut];
+  if (align === "center") {
+    const left = Math.floor(pad / 2);
+    return [...space(left), ...cut, ...space(pad - left)];
+  }
+  return [...cut, ...space(pad)];
+}
+
+interface Token {
+  text: string;
+  style: Omit<Span, "text">;
+  space: boolean;
+}
+
+/** Split a line into whitespace and non-whitespace runs, keeping each style. */
+function tokenize(line: SpanLine): Token[] {
+  const out: Token[] = [];
+  for (const span of line) {
+    const style = styleOf(span);
+    for (const part of span.text.split(/(\s+)/)) {
+      if (part === "") continue;
+      out.push({ text: part, style, space: /^\s+$/.test(part) });
+    }
+  }
+  return out;
+}
+
+/** Join runs that share a style, so the output has no needless span churn. */
+function coalesce(spans: SpanLine): SpanLine {
+  const out: SpanLine = [];
+  for (const span of spans) {
+    if (span.text === "") continue;
+    const previous = out[out.length - 1];
+    if (previous && sameStyle(previous, span)) previous.text += span.text;
+    else out.push({ ...span });
+  }
+  return out;
+}
+
+function sameStyle(a: Span, b: Span): boolean {
+  return a.fg === b.fg && a.bg === b.bg && a.attrs === b.attrs
+    && !!a.bold === !!b.bold && !!a.dim === !!b.dim
+    && !!a.italic === !!b.italic && !!a.underline === !!b.underline;
+}
+
+/** Drop trailing whitespace spans, the way a soft wrap trims its line end. */
+function trimEnd(spans: SpanLine): SpanLine {
+  const out = spans.map((s) => ({ ...s }));
+  while (out.length > 0) {
+    const last = out[out.length - 1] as Span;
+    last.text = last.text.replace(/\s+$/, "");
+    if (last.text !== "") break;
+    out.pop();
+  }
+  return out;
+}
+
+/**
+ * Greedy word wrap at `width` columns, preserving each span's style across the
+ * break. Mirrors `wrap()` in unicode.ts, including its hard split of a word
+ * longer than the line and its trimming of the soft-wrapped line end.
+ */
+export function wrapSpans(line: SpanLine, width: number): SpanLine[] {
+  if (width <= 0) return [];
+  const lines: SpanLine[] = [];
+  let current: SpanLine = [];
+  let currentWidth = 0;
+
+  const push = (trim: boolean): void => {
+    lines.push(coalesce(trim ? trimEnd(current) : current));
+    current = [];
+    currentWidth = 0;
+  };
+
+  for (const token of tokenize(line)) {
+    const w = stringWidth(token.text);
+    if (currentWidth + w > width && currentWidth > 0) {
+      push(true);
+      // A break swallows the whitespace that caused it, exactly as `wrap` does.
+      if (token.space) continue;
+    }
+    if (w > width) {
+      for (const g of graphemes(token.text)) {
+        if (currentWidth + g.width > width) push(false);
+        current.push({ ...token.style, text: cellText(g.value) });
+        currentWidth += g.width;
+      }
+      continue;
+    }
+    current.push({ ...token.style, text: token.text });
+    currentWidth += w;
+  }
+  // The last line is trimmed like a soft-wrapped one. Only the hard split of an
+  // overlong word pushes untrimmed, because there the break is mid-word and the
+  // whitespace it would trim is real content.
+  push(true);
+  return lines;
+}
+
+/** Wrap every line of a rich value, in order. */
+export function wrapRich(value: RichText, width: number): SpanLine[] {
+  const out: SpanLine[] = [];
+  for (const line of toSpanLines(value)) {
+    if (line.length === 0) {
+      // A blank line survives wrapping as a blank line.
+      out.push([]);
+      continue;
+    }
+    for (const wrapped of wrapSpans(line, width)) out.push(wrapped);
+  }
+  return out;
+}

--- a/packages/hqtui/src/surface.ts
+++ b/packages/hqtui/src/surface.ts
@@ -3,6 +3,7 @@ import { DEFAULT_COLOR, type Color } from "./color.ts";
 import { type Rect, inset, intersect, isEmpty, type Padding } from "./layout.ts";
 import { graphemes, stringWidth, truncate, fit } from "./unicode.ts";
 import type { Theme } from "./theme.ts";
+import { fitSpans, spanStyle, spanWidth, truncateSpans, type SpanLine } from "./richtext.ts";
 
 export type BorderStyle = "rounded" | "single" | "double" | "thick" | "dashed" | "ascii" | "none";
 
@@ -220,6 +221,45 @@ export class Surface {
       }
       cx += g.width;
       written += g.width;
+    }
+    return written;
+  }
+
+  /**
+   * Draw one line of styled spans at local (x, y). Returns columns written.
+   *
+   * The same clipping, truncation and alignment as `text`, but each span paints
+   * with its own colours over the options given here, so a line can carry more
+   * than one style. `text` is the single-span case of this.
+   */
+  spans(x: number, y: number, line: SpanLine, options: TextOptions = {}): number {
+    const ay = this.rect.y + y;
+    const c = this.clip;
+    if (ay < c.y || ay >= c.y + c.height) return 0;
+
+    const limit = Math.min(options.maxWidth ?? this.width - x, this.width - x);
+    if (limit <= 0) return 0;
+    let content = line;
+    if (options.ellipsis !== false && spanWidth(content) > limit) {
+      content = truncateSpans(content, limit);
+    }
+    if (options.align && options.align !== "left") {
+      content = fitSpans(content, limit, options.align);
+    }
+
+    const base: Style = { fg: options.fg, bg: options.bg, attrs: options.attrs };
+    let cx = this.rect.x + x;
+    let written = 0;
+    for (const span of content) {
+      const style = spanStyle(span, base);
+      for (const g of graphemes(span.text)) {
+        if (written + g.width > limit) return written;
+        if (cx >= c.x && cx + g.width <= c.x + c.width) {
+          this.buffer.setCell(cx, ay, g.value, style);
+        }
+        cx += g.width;
+        written += g.width;
+      }
     }
     return written;
   }

--- a/packages/hqtui/src/ui.ts
+++ b/packages/hqtui/src/ui.ts
@@ -7,6 +7,7 @@ import {
   type Constraint, type Rect, type Padding, type Size, inset, stack, solve, isEmpty,
 } from "./layout.ts";
 import { stringWidth, wrap } from "./unicode.ts";
+import { isRich, toSpanLines, wrapRich, type RichText } from "./richtext.ts";
 import { BrailleCanvas } from "./graphics/braille.ts";
 import * as W from "./widgets/index.ts";
 
@@ -292,18 +293,29 @@ export class Container {
 
   // ------------------------------------------------------------------ text
 
-  text(content: string, options: W.TextOptions & ContainerOptions = {}): this {
-    const lines = options.wrap ? wrap(content, this.crossWidth).length : content.split("\n").length;
+  /**
+   * A line, a paragraph, or styled spans:
+   *
+   *   ui.text("plain");
+   *   ui.text([{ text: "ERROR ", fg: theme.danger, bold: true }, { text: reason }]);
+   *
+   * The intrinsic height is measured the same way for both, so a styled
+   * paragraph reserves the rows it will actually occupy once wrapped.
+   */
+  text(content: RichText, options: W.TextOptions & ContainerOptions = {}): this {
+    const lines = isRich(content)
+      ? (options.wrap ? wrapRich(content, this.crossWidth) : toSpanLines(content)).length
+      : (options.wrap ? wrap(content, this.crossWidth).length : content.split("\n").length);
     return this.add((s) => W.drawText(s, content, options), this.sizeOf(options, "auto", lines));
   }
 
   /** Muted secondary text. */
-  label(content: string, options: W.TextOptions & ContainerOptions = {}): this {
+  label(content: RichText, options: W.TextOptions & ContainerOptions = {}): this {
     return this.text(content, { fg: this.theme.muted, ...options });
   }
 
   /** Bold heading in the theme's title color. */
-  heading(content: string, options: W.TextOptions & ContainerOptions = {}): this {
+  heading(content: RichText, options: W.TextOptions & ContainerOptions = {}): this {
     return this.text(content, { fg: this.theme.title, bold: true, ...options });
   }
 

--- a/packages/hqtui/src/widgets/text.ts
+++ b/packages/hqtui/src/widgets/text.ts
@@ -4,6 +4,7 @@ import { Attr } from "../buffer.ts";
 import type { Color } from "../color.ts";
 import { mix } from "../color.ts";
 import { fit, stringWidth, truncate, wrap } from "../unicode.ts";
+import { fitSpans, isRich, toSpanLines, wrapRich, type RichText, type SpanLine } from "../richtext.ts";
 import { elevate } from "../theme.ts";
 
 export interface TextOptions extends Style {
@@ -24,16 +25,29 @@ function attrsOf(o: TextOptions): number {
   return a;
 }
 
-export function drawText(surface: Surface, content: string, options: TextOptions = {}): void {
+export function drawText(surface: Surface, content: RichText, options: TextOptions = {}): void {
   if (surface.empty) return;
   const style: Style = {
     fg: options.fg ?? surface.theme.foreground,
     bg: options.bg,
     attrs: attrsOf(options),
   };
-  const lines = options.wrap ? wrap(content, surface.width) : content.split("\n");
+  // The plain-string path is left exactly as it was rather than routed through
+  // the span code. The two agree — richtext.test.ts holds them to the same
+  // columns over a corpus — but "agree" and "emit identical cells" are not the
+  // same claim, and every committed fixture depends on the second one.
+  if (!isRich(content)) {
+    const lines = options.wrap ? wrap(content, surface.width) : content.split("\n");
+    for (let i = 0; i < lines.length && i < surface.height; i++) {
+      surface.text(0, i, fit(truncate(lines[i], surface.width), surface.width, options.align ?? "left"), style);
+    }
+    return;
+  }
+  const lines = options.wrap
+    ? wrapRich(content, surface.width)
+    : toSpanLines(content);
   for (let i = 0; i < lines.length && i < surface.height; i++) {
-    surface.text(0, i, fit(truncate(lines[i], surface.width), surface.width, options.align ?? "left"), style);
+    surface.spans(0, i, fitSpans(lines[i] as SpanLine, surface.width, options.align ?? "left"), style);
   }
 }
 

--- a/packages/hqtui/test/richtext-render.test.ts
+++ b/packages/hqtui/test/richtext-render.test.ts
@@ -1,0 +1,107 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { renderToScreen, renderToText } from "../src/testing.ts";
+import { Attr } from "../src/buffer.ts";
+import { hex } from "../src/color.ts";
+import type { SpanLine } from "../src/richtext.ts";
+
+const RED = hex("#ff0000");
+const BLUE = hex("#0000ff");
+
+test("a styled line paints each span in its own colour", () => {
+  const screen = renderToScreen(
+    ({ ui }) => {
+      ui.text([
+        { text: "ERR ", fg: RED, bold: true },
+        { text: "ok", fg: BLUE },
+      ]);
+    },
+    { width: 10, height: 1 },
+  );
+  assert.equal(screen.line(0), "ERR ok");
+  assert.equal(screen.cell(0, 0).fg, RED);
+  assert.ok((screen.cell(0, 0).attrs & Attr.Bold) !== 0, "first span is bold");
+  assert.equal(screen.cell(4, 0).fg, BLUE);
+  assert.ok((screen.cell(4, 0).attrs & Attr.Bold) === 0, "second span is not bold");
+});
+
+test("a one-span line renders the same cells as the equivalent string", () => {
+  const draw = (rich: boolean) =>
+    renderToScreen(
+      ({ ui, theme }) => {
+        if (rich) ui.text([{ text: "hello world", fg: theme.foreground }]);
+        else ui.text("hello world");
+      },
+      { width: 20, height: 1 },
+    );
+  assert.deepEqual(draw(true).toJSON(), draw(false).toJSON());
+});
+
+test("styles survive wrapping across lines", () => {
+  const line: SpanLine = [
+    { text: "AAAA ", fg: RED },
+    { text: "BBBB CCCC", fg: BLUE },
+  ];
+  const screen = renderToScreen(({ ui }) => ui.text(line, { wrap: true }), { width: 6, height: 4 });
+  assert.equal(screen.line(0), "AAAA");
+  assert.equal(screen.cell(0, 0).fg, RED);
+  // The blue run continues onto the wrapped lines rather than resetting.
+  assert.equal(screen.line(1), "BBBB");
+  assert.equal(screen.cell(0, 1).fg, BLUE);
+  assert.equal(screen.line(2), "CCCC");
+  assert.equal(screen.cell(0, 2).fg, BLUE);
+});
+
+test("a styled paragraph reserves the rows it actually wraps to", () => {
+  // If the intrinsic height were measured as one line, the divider below would
+  // sit on top of the text instead of under it.
+  const text = renderToText(
+    ({ ui }) => {
+      ui.text([{ text: "one two three four five six", fg: RED }], { wrap: true });
+      ui.divider();
+    },
+    { width: 10, height: 6 },
+  ).split("\n");
+  const rule = text.findIndex((l) => l.startsWith("──"));
+  assert.ok(rule >= 3, `divider landed on row ${rule}, above the wrapped text`);
+});
+
+test("a truncated styled line keeps its colours and the ellipsis", () => {
+  const screen = renderToScreen(
+    ({ ui }) => ui.text([{ text: "aaaa", fg: RED }, { text: "bbbbbbbb", fg: BLUE }]),
+    { width: 6, height: 1 },
+  );
+  assert.equal(screen.line(0), "aaaab…");
+  assert.equal(screen.cell(0, 0).fg, RED);
+  assert.equal(screen.cell(5, 0).fg, BLUE, "the ellipsis takes the interrupted span's colour");
+});
+
+test("label and heading take spans too, and the span colour wins", () => {
+  const screen = renderToScreen(
+    ({ ui }) => {
+      ui.label([{ text: "muted" }, { text: "red", fg: RED }]);
+      ui.heading([{ text: "title" }]);
+    },
+    { width: 12, height: 2 },
+  );
+  assert.equal(screen.line(0), "mutedred");
+  assert.equal(screen.cell(5, 0).fg, RED);
+  // The unstyled span inherits what label chose.
+  assert.notEqual(screen.cell(0, 0).fg, RED);
+  assert.ok((screen.cell(0, 1).attrs & Attr.Bold) !== 0, "heading is still bold");
+});
+
+test("alignment applies to the whole styled line", () => {
+  const screen = renderToScreen(
+    ({ ui }) => ui.text([{ text: "ab", fg: RED }], { align: "right" }),
+    { width: 6, height: 1 },
+  );
+  assert.equal(screen.line(0), "    ab");
+  assert.equal(screen.cell(4, 0).fg, RED);
+});
+
+test("an empty span line renders a blank row without crashing", () => {
+  const screen = renderToScreen(({ ui }) => ui.text([[], [{ text: "x" }]]), { width: 4, height: 2 });
+  assert.equal(screen.line(0), "");
+  assert.equal(screen.line(1), "x");
+});

--- a/packages/hqtui/test/richtext.test.ts
+++ b/packages/hqtui/test/richtext.test.ts
@@ -1,0 +1,187 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  fitSpans, isRich, spanStyle, spanText, spanWidth, toSpanLines,
+  truncateSpans, wrapRich, wrapSpans, type SpanLine,
+} from "../src/richtext.ts";
+import { fit, stringWidth, truncate, wrap } from "../src/unicode.ts";
+import { Attr } from "../src/buffer.ts";
+
+/**
+ * The corpus every parity test runs against. Two text layout engines that
+ * disagree by one column is a bug you find in a screenshot months later, so
+ * the span versions are held to the exact output of the string versions.
+ */
+const CORPUS = [
+  "",
+  "hello",
+  "hello world",
+  "the quick brown fox jumps over the lazy dog",
+  "supercalifragilisticexpialidocious",
+  "a bb ccc dddd eeeee ffffff",
+  "  leading and trailing  ",
+  "tabs\tand\tthings",
+  "CJK 日本語のテキスト wide",
+  "日本語日本語日本語日本語",
+  "emoji 👍 and 👨‍👩‍👧‍👦 family",
+  "combining é and é marks",
+  "line one\nline two\nline three",
+  "trailing newline\n",
+  "\nleading newline",
+  "double\n\nblank",
+  "one-very-long-unbroken-token-that-exceeds-any-sane-width",
+  "mixed 日本語 with ascii and 👍 emoji together",
+];
+
+const WIDTHS = [1, 2, 3, 5, 8, 13, 20, 40];
+
+function one(text: string): SpanLine {
+  return text === "" ? [] : [{ text }];
+}
+
+test("spanWidth matches stringWidth", () => {
+  for (const text of CORPUS) {
+    assert.equal(spanWidth(one(text)), stringWidth(text), text);
+  }
+});
+
+test("truncateSpans cuts at the same column as truncate", () => {
+  for (const text of CORPUS) {
+    if (text.includes("\n")) continue; // truncate() has no newline semantics
+    for (const width of WIDTHS) {
+      assert.equal(
+        spanText(truncateSpans(one(text), width)),
+        truncate(text, width),
+        `${JSON.stringify(text)} @${width}`,
+      );
+    }
+  }
+});
+
+test("fitSpans pads to the same columns as fit", () => {
+  for (const text of CORPUS) {
+    if (text.includes("\n")) continue;
+    for (const width of WIDTHS) {
+      for (const align of ["left", "right", "center"] as const) {
+        assert.equal(
+          spanText(fitSpans(one(text), width, align)),
+          fit(text, width, align),
+          `${JSON.stringify(text)} @${width} ${align}`,
+        );
+      }
+    }
+  }
+});
+
+test("wrapSpans breaks in the same places as wrap", () => {
+  for (const text of CORPUS) {
+    if (text.includes("\n")) continue; // wrap() splits paragraphs itself
+    for (const width of WIDTHS) {
+      assert.deepEqual(
+        wrapSpans(one(text), width).map(spanText),
+        wrap(text, width),
+        `${JSON.stringify(text)} @${width}`,
+      );
+    }
+  }
+});
+
+test("wrapRich on a plain string matches wrap, newlines included", () => {
+  for (const text of CORPUS) {
+    for (const width of WIDTHS) {
+      assert.deepEqual(
+        wrapRich(text, width).map(spanText),
+        wrap(text, width),
+        `${JSON.stringify(text)} @${width}`,
+      );
+    }
+  }
+});
+
+// ---------------------------------------------------------------- styling
+
+test("a string is the one-span case", () => {
+  assert.equal(isRich("plain"), false);
+  assert.deepEqual(toSpanLines("plain"), [[{ text: "plain" }]]);
+});
+
+test("newlines inside a span split it into lines", () => {
+  const lines = toSpanLines([{ text: "a\nb", fg: 3 }]);
+  assert.deepEqual(lines, [[{ fg: 3, text: "a" }], [{ fg: 3, text: "b" }]]);
+});
+
+test("a blank line survives as a blank line", () => {
+  assert.deepEqual(toSpanLines("a\n\nb").map(spanText), ["a", "", "b"]);
+  assert.deepEqual(wrapRich("a\n\nb", 10).map(spanText), ["a", "", "b"]);
+});
+
+test("styles survive a wrap", () => {
+  const line: SpanLine = [
+    { text: "ERROR ", fg: 1, bold: true },
+    { text: "connection refused by the upstream host" },
+  ];
+  const wrapped = wrapSpans(line, 16);
+  assert.ok(wrapped.length > 1);
+  const first = wrapped[0] as SpanLine;
+  assert.equal(first[0]?.fg, 1);
+  assert.equal(first[0]?.bold, true);
+  // Every line's columns still fit.
+  for (const l of wrapped) assert.ok(spanWidth(l) <= 16, spanText(l));
+  // No text is lost or duplicated.
+  assert.equal(
+    wrapped.map(spanText).join(" ").replace(/\s+/g, " ").trim(),
+    "ERROR connection refused by the upstream host",
+  );
+});
+
+test("styles survive a truncation, and the ellipsis takes the cut span's style", () => {
+  const line: SpanLine = [
+    { text: "ok ", fg: 2 },
+    { text: "then a long red tail", fg: 1 },
+  ];
+  const cut = truncateSpans(line, 10);
+  assert.equal(spanWidth(cut), 10);
+  assert.equal(cut[cut.length - 1]?.text, "…");
+  assert.equal(cut[cut.length - 1]?.fg, 1, "ellipsis inherits the interrupted span");
+});
+
+test("truncating inside the first span keeps that span's style on the ellipsis", () => {
+  const cut = truncateSpans([{ text: "aaaaaaaaaa", fg: 5 }, { text: "bbb", fg: 6 }], 4);
+  assert.equal(spanText(cut), "aaa…");
+  assert.equal(cut[cut.length - 1]?.fg, 5);
+});
+
+test("padding carries no style, so it picks up the widget's", () => {
+  const padded = fitSpans([{ text: "hi", fg: 4, bg: 7 }], 6);
+  const pad = padded[padded.length - 1];
+  assert.equal(pad?.text, "    ");
+  assert.equal(pad?.fg, undefined);
+  assert.equal(pad?.bg, undefined);
+});
+
+test("spanStyle folds the boolean shorthands into attrs over a base", () => {
+  assert.deepEqual(
+    spanStyle({ text: "x", bold: true, underline: true }, { fg: 9, attrs: Attr.Dim }),
+    { fg: 9, bg: undefined, attrs: Attr.Dim | Attr.Bold | Attr.Underline },
+  );
+  // An explicit span colour wins over the base.
+  assert.equal(spanStyle({ text: "x", fg: 2 }, { fg: 9 }).fg, 2);
+  // And an absent one inherits it.
+  assert.equal(spanStyle({ text: "x" }, { fg: 9 }).fg, 9);
+});
+
+test("adjacent runs sharing a style are coalesced by wrapping", () => {
+  const wrapped = wrapSpans([{ text: "a", fg: 1 }, { text: "b", fg: 1 }, { text: "c", fg: 2 }], 40);
+  assert.deepEqual(wrapped, [[{ fg: 1, text: "ab" }, { fg: 2, text: "c" }]]);
+});
+
+test("empty spans are dropped rather than rendered", () => {
+  assert.deepEqual(toSpanLines([{ text: "" }, { text: "x" }]), [[{ text: "x" }]]);
+});
+
+test("a zero or negative width yields nothing, as the string path does", () => {
+  assert.deepEqual(wrapSpans(one("anything"), 0), []);
+  assert.deepEqual(wrapSpans(one("anything"), 0), wrap("anything", 0).map(one));
+  assert.deepEqual(truncateSpans(one("anything"), 0), []);
+  assert.equal(spanText(truncateSpans(one("anything"), 0)), truncate("anything", 0));
+});


### PR DESCRIPTION
Closes #60 for TypeScript. The six ports are follow-up work — see the last section.

## What was wrong

`drawText` applied one `Style` to the whole string:

```ts
const style: Style = { fg: options.fg ?? surface.theme.foreground, ... };
const lines = options.wrap ? wrap(content, surface.width) : content.split("\n");
```

so two colours on one line meant splitting into separate widgets at hand-computed columns. Syntax highlighting, inline log-level colouring, diffs and search-match highlighting were all off the table.

## What this adds

`Span` → `SpanLine` → `RichText`, plus span-aware measuring, truncation, padding and word wrap in a new `packages/hqtui/src/richtext.ts`; a `Surface.spans()` renderer; and `RichText` acceptance on `drawText` and `ui.text` / `ui.label` / `ui.heading`.

```ts
ui.text([
  { text: "ERROR ", fg: theme.danger, bold: true },
  { text: "connection refused" },
]);
```

A bare string is the one-span case, so **no existing call site changes**. Spans inherit the widget's style for anything they don't set, which is why `ui.label([{ text: "muted" }, { text: "red", fg: RED }])` keeps the label colour on the first span.

## Why you can trust the layout

Two text layout engines that disagree by one column is a bug you find in a screenshot six months later. So the span versions are held to the *exact* output of the string versions they mirror — `richtext.test.ts` asserts `truncateSpans`/`fitSpans`/`wrapSpans` match `truncate`/`fit`/`wrap` column for column across a corpus of CJK, emoji, ZWJ family sequences, combining marks, leading/trailing whitespace, blank lines and overlong unbroken tokens, at eight widths.

That test earned its keep on the first run: it caught `wrapSpans` not trimming its final line, which `wrap` does. That would have shipped as one stray trailing space per wrapped paragraph.

## Why no existing frame moves

The plain-string path inside `drawText` is deliberately left intact rather than routed through the span code. The two agree, but *agree* and *emit identical cells* are different claims, and every committed fixture depends on the second one.

Both generators confirm it, with no drift:

- `bun ports/conformance/generate.ts`
- `bun apps/demo/scripts/native-parity.ts` — 120 cases

## Checks

- 232 tests pass under `bun test` and `bun run test:node` (was 208; +24 here)
- `bun run typecheck` clean

## Not in this PR

- **The six ports.** This is additive and changes no existing frame, so `ports/{rust,go,python,zig,cpp}` and the COBOL adapter stay in parity — they simply don't offer spans yet. Porting is the rest of #60, and the parity corpus above is the spec to port against.
- **Widgets beyond text.** List items, table cells, log messages and panel titles still take `string`. Those are the next increment now that the core exists, and they are what a JSON response inspector or a diff view actually needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Df2FNu5DhinMV2soRz3cy
