### PR TITLE
0.3.0: styled text spans

### DIFF
--- a/apps/benchmark/package.json
+++ b/apps/benchmark/package.json
@@ -7,6 +7,6 @@
     "start": "bun src/main.ts"
   },
   "dependencies": {
-    "@profullstack/hqtui": "^0.2.0"
+    "@profullstack/hqtui": "^0.3.0"
   }
 }

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@profullstack/hqtui-demo",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "The HQTUI reference dashboard: a btop-grade terminal system monitor. Runs on real system metrics or a deterministic simulation.",
   "license": "MIT",
   "type": "module",
@@ -27,7 +27,7 @@
     "audit:scroll": "bun scripts/scrollaudit.ts"
   },
   "dependencies": {
-    "@profullstack/hqtui": "^0.2.0"
+    "@profullstack/hqtui": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/apps/demo/src/main.ts
+++ b/apps/demo/src/main.ts
@@ -51,7 +51,7 @@ function parseArgs(argv: string[]): Options {
       case "-h":
       case "--help": printHelp(); process.exit(0);
       case "-v":
-      case "--version": console.log("hqtui-demo 0.2.0"); process.exit(0);
+      case "--version": console.log("hqtui-demo 0.3.0"); process.exit(0);
     }
   }
   return options;

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -157,7 +157,7 @@ export default async function Home() {
               High Quality Terminal UI for TypeScript, Rust, Go, Python, Zig and C++
             </p>
             <Badge variant="secondary" className="mb-5 font-mono text-xs">
-              v0.2.0 · {COUNT} language demos · MIT
+              v0.3.0 · {COUNT} language demos · MIT
             </Badge>
             <p className="text-balance text-3xl font-bold tracking-tight sm:text-5xl">
               Terminal dashboards that

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@base-ui/react": "1.7.0",
-    "@profullstack/hqtui": "^0.2.0",
+    "@profullstack/hqtui": "^0.3.0",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "lucide-react": "1.37.0",

--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
     },
     "apps/demo": {
       "name": "@profullstack/hqtui-demo",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "bin": {
         "hqtui-demo": "./src/main.ts",
       },
@@ -34,7 +34,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@base-ui/react": "1.7.0",
-        "@profullstack/hqtui": "^0.2.0",
+        "@profullstack/hqtui": "^0.3.0",
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
         "lucide-react": "1.37.0",
@@ -58,19 +58,19 @@
       "name": "@profullstack/hqtui-examples",
       "version": "0.1.0",
       "dependencies": {
-        "@profullstack/hqtui": "^0.2.0",
+        "@profullstack/hqtui": "^0.3.0",
       },
     },
     "packages/hqtui": {
       "name": "@profullstack/hqtui",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "bin": {
         "hqtui": "./bin/hqtui.mjs",
       },
     },
     "ports/cobol/adapter": {
       "name": "@profullstack/hqtui-cobol-adapter",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@profullstack/hqtui": "workspace:*",
       },

--- a/examples/package.json
+++ b/examples/package.json
@@ -4,6 +4,6 @@
   "version": "0.1.0",
   "type": "module",
   "dependencies": {
-    "@profullstack/hqtui": "^0.2.0"
+    "@profullstack/hqtui": "^0.3.0"
   }
 }

--- a/packages/hqtui/package.json
+++ b/packages/hqtui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@profullstack/hqtui",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "High Quality Terminal UI for TypeScript. btop-grade dashboards with a one-import API, dark by default, zero runtime dependencies.",
   "license": "MIT",
   "type": "module",

--- a/packages/hqtui/src/cli.ts
+++ b/packages/hqtui/src/cli.ts
@@ -13,7 +13,7 @@ import { detectCapabilities } from "./capabilities.ts";
 import { themeList, themes } from "./theme.ts";
 import { BrailleCanvas } from "./graphics/braille.ts";
 
-const VERSION = "0.2.0";
+const VERSION = "0.3.0";
 
 function help(): void {
   console.log(`hqtui ${VERSION} — High Quality Terminal UI for TypeScript

--- a/ports/cobol/adapter/package.json
+++ b/ports/cobol/adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@profullstack/hqtui-cobol-adapter",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "description": "Reads 80-column COBOL scene records and draws them with HQTUI.",
   "dependencies": {


### PR DESCRIPTION
Release bump for the spans work merged in #65.

## What ships

`Span` / `SpanLine` / `RichText` plus `Surface.spans()`, so a line can carry more than one colour:

```ts
ui.text([
  { text: "ERROR ", fg: theme.danger, bold: true },
  { text: "connection refused" },
]);
```

`drawText` and `ui.text` / `label` / `heading` accept spans wherever they took a string. A bare string is the one-span case, so no existing call site changes and no committed frame moves.

## Bump surface

Every hand-written version string, per `packages/hqtui/test/version.test.ts`:

- `packages/hqtui/package.json`, `packages/hqtui/src/cli.ts` VERSION
- `apps/demo/package.json` (version + dep range), `apps/demo/src/main.ts` `--version`
- `apps/web/app/page.tsx` badge and the `@profullstack/hqtui` range in `apps/web`, `apps/benchmark`, `examples`
- `ports/cobol/adapter/package.json`
- `bun.lock` — the two workspace ranges and three version fields that `bun install` leaves stale and `--frozen-lockfile` accepts either way

## Checks

- `bun install --frozen-lockfile` clean
- `bun run typecheck` exit 0
- 232 tests pass under `bun test` and `node --test`
- `node apps/demo/bin/hqtui-demo.mjs --version` → `hqtui-demo 0.3.0`, proving the compiled demo runs

After merge: `gh release create v0.3.0` on the merge SHA, which triggers `publish.yml` for both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Df2FNu5DhinMV2soRz3cy