### PR TITLE
Inline and fixed viewports, so an app can live in the command line

### DIFF
--- a/examples/inline.ts
+++ b/examples/inline.ts
@@ -1,0 +1,61 @@
+/**
+ * An inline viewport: `bun examples/inline.ts`.
+ *
+ * The shape `npm`, `cargo`, `docker pull` and every installer use. A few live
+ * rows sit in the normal flow of the command line, finished work scrolls away
+ * above them into the terminal's scrollback, and when the process exits the
+ * shell holds a readable transcript instead of a blanked alternate screen.
+ *
+ * Nothing here clears the screen, and your prompt comes back below the last
+ * frame rather than on top of it. Run it after something else and you will see
+ * that output still there.
+ */
+import { createApp } from "@profullstack/hqtui";
+
+const steps = [
+  "resolve dependencies",
+  "compile core",
+  "compile widgets",
+  "link",
+  "run tests",
+];
+
+const app = await createApp({
+  // Three rows of live UI. Everything else belongs to the shell.
+  viewport: { mode: "inline", height: 3 },
+  quitKeys: [],
+  alwaysRender: true,
+  fps: 20,
+});
+
+let done = 0;
+let spinner = 0;
+const frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+app.render(({ ui, theme }) => {
+  ui.text(`building  ${done}/${steps.length}`, { fg: theme.primary, bold: true });
+  ui.meter({ label: "", value: done / steps.length });
+  ui.text(
+    done < steps.length ? `${frames[spinner % frames.length]} ${steps[done]}` : "done",
+    { fg: theme.muted },
+  );
+});
+
+void app.start();
+
+const timer = setInterval(() => {
+  spinner++;
+  if (spinner % 8 !== 0) return;
+
+  // The finished line goes into the scrollback, permanently. The live rows
+  // below it keep redrawing where they are.
+  app.insertBefore(1, (ui) => {
+    ui.text(`  ✓ ${steps[done]}`);
+  });
+  done++;
+
+  if (done >= steps.length) {
+    clearInterval(timer);
+    setTimeout(() => app.stop(), 300);
+  }
+}, 60);

--- a/packages/hqtui/src/ansi.ts
+++ b/packages/hqtui/src/ansi.ts
@@ -50,6 +50,24 @@ export function moveToColumn(x: number): string {
   return `${CSI}${x + 1}G`;
 }
 
+/**
+ * Cursor up and down, in rows.
+ *
+ * An inline viewport cannot use absolute addressing: it does not know which
+ * screen row it starts on, and a scroll moves it without telling anyone. It
+ * returns to its own top-left with a saved cursor and walks from there, which
+ * is what these are for.
+ */
+export function moveUp(n: number): string {
+  if (n <= 0) return "";
+  return n === 1 ? `${CSI}A` : `${CSI}${n}A`;
+}
+
+export function moveDown(n: number): string {
+  if (n <= 0) return "";
+  return n === 1 ? `${CSI}B` : `${CSI}${n}B`;
+}
+
 export function setTitle(title: string): string {
   // The title is interpolated into an OSC sequence, so anything that could end
   // or restart it has to go. `stripUnsafe` is the same policy the grid uses:

--- a/packages/hqtui/src/app.ts
+++ b/packages/hqtui/src/app.ts
@@ -1,5 +1,5 @@
 import { FrameBuffer } from "./buffer.ts";
-import { Encoder } from "./diff.ts";
+import { Encoder, encodeRows } from "./diff.ts";
 import { ansi } from "./ansi.ts";
 import { Terminal, type TerminalOptions, emergencyRestore } from "./terminal.ts";
 import type { Capabilities } from "./capabilities.ts";
@@ -111,12 +111,14 @@ export class App {
     this.capabilities = this.terminal.capabilities;
     this.theme = resolveTheme(options.theme);
 
-    const { columns, rows } = this.terminal.size();
-    this.current = new FrameBuffer(columns, rows);
-    this.previous = new FrameBuffer(columns, rows);
+    const rect = this.terminal.viewportRect();
+    this.current = new FrameBuffer(rect.width, rect.height);
+    this.previous = new FrameBuffer(rect.width, rect.height);
     this.encoder = new Encoder({
       colors: this.capabilities.colors,
       monochrome: options.monochrome ?? this.capabilities.colors === "none",
+      origin: { x: rect.x, y: rect.y },
+      relative: this.terminal.viewport.mode === "inline",
     });
   }
 
@@ -200,6 +202,67 @@ export class App {
     this.dirty = true;
   }
 
+  /**
+   * Write `height` rows into the terminal's scrollback, above the live view.
+   *
+   * This is what an inline app is for. The live rows stay where they are and
+   * keep redrawing; what you pass here scrolls away above them and is still
+   * there when the process exits, which is how `npm`, `cargo` and every
+   * installer behave and what the alternate screen can never do.
+   *
+   *   app.insertBefore(1, ui => ui.text("compiled in 1.2s", { fg: theme.success }));
+   *
+   * It is a no-op for a fullscreen or fixed viewport, where there is no "above"
+   * to write into -- the app owns every row it can see.
+   */
+  insertBefore(height: number, draw: (ui: Container) => void): void {
+    if (this.terminal.viewport.mode !== "inline" || height <= 0) return;
+    const width = this.current.width;
+    if (width <= 0) return;
+
+    const buffer = new FrameBuffer(width, height);
+    // No background: these lines join the user's terminal, and a block of
+    // theme colour across their scrollback is not ours to paint.
+    buffer.clear(undefined, this.theme.foreground);
+    const surface = createSurface(buffer, this.theme);
+    const container = new Container(surface, this.scrollbackContext(), "column");
+    draw(container);
+    container.flush();
+
+    this.terminal.insertBefore(encodeRows(buffer, {
+      colors: this.capabilities.colors,
+      monochrome: this.options.monochrome ?? this.capabilities.colors === "none",
+    }));
+    // Everything below the anchor is now whatever the terminal shifted there.
+    this.forceRepaint = true;
+    this.dirty = true;
+    this.frame();
+  }
+
+  /**
+   * A render context for lines that are printed once and never redrawn.
+   *
+   * Scrollback is not interactive: it cannot take focus, a click cannot reach
+   * it, and nothing about it can ask for another frame -- by the time anyone
+   * looks, it has scrolled away.
+   */
+  private scrollbackContext(): RenderContext {
+    return {
+      theme: this.theme,
+      capabilities: this.capabilities,
+      width: this.current.width,
+      height: 0,
+      frame: this.frameCount,
+      elapsed: Date.now() - this.startedAt,
+      focusIndex: -1,
+      collapseBorders: this.options.collapseBorders ?? false,
+      registerFocus: () => ({ index: -1, focused: false }),
+      hit: () => {},
+      overlay: () => {},
+      invalidate: () => {},
+    };
+  }
+
   /** Start the loop. Resolves when the app exits. */
   async start(): Promise<void> {
     if (this.running) return;
@@ -214,12 +277,14 @@ export class App {
     // host, the render loop must not keep drawing into the restored shell.
     this.subscriptions.push(this.terminal.onTeardown(() => this.stop()));
     this.subscriptions.push(this.terminal.onInput((event) => this.handleInput(event)));
-    this.subscriptions.push(this.terminal.onResizeEvent(({ columns, rows }) => {
-      this.current.resize(columns, rows);
-      this.previous.resize(columns, rows);
+    this.subscriptions.push(this.terminal.onResizeEvent(() => {
+      const rect = this.terminal.viewportRect();
+      this.current.resize(rect.width, rect.height);
+      this.previous.resize(rect.width, rect.height);
+      this.encoder.origin = { x: rect.x, y: rect.y };
       this.forceRepaint = true;
       this.dirty = true;
-      this.emit("resize", { width: columns, height: rows });
+      this.emit("resize", { width: rect.width, height: rect.height });
       this.frame();
     }));
 
@@ -312,10 +377,11 @@ export class App {
     const started = performance.now();
     this.dirty = false;
 
-    const size = this.terminal.size();
-    if (size.columns !== this.current.width || size.rows !== this.current.height) {
-      this.current.resize(size.columns, size.rows);
-      this.previous.resize(size.columns, size.rows);
+    const rect = this.terminal.viewportRect();
+    if (rect.width !== this.current.width || rect.height !== this.current.height) {
+      this.current.resize(rect.width, rect.height);
+      this.previous.resize(rect.width, rect.height);
+      this.encoder.origin = { x: rect.x, y: rect.y };
       this.forceRepaint = true;
     }
 
@@ -368,6 +434,10 @@ export class App {
 
     let output = result.output;
     if (output.length > 0) {
+      // An inline viewport measures everything from its own top-left, so the
+      // cursor has to be put there before the frame rather than assumed to be
+      // wherever the last one finished.
+      if (this.encoder.relative) output = ansi.cursorRestore + ansi.cursorSave + "\r" + output;
       if (this.capabilities.synchronizedOutput) output = ansi.beginSync + output + ansi.endSync;
       this.terminal.write(output);
     }

--- a/packages/hqtui/src/diff.ts
+++ b/packages/hqtui/src/diff.ts
@@ -1,9 +1,10 @@
-import type { FrameBuffer } from "./buffer.ts";
+import { FrameBuffer } from "./buffer.ts";
 import { Attr } from "./buffer.ts";
 import type { Capabilities } from "./capabilities.ts";
 import { DEFAULT_COLOR, type Color, blue, green, grayscale, red, to16, to256 } from "./color.ts";
 import {
-  CSI, bg16, bg256, bgDefault, bgTrue, fg16, fg256, fgDefault, fgTrue, moveTo, moveToColumn, moveRight,
+  CSI, ESC, bg16, bg256, bgDefault, bgTrue, fg16, fg256, fgDefault, fgTrue, moveDown, moveTo,
+  moveToColumn, moveRight, moveUp,
 } from "./ansi.ts";
 import { CONTINUATION, cellText, cellWidth } from "./unicode.ts";
 
@@ -35,6 +36,23 @@ export interface EncoderOptions {
   colors?: Capabilities["colors"];
   /** Drain all color, keeping attributes. */
   monochrome?: boolean;
+  /**
+   * Where cell (0, 0) of the buffer sits on the screen. For a viewport that
+   * owns a fixed region of somebody else's terminal rather than the whole of
+   * one.
+   */
+  origin?: { x: number; y: number };
+  /**
+   * Address cells relative to wherever the cursor is when `encode` is called,
+   * rather than by absolute screen coordinates.
+   *
+   * An inline viewport has no absolute coordinates it can trust: it does not
+   * know which screen row it starts on, and the terminal can scroll it upwards
+   * at any moment without saying so. The caller parks the cursor at the
+   * viewport's top-left before each frame and everything is measured from
+   * there.
+   */
+  relative?: boolean;
 }
 
 /**
@@ -46,10 +64,15 @@ export class Encoder {
   private parts: string[] = [];
   colors: Capabilities["colors"];
   monochrome: boolean;
+  /** Screen position of buffer cell (0, 0). Ignored when `relative`. */
+  origin: { x: number; y: number };
+  relative: boolean;
 
   constructor(options: EncoderOptions = {}) {
     this.colors = options.colors ?? "truecolor";
     this.monochrome = options.monochrome ?? false;
+    this.origin = options.origin ?? { x: 0, y: 0 };
+    this.relative = options.relative ?? false;
   }
 
   /** Forget what we believe about the terminal; the next write re-states everything. */
@@ -115,18 +138,43 @@ export class Encoder {
 
   private moveCursor(x: number, y: number): void {
     const s = this.state;
+    // A carriage return goes to column 0 of the screen, not of the viewport,
+    // so it is only the same thing when the viewport starts there.
+    const home = this.relative ? 0 : this.origin.x;
     if (s.known && s.y === y) {
       if (s.x === x) return;
       if (x > s.x && x - s.x <= 3) {
         // Short hop: cheaper than a full CUP, and never repaints cells.
         this.parts.push(moveRight(x - s.x));
-      } else if (x === 0) {
+      } else if (x === 0 && home === 0) {
         this.parts.push("\r");
+      } else if (this.relative) {
+        this.parts.push("\r" + moveRight(x));
       } else {
-        this.parts.push(moveToColumn(x));
+        this.parts.push(moveToColumn(x + this.origin.x));
       }
+    } else if (this.relative) {
+      // Relative mode has no absolute coordinate to jump to, so it walks: down
+      // or up to the row, then back to the left edge and across. Where the
+      // cursor is no longer trusted -- writing a row's last column leaves it in
+      // the terminal's pending-wrap limbo -- it goes back to the saved anchor
+      // and walks from there, which is exact whatever the terminal did.
+      if (s.known) {
+        this.parts.push(y > s.y ? moveDown(y - s.y) : moveUp(s.y - y));
+      } else {
+        // Restore, and re-save: in some terminals DECRC pops the saved
+        // position rather than peeking at it, and a second restore against one
+        // save sends the cursor home instead. Restoring also brings back the
+        // saved pen, which is the default one, so the style model has to admit
+        // it no longer knows what is in force.
+        this.parts.push(`${ESC}8${ESC}7`, moveDown(y));
+        s.fg = DEFAULT_COLOR;
+        s.bg = DEFAULT_COLOR;
+        s.attrs = 0;
+      }
+      this.parts.push(x === 0 ? "\r" : "\r" + moveRight(x));
     } else {
-      this.parts.push(moveTo(x, y));
+      this.parts.push(moveTo(x + this.origin.x, y + this.origin.y));
     }
     s.x = x;
     s.y = y;
@@ -147,6 +195,17 @@ export class Encoder {
     const sameSize = prev.width === w && prev.height === h;
     const repaint = full || !sameSize;
     if (repaint) this.invalidateState();
+    // The caller parks the cursor at the viewport's top-left before every frame in
+    // relative mode, so that is where the walk starts from.
+    if (this.relative) {
+      this.state.x = 0;
+      this.state.y = 0;
+      this.state.known = true;
+      // Getting there meant a DECRC, which brought the saved pen back with it.
+      this.state.fg = DEFAULT_COLOR;
+      this.state.bg = DEFAULT_COLOR;
+      this.state.attrs = 0;
+    }
 
     const nc = next.chars;
     const nf = next.fg;
@@ -213,6 +272,37 @@ export class Encoder {
 
     return { output: this.parts.join(""), changedCells: changed, dirtyRows };
   }
+}
+
+/**
+ * One string per row, styled but never positioned.
+ *
+ * For output that is printed rather than painted: the lines an inline viewport
+ * pushes up into the user's scrollback, which the terminal lays out itself and
+ * which must therefore carry no cursor movement at all. Trailing blanks are
+ * dropped so a finished line does not paint a bar of background across the
+ * width of the terminal, and each row ends by putting the pen back.
+ */
+export function encodeRows(buffer: FrameBuffer, options: EncoderOptions = {}): string[] {
+  const encoder = new Encoder({ ...options, origin: { x: 0, y: 0 }, relative: false });
+  const width = buffer.width;
+  const row = new FrameBuffer(width, 1);
+  const blank = new FrameBuffer(-1, -1);
+  const rows: string[] = [];
+  for (let y = 0; y < buffer.height; y++) {
+    const from = y * width;
+    row.chars.set(buffer.chars.subarray(from, from + width));
+    row.fg.set(buffer.fg.subarray(from, from + width));
+    row.bg.set(buffer.bg.subarray(from, from + width));
+    row.attrs.set(buffer.attrs.subarray(from, from + width));
+    encoder.invalidateState();
+    // The row is encoded as row 0 of a one-row buffer, so the only positioning
+    // in it is the jump home. Dropping that leaves the styling, which is all a
+    // printed line may carry.
+    const line = encoder.encode(blank, row, true).output.replace(`${CSI}1;1H`, "");
+    rows.push(line.replace(/[ ]+$/, "") + `${CSI}0m`);
+  }
+  return rows;
 }
 
 /** One-shot encode of a whole buffer, e.g. for `renderToAnsi` in tests. */

--- a/packages/hqtui/src/index.ts
+++ b/packages/hqtui/src/index.ts
@@ -20,7 +20,10 @@ export type {
 } from "./ui.ts";
 
 // Terminal + capabilities
-export { Terminal, createTerminal, emergencyRestore, type TerminalOptions, type TerminalSize } from "./terminal.ts";
+export {
+  Terminal, createTerminal, emergencyRestore,
+  type TerminalOptions, type TerminalSize, type Viewport, type Rect as ViewportRect,
+} from "./terminal.ts";
 export { detectCapabilities, type Capabilities, type ColorDepth, type CapabilityOverrides } from "./capabilities.ts";
 
 // Rendering core

--- a/packages/hqtui/src/terminal.ts
+++ b/packages/hqtui/src/terminal.ts
@@ -1,6 +1,33 @@
-import { ansi, setTitle } from "./ansi.ts";
+import { ansi, moveTo, moveUp, setTitle } from "./ansi.ts";
 import { type Capabilities, type CapabilityOverrides, detectCapabilities } from "./capabilities.ts";
 import { InputParser, type InputEvent } from "./input.ts";
+
+/**
+ * How much of the terminal the app owns.
+ *
+ * `fullscreen` is what hqtui has always done: the alternate screen, the whole
+ * grid, and the user's shell handed back untouched at the end.
+ *
+ * `inline` draws a bounded strip in the normal flow of the command line, the
+ * shape every installer and build tool uses -- a few live rows pinned below
+ * output that scrolls away above them, and a readable transcript left behind
+ * when the process exits. It has no absolute coordinates it can trust, because
+ * it does not know which screen row it started on and the terminal can scroll
+ * it up at any moment; it navigates from a saved cursor instead.
+ *
+ * `fixed` claims a rectangle of a terminal something else is driving.
+ */
+export type Viewport =
+  | { mode: "fullscreen" }
+  | { mode: "inline"; height: number }
+  | { mode: "fixed"; x: number; y: number; width: number; height: number };
+
+export interface Rect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
 
 export interface TerminalOptions {
   input?: NodeJS.ReadStream;
@@ -17,6 +44,8 @@ export interface TerminalOptions {
   installExitHandlers?: boolean;
   /** How long to wait before a lone ESC counts as the Escape key. Default 30ms. */
   escapeTimeout?: number;
+  /** How much of the terminal to draw into. Default the whole of it. */
+  viewport?: Viewport;
 }
 
 export interface TerminalSize {
@@ -34,7 +63,7 @@ export class Terminal {
   readonly input: NodeJS.ReadStream;
   readonly output: NodeJS.WriteStream;
   readonly capabilities: Capabilities;
-  private options: Required<Omit<TerminalOptions, "capabilities" | "title" | "input" | "output" | "escapeTimeout">> & { title?: string };
+  private options: Required<Omit<TerminalOptions, "capabilities" | "title" | "input" | "output" | "escapeTimeout" | "viewport">> & { title?: string };
   private parser = new InputParser();
   private entered = false;
   /** Milliseconds to wait before deciding a lone ESC was the Escape key. */
@@ -45,6 +74,13 @@ export class Terminal {
   private cleanupHandlers: (() => void)[] = [];
   private teardownListeners = new Set<() => void>();
   private escapeTimer: NodeJS.Timeout | null = null;
+  private viewportMode: Viewport = { mode: "fullscreen" };
+  /**
+   * Rows an inline viewport has reserved below the anchor. Kept because a
+   * resize can shrink the terminal under it, and because `restore` has to know
+   * how far down to move before handing the shell back.
+   */
+  private reserved = 0;
   private onData = (chunk: Buffer | string): void => {
     const text = typeof chunk === "string" ? chunk : chunk.toString("utf8");
     this.dispatch(this.parser.parse(text));
@@ -75,8 +111,12 @@ export class Terminal {
     this.output = options.output ?? process.stdout;
     this.capabilities = detectCapabilities(options.capabilities ?? {}, process.env, this.output);
     this.escapeTimeout = options.escapeTimeout ?? 30;
+    this.viewportMode = options.viewport ?? { mode: "fullscreen" };
+    // Only a fullscreen app may take the alternate screen. The whole point of
+    // the other two is to leave what is already on the terminal alone.
+    const fullscreen = this.viewportMode.mode === "fullscreen";
     this.options = {
-      alternateScreen: options.alternateScreen ?? true,
+      alternateScreen: fullscreen ? options.alternateScreen ?? true : false,
       mouse: options.mouse ?? this.capabilities.mouse,
       hideCursor: options.hideCursor ?? true,
       bracketedPaste: options.bracketedPaste ?? this.capabilities.bracketedPaste,
@@ -100,6 +140,40 @@ export class Terminal {
     };
   }
 
+  /** How much of the terminal the app owns. */
+  get viewport(): Viewport {
+    return this.viewportMode;
+  }
+
+  /**
+   * The region to draw into, in screen cells.
+   *
+   * For an inline viewport the `y` is a fiction -- it is always 0, because the
+   * strip is addressed from its own saved cursor rather than from the top of
+   * the screen -- but the width and height are real, and they are what the
+   * framebuffer is sized from.
+   */
+  viewportRect(): Rect {
+    const { columns, rows } = this.size();
+    const v = this.viewportMode;
+    if (v.mode === "inline") {
+      // A viewport taller than the terminal would scroll itself off the top
+      // every frame, so it gives up the rows it cannot have.
+      return { x: 0, y: 0, width: columns, height: Math.max(1, Math.min(v.height, rows)) };
+    }
+    if (v.mode === "fixed") {
+      const x = Math.max(0, Math.min(v.x, Math.max(0, columns - 1)));
+      const y = Math.max(0, Math.min(v.y, Math.max(0, rows - 1)));
+      return {
+        x,
+        y,
+        width: Math.max(0, Math.min(v.width, columns - x)),
+        height: Math.max(0, Math.min(v.height, rows - y)),
+      };
+    }
+    return { x: 0, y: 0, width: columns, height: rows };
+  }
+
   write(data: string): void {
     if (data.length === 0) return;
     this.output.write(data);
@@ -117,8 +191,12 @@ export class Terminal {
     if (this.options.bracketedPaste) setup += ansi.bracketedPasteOn;
     if (this.options.focusEvents) setup += ansi.focusOn;
     if (this.options.title) setup += setTitle(this.options.title);
-    setup += ansi.clearScreen + ansi.cursorHome;
+    // Only a fullscreen app owns the grid, so only a fullscreen app may wipe
+    // it. An inline strip or a fixed region is a guest on somebody else's
+    // screen and has no business clearing it.
+    if (this.viewportMode.mode === "fullscreen") setup += ansi.clearScreen + ansi.cursorHome;
     this.write(setup);
+    if (this.viewportMode.mode === "inline") this.reserveInline();
 
     if (this.input.isTTY && typeof this.input.setRawMode === "function") {
       this.input.setRawMode(true);
@@ -148,15 +226,70 @@ export class Terminal {
     this.input.pause?.();
 
     let teardown = ansi.reset;
+    // An inline app leaves its last frame behind as part of the transcript, so
+    // the cursor has to come out below it rather than on top of it.
+    if (this.viewportMode.mode === "inline" && this.reserved > 0) {
+      teardown = toAnchor() + "\r" + "\n".repeat(this.reserved) + teardown;
+      this.reserved = 0;
+    }
     if (this.options.focusEvents) teardown += ansi.focusOff;
     if (this.options.bracketedPaste) teardown += ansi.bracketedPasteOff;
     if (this.options.mouse) teardown += ansi.mouseOff;
     if (this.options.hideCursor) teardown += ansi.cursorShow;
-    teardown += this.options.alternateScreen ? ansi.alternateScreenOff : `\n`;
+    teardown += this.options.alternateScreen
+      ? ansi.alternateScreenOff
+      : this.viewportMode.mode === "inline" ? "" : `\n`;
     this.write(teardown);
 
     for (const off of this.cleanupHandlers) off();
     this.cleanupHandlers = [];
+  }
+
+  /**
+   * Make room for an inline viewport and remember where it starts.
+   *
+   * There is no way to ask where the cursor is without a round trip the caller
+   * would have to await, and no way to trust the answer afterwards -- any
+   * output scrolls the screen and moves the strip without a word. So the
+   * anchor is never a number: it is a saved cursor position, re-saved whenever
+   * the strip moves.
+   *
+   * Printing the newlines first is what reserves the space. If the cursor was
+   * near the bottom the terminal scrolls, which is exactly what should happen;
+   * walking back up then lands on the strip's first row wherever it ended up.
+   */
+  private reserveInline(): void {
+    const height = this.viewportRect().height;
+    this.reserved = height;
+    this.write("\r" + "\n".repeat(Math.max(0, height - 1)) + moveUp(height - 1) + "\r");
+    this.write(anchor());
+  }
+
+  /**
+   * Write lines above an inline viewport, permanently.
+   *
+   * This is the half of inline mode that makes it worth having: finished work
+   * scrolls away into the user's scrollback while the live rows stay put. The
+   * lines are printed where the strip currently begins and the strip is
+   * re-anchored below them, so if that runs off the bottom the terminal scrolls
+   * and the oldest lines leave through the top -- into scrollback, which is
+   * where they were always going.
+   *
+   * The caller repaints the viewport afterwards: everything below the anchor is
+   * now whatever the terminal happened to shift there.
+   */
+  insertBefore(lines: string[]): void {
+    if (this.viewportMode.mode !== "inline" || lines.length === 0) return;
+    const height = this.reserved;
+    let out = toAnchor() + "\r";
+    for (const line of lines) out += ansi.clearLine + line + ansi.reset + "\r\n";
+    // Re-reserve from the new anchor, then walk back to it. Writing the rows
+    // is what forces the terminal to scroll if the strip no longer fits, and
+    // walking back afterwards finds it wherever the scroll left it.
+    out += ansi.clearLine;
+    for (let i = 1; i < height; i++) out += "\r\n" + ansi.clearLine;
+    out += moveUp(height - 1) + "\r" + anchor();
+    this.write(out);
   }
 
   onInput(listener: Listener<InputEvent>): () => void {
@@ -228,6 +361,30 @@ export class Terminal {
       process.off("unhandledRejection", onRejection);
     });
   }
+}
+
+/**
+ * Save the anchor an inline viewport measures from.
+ *
+ * The pen is reset first so that the saved graphic rendition is always the
+ * default one. DECRC restores attributes along with the position, so without
+ * that the colour in force at some arbitrary moment would come back with every
+ * jump and quietly desynchronise the renderer's model of the terminal.
+ */
+function anchor(): string {
+  return ansi.reset + ansi.cursorSave;
+}
+
+/**
+ * Go back to the anchor, and immediately save it again.
+ *
+ * DECRC is a pop rather than a peek in some terminals: restore twice against
+ * one save and the second sends the cursor home, which is the top of the
+ * user's screen and not remotely where the viewport is. Re-arming after every
+ * restore makes the sequence mean the same thing on both kinds.
+ */
+function toAnchor(): string {
+  return ansi.cursorRestore + anchor();
 }
 
 export function createTerminal(options: TerminalOptions = {}): Terminal {

--- a/packages/hqtui/test/viewport.test.ts
+++ b/packages/hqtui/test/viewport.test.ts
@@ -1,0 +1,211 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { PassThrough } from "node:stream";
+import { App } from "../src/app.ts";
+import { Terminal } from "../src/terminal.ts";
+
+/** A terminal whose output we can read back, since the escapes are the contract. */
+function fakeTty(columns = 20, rows = 10) {
+  const input = new PassThrough() as unknown as NodeJS.ReadStream;
+  const output = new PassThrough() as unknown as NodeJS.WriteStream;
+  let written = "";
+  (output as unknown as PassThrough).on("data", (chunk) => { written += String(chunk); });
+  Object.assign(output, { columns, rows });
+  return { input, output, read: () => written, clear: () => { written = ""; } };
+}
+
+const options = {
+  installExitHandlers: false,
+  quitKeys: [] as string[],
+  capabilities: { mouse: false, synchronizedOutput: false },
+  bracketedPaste: false,
+  focusEvents: false,
+} as const;
+
+test("viewport: fullscreen is still the default, alternate screen and all", () => {
+  const tty = fakeTty();
+  const terminal = new Terminal({ ...tty, installExitHandlers: false });
+  assert.deepEqual(terminal.viewport, { mode: "fullscreen" });
+  assert.deepEqual(terminal.viewportRect(), { x: 0, y: 0, width: 20, height: 10 });
+  terminal.enter();
+  assert.ok(tty.read().includes("\x1b[?1049h"), "took the alternate screen");
+  terminal.restore();
+});
+
+test("viewport: inline neither takes the alternate screen nor clears what is there", () => {
+  const tty = fakeTty();
+  const terminal = new Terminal({
+    ...tty,
+    installExitHandlers: false,
+    viewport: { mode: "inline", height: 3 },
+  });
+  terminal.enter();
+  const out = tty.read();
+  // The whole point is that the user's terminal survives.
+  assert.ok(!out.includes("\x1b[?1049h"), "must not take the alternate screen");
+  assert.ok(!out.includes("\x1b[2J"), "must not clear the screen");
+  // Three rows reserved: two newlines to make the room, then back to the top.
+  assert.ok(out.includes("\n\n"), "reserved its rows");
+  assert.ok(out.includes("\x1b[2A"), "walked back to the first of them");
+  assert.ok(out.endsWith("\x1b[0m\x1b7"), "reset the pen, then saved the anchor");
+  terminal.restore();
+});
+
+test("viewport: inline asks for no more rows than the terminal has", () => {
+  const tty = fakeTty(20, 4);
+  const terminal = new Terminal({
+    ...tty,
+    installExitHandlers: false,
+    viewport: { mode: "inline", height: 40 },
+  });
+  // A strip taller than the screen would scroll itself away every frame.
+  assert.equal(terminal.viewportRect().height, 4);
+});
+
+test("viewport: leaving an inline app puts the cursor below its last frame", () => {
+  const tty = fakeTty();
+  const terminal = new Terminal({
+    ...tty,
+    installExitHandlers: false,
+    viewport: { mode: "inline", height: 3 },
+  });
+  terminal.enter();
+  tty.clear();
+  terminal.restore();
+  const out = tty.read();
+  assert.ok(out.startsWith("\x1b8"), "went back to the anchor first");
+  assert.equal((out.match(/\n/g) ?? []).length, 3, "then down past all three rows");
+});
+
+test("viewport: a fixed region is clamped to the terminal it is placed in", () => {
+  const tty = fakeTty(20, 10);
+  const terminal = new Terminal({
+    ...tty,
+    installExitHandlers: false,
+    viewport: { mode: "fixed", x: 15, y: 8, width: 30, height: 30 },
+  });
+  assert.deepEqual(terminal.viewportRect(), { x: 15, y: 8, width: 5, height: 2 });
+});
+
+test("viewport: an app draws into its viewport, not the whole screen", async () => {
+  const tty = fakeTty(20, 10);
+  const app = new App({ ...tty, ...options, viewport: { mode: "inline", height: 3 } });
+  app.render(({ ui }) => ui.text("hello"));
+  assert.equal(app.height, 3, "the buffer is the strip, not the screen");
+  assert.equal(app.width, 20);
+  void app.start();
+  await new Promise((r) => setImmediate(r));
+  app.stop();
+});
+
+test("viewport: an inline frame is addressed from its saved anchor", async () => {
+  const tty = fakeTty(20, 10);
+  const app = new App({ ...tty, ...options, viewport: { mode: "inline", height: 2 } });
+  let label = "hello";
+  app.render(({ ui }) => ui.text(label));
+  void app.start();
+  await new Promise((r) => setImmediate(r));
+
+  tty.clear();
+  label = "goodbye";
+  app.frame();
+  const frame = tty.read();
+  app.stop();
+
+  // Absolute addressing is exactly what an inline strip cannot use: it does not
+  // know its screen row, and a scroll moves it without saying so. Every jump in
+  // a frame is measured from the saved anchor instead.
+  assert.ok(frame.startsWith("\x1b8\x1b7\r"), `frame did not start at the anchor: ${JSON.stringify(frame)}`);
+  assert.ok(!/\x1b\[\d+;\d+H/.test(frame), `frame used absolute addressing: ${JSON.stringify(frame)}`);
+  assert.ok(frame.includes("goodbye"));
+});
+
+test("viewport: a fixed region offsets its addressing instead", async () => {
+  const tty = fakeTty(40, 10);
+  const app = new App({
+    ...tty,
+    ...options,
+    viewport: { mode: "fixed", x: 4, y: 6, width: 10, height: 2 },
+  });
+  app.render(({ ui }) => ui.text("hi"));
+  void app.start();
+  await new Promise((r) => setImmediate(r));
+  const out = tty.read();
+  app.stop();
+  // Row 7, column 5 in one-based terms: the region's own (0, 0).
+  assert.ok(out.includes("\x1b[7;5H"), `expected the region's origin: ${JSON.stringify(out)}`);
+});
+
+test("viewport: insertBefore writes above the strip and leaves it anchored", async () => {
+  const tty = fakeTty(20, 10);
+  const app = new App({ ...tty, ...options, viewport: { mode: "inline", height: 2 } });
+  app.render(({ ui }) => ui.text("live"));
+  void app.start();
+  await new Promise((r) => setImmediate(r));
+  tty.clear();
+
+  app.insertBefore(1, (ui) => ui.text("done"));
+  const out = tty.read();
+  app.stop();
+
+  assert.ok(out.includes("done"), "the line was written");
+  assert.ok(out.includes("live"), "and the strip was repainted after it");
+  assert.ok(out.indexOf("done") < out.indexOf("live"), "the finished line goes above");
+  // Re-anchored: the strip has to be findable again after the terminal may
+  // have scrolled it.
+  assert.ok(out.includes("\x1b7"), "saved the new anchor");
+});
+
+test("viewport: insertBefore is a no-op where there is no above", async () => {
+  const tty = fakeTty(20, 10);
+  const app = new App({ ...tty, ...options });
+  app.render(({ ui }) => ui.text("live"));
+  void app.start();
+  await new Promise((r) => setImmediate(r));
+  tty.clear();
+
+  // A fullscreen app owns every row it can see; there is nothing to insert into.
+  app.insertBefore(1, (ui) => ui.text("done"));
+  assert.ok(!tty.read().includes("done"));
+  app.stop();
+});
+
+test("viewport: every restore re-arms the save it just spent", async () => {
+  const tty = fakeTty(24, 10);
+  const app = new App({ ...tty, ...options, viewport: { mode: "inline", height: 3 } });
+  let n = 0;
+  app.render(({ ui }) => {
+    ui.text(`step ${n}`);
+    ui.meter({ label: "x", value: n / 5 });
+    ui.text("working");
+  });
+  void app.start();
+  await new Promise((r) => setImmediate(r));
+
+  for (; n < 4; n++) {
+    app.insertBefore(1, (ui) => ui.text(`ok ${n}`));
+    app.frame();
+  }
+  const out = tty.read();
+  app.stop();
+
+  // DECRC pops the saved position in some terminals rather than peeking at it.
+  // Spend the save without putting it back and the next restore sends the
+  // cursor to the top of the user's screen -- which is where the whole strip
+  // then redraws itself, over their shell. Every restore must re-arm.
+  const restores = [...out.matchAll(/\x1b8/g)].map((m) => m.index ?? 0);
+  assert.ok(restores.length > 4, `expected several restores, got ${restores.length}`);
+  for (const at of restores) {
+    // A pen reset may sit between the two; nothing that moves the cursor may.
+    const after = out.slice(at + 2, at + 12);
+    assert.ok(
+      after.startsWith("\x1b7") || after.startsWith("\x1b[0m\x1b7"),
+      `restore at ${at} left the save spent: ${JSON.stringify(out.slice(at, at + 14))}`,
+    );
+  }
+
+  // And the finished lines are all there, in order.
+  const order = ["ok 0", "ok 1", "ok 2", "ok 3"].map((line) => out.indexOf(line));
+  assert.ok(order.every((at) => at >= 0), `a line went missing: ${order}`);
+  assert.deepEqual(order, [...order].sort((a, b) => a - b), "lines arrived out of order");
+});


### PR DESCRIPTION
Closes #61.

hqtui took over the whole screen or it did not run. `alternateScreen: false` wrote to the main screen but still cleared it and still owned every row, so the one shape it could not build was the common one: an installer, a build, a deploy watcher — a few live rows pinned low, finished work scrolling away above them, and a readable transcript left behind at the end.

```ts
const app = await createApp({ viewport: { mode: "inline", height: 3 } });
app.insertBefore(1, ui => ui.text("compiled in 1.2s"));
```

`fullscreen` is the default and nothing about it changes. `inline` reserves a strip in the normal flow of the terminal and never clears anything. `fixed` takes a rectangle of a screen something else is driving. There is a runnable example: `bun examples/inline.ts`.

## The hard part

An inline strip has no coordinates it can trust. It does not know which screen row it started on, and the terminal scrolls it upwards without saying so. It could ask — ratatui does, with a cursor position report — but the answer is stale the moment anything scrolls. So the anchor here is never a number: it is a saved cursor, re-saved whenever the strip moves, and the encoder gained a relative addressing mode that walks from it rather than jumping to absolute rows.

Two things cost real debugging:

**DECRC is a pop, not a peek.** Restore twice against one save and some terminals send the cursor home instead — the top of the user's screen, where the strip then redraws itself over their shell. A frame restores many times, once per row it cannot track the cursor through. Every restore now re-arms its save, so the sequence means the same thing on the stack terminals and the single-slot ones. There is a test asserting exactly that, because a single frame looks perfectly fine either way and only the fourth one is wrong.

**DECRC restores the pen along with the position**, so the encoder's model of the current colour was quietly wrong after every jump. Anchors are saved with the pen reset, and the encoder admits it knows nothing about the pen after a restore.

## Verified

Not just by reading the escapes back — the example was run in a real pty and replayed through a VT emulator. On an eight-row terminal:

```
=== scrollback ===        === screen ===
'shell line one'          'building  5/5'
'shell line two'          '███████████████ 100%'
'filler a'                'done'
'filler b'                'AFTER-PROMPT'
'filler c'
'  ✓ resolve dependencies'
'  ✓ compile core'
'  ✓ compile widgets'
'  ✓ link'
'  ✓ run tests'
```

The finished lines land in scrollback in order, the strip stays put, and the prompt returns below the last frame with the shell's earlier output untouched.

Also: 286 tests under both `bun test` and `node --test`, typecheck, `next build`, the benchmark, and both widget galleries.

## Scope

TypeScript only, as the issue proposes — each port has its own terminal implementation and the semantics were worth settling in one place first. No port file is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Df2FNu5DhinMV2soRz3cy